### PR TITLE
BUF-6: Postgres schema v1 — entity, alias, staging, raw, review queue

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,28 @@ jobs:
   lint-typecheck-test:
     name: Lint + typecheck + test
     runs-on: ubuntu-latest
+
+    # Postgres + pgvector for the BUF-6 integration tests. Same image the
+    # local docker-compose uses, so CI and local exercise the same surface.
+    services:
+      postgres:
+        image: pgvector/pgvector:pg16
+        env:
+          POSTGRES_USER: nexus
+          POSTGRES_PASSWORD: nexus
+          POSTGRES_DB: nexus
+        ports:
+          - 5432:5432
+        # Health-check so the test step waits for Postgres to accept queries.
+        options: >-
+          --health-cmd "pg_isready -U nexus -d nexus"
+          --health-interval 5s
+          --health-timeout 5s
+          --health-retries 10
+
+    env:
+      TEST_DATABASE_URL: postgresql+psycopg://nexus:nexus@localhost:5432/nexus
+
     steps:
       - uses: actions/checkout@v4
 

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@
 
 SHELL := /bin/bash
 
-.PHONY: help dev up down sync test lint format typecheck precommit ci clean
+.PHONY: help dev up down sync migrate test lint format typecheck precommit ci clean
 
 help:
 	@echo "Targets:"
@@ -13,6 +13,7 @@ help:
 	@echo "  up          Bring up the docker-compose data plane."
 	@echo "  down        Stop & remove the data plane (volumes preserved)."
 	@echo "  sync        Resolve and install the uv workspace (incl. dev group)."
+	@echo "  migrate     Apply Alembic migrations against \$$DATABASE_URL."
 	@echo "  test        Run pytest across all workspace members."
 	@echo "  lint        Run ruff + black --check."
 	@echo "  format      Apply ruff --fix and black."
@@ -39,6 +40,11 @@ down:
 
 sync:
 	uv sync --all-packages
+
+migrate:
+	# Run from packages/shared so alembic finds alembic.ini next door.
+	# DATABASE_URL overrides the dev-compose default (see env.py).
+	cd packages/shared && uv run alembic upgrade head
 
 test:
 	uv run pytest

--- a/README.md
+++ b/README.md
@@ -21,6 +21,20 @@ uv run pytest
 
 Copy `.env.example` to `.env` before running anything that needs credentials.
 
+To apply the BUF-6 schema (entity, alias, staging, raw store) to a fresh
+Postgres:
+
+```bash
+make migrate    # uses $DATABASE_URL; defaults to the dev-compose Postgres
+```
+
+Integration tests against Postgres are skipped unless `TEST_DATABASE_URL` is
+set:
+
+```bash
+TEST_DATABASE_URL=postgresql+psycopg://nexus:nexus@localhost:5432/nexus uv run pytest
+```
+
 ## Repo layout
 
 ```
@@ -58,6 +72,7 @@ package has its own `pyproject.toml`, and `uv sync` resolves them together.
 | `make up`         | Bring up the data plane only.                           |
 | `make down`       | Stop the data plane (volumes preserved).                |
 | `make sync`       | Resolve and install the uv workspace.                   |
+| `make migrate`    | Apply Alembic migrations against `$DATABASE_URL`.       |
 | `make test`       | Run pytest across all workspace members.                |
 | `make lint`       | Run ruff + black --check.                               |
 | `make typecheck`  | Run mypy.                                               |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,7 +8,10 @@
 
 services:
   postgres:
-    image: postgres:16
+    # pgvector image is plain Postgres 16 with the vector extension preinstalled
+    # — alembic's `CREATE EXTENSION vector` (BUF-6) needs it. ADR-006 puts
+    # embeddings on this same instance instead of running Qdrant alongside.
+    image: pgvector/pgvector:pg16
     container_name: nexus-postgres
     restart: unless-stopped
     environment:

--- a/packages/shared/alembic.ini
+++ b/packages/shared/alembic.ini
@@ -1,0 +1,42 @@
+[alembic]
+# Migrations live next to this file. Run from `packages/shared/`:
+#   uv run alembic upgrade head
+# DATABASE_URL (set in .env or the shell) overrides the URL below at runtime —
+# see env.py.
+script_location = alembic
+sqlalchemy.url = postgresql+psycopg://nexus:nexus@localhost:5432/nexus
+file_template = %%(year)d%%(month).2d%%(day).2d_%%(rev)s_%%(slug)s
+
+[loggers]
+keys = root,sqlalchemy,alembic
+
+[handlers]
+keys = console
+
+[formatters]
+keys = generic
+
+[logger_root]
+level = WARNING
+handlers = console
+qualname =
+
+[logger_sqlalchemy]
+level = WARNING
+handlers =
+qualname = sqlalchemy.engine
+
+[logger_alembic]
+level = INFO
+handlers =
+qualname = alembic
+
+[handler_console]
+class = StreamHandler
+args = (sys.stderr,)
+level = NOTSET
+formatter = generic
+
+[formatter_generic]
+format = %(levelname)-5.5s [%(name)s] %(message)s
+datefmt = %H:%M:%S

--- a/packages/shared/alembic/env.py
+++ b/packages/shared/alembic/env.py
@@ -1,0 +1,77 @@
+"""Alembic migration environment.
+
+Reads ``DATABASE_URL`` from the process environment (falling back to the URL
+in ``alembic.ini``), wires the SQLAlchemy metadata from
+:mod:`esports_sim.db`, and runs migrations synchronously — Alembic doesn't
+need the async path even though services do.
+"""
+
+from __future__ import annotations
+
+import os
+from logging.config import fileConfig
+
+import esports_sim.db.models  # noqa: F401  side-effect import: registers all tables
+from alembic import context
+from esports_sim.db.base import Base
+from sqlalchemy import engine_from_config, pool
+
+# Alembic Config object provides access to values within the .ini file.
+config = context.config
+
+# Allow DATABASE_URL to override alembic.ini at runtime. Services run with
+# their own URL, CI uses the service-container URL, devs use the
+# docker-compose default.
+db_url = os.getenv("DATABASE_URL")
+if db_url:
+    # Alembic uses the sync `psycopg` driver; if the URL was pasted from a
+    # service config that uses asyncpg, swap it transparently so we don't
+    # force every consumer to maintain two URLs.
+    if db_url.startswith("postgresql+asyncpg://"):
+        db_url = db_url.replace("postgresql+asyncpg://", "postgresql+psycopg://", 1)
+    elif db_url.startswith("postgresql://"):
+        db_url = db_url.replace("postgresql://", "postgresql+psycopg://", 1)
+    config.set_main_option("sqlalchemy.url", db_url)
+
+# Configure Python logging from the alembic.ini file.
+if config.config_file_name is not None:
+    fileConfig(config.config_file_name)
+
+target_metadata = Base.metadata
+
+
+def run_migrations_offline() -> None:
+    """Emit SQL to stdout instead of executing against a live DB."""
+    url = config.get_main_option("sqlalchemy.url")
+    context.configure(
+        url=url,
+        target_metadata=target_metadata,
+        literal_binds=True,
+        dialect_opts={"paramstyle": "named"},
+    )
+    with context.begin_transaction():
+        context.run_migrations()
+
+
+def run_migrations_online() -> None:
+    """Open a connection and run migrations transactionally."""
+    connectable = engine_from_config(
+        config.get_section(config.config_ini_section, {}),
+        prefix="sqlalchemy.",
+        poolclass=pool.NullPool,
+    )
+    with connectable.connect() as connection:
+        context.configure(
+            connection=connection,
+            target_metadata=target_metadata,
+            # Surface server-side defaults in autogenerate diffs.
+            compare_server_default=True,
+        )
+        with context.begin_transaction():
+            context.run_migrations()
+
+
+if context.is_offline_mode():
+    run_migrations_offline()
+else:
+    run_migrations_online()

--- a/packages/shared/alembic/script.py.mako
+++ b/packages/shared/alembic/script.py.mako
@@ -1,0 +1,28 @@
+"""${message}
+
+Revision ID: ${up_revision}
+Revises: ${down_revision | comma,n}
+Create Date: ${create_date}
+
+"""
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+import sqlalchemy as sa
+${imports if imports else ""}
+
+# revision identifiers, used by Alembic.
+revision: str = ${repr(up_revision)}
+down_revision: str | None = ${repr(down_revision)}
+branch_labels: str | Sequence[str] | None = ${repr(branch_labels)}
+depends_on: str | Sequence[str] | None = ${repr(depends_on)}
+
+
+def upgrade() -> None:
+    ${upgrades if upgrades else "pass"}
+
+
+def downgrade() -> None:
+    ${downgrades if downgrades else "pass"}

--- a/packages/shared/alembic/versions/20260426_0001_initial_schema.py
+++ b/packages/shared/alembic/versions/20260426_0001_initial_schema.py
@@ -1,0 +1,226 @@
+"""Initial schema: entity, entity_alias, staging_record, raw_record, alias_review_queue.
+
+Lands the BUF-6 substrate plus the ``vector`` extension so BUF-28 can add
+embedding tables without a second migration cycle (per the BUF-6 review
+comment + ADR-006).
+
+Revision ID: 0001
+Revises:
+Create Date: 2026-04-26
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "0001"
+down_revision: str | None = None
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+# Enum value lists. Kept as literals on purpose: a migration must keep working
+# even after the application enum gets new values, so we don't import
+# esports_sim.db.enums here. Adding a value goes through ALTER TYPE ... ADD
+# VALUE in a follow-up migration.
+_ENTITY_TYPES = ("player", "team", "coach", "tournament")
+_PLATFORMS = (
+    "riot_api",
+    "liquipedia",
+    "vlr",
+    "esportsearnings",
+    "twitch",
+    "twitter",
+)
+_STAGING_STATUSES = ("pending", "processed", "blocked", "review")
+_REVIEW_STATUSES = ("pending", "resolved", "skipped", "blocked")
+
+
+def _enum(name: str, values: tuple[str, ...]) -> postgresql.ENUM:
+    """Reference an already-created Postgres ENUM type without recreating it."""
+    return postgresql.ENUM(*values, name=name, create_type=False)
+
+
+def upgrade() -> None:
+    # pgvector — BUF-28 will write into vector columns; lighting it up here
+    # avoids a second migration that would otherwise need a maintenance
+    # window. `IF NOT EXISTS` keeps this safe if the operator already ran it.
+    op.execute("CREATE EXTENSION IF NOT EXISTS vector")
+
+    # Enum types must exist before the tables that reference them.
+    postgresql.ENUM(*_ENTITY_TYPES, name="entity_type").create(op.get_bind(), checkfirst=True)
+    postgresql.ENUM(*_PLATFORMS, name="platform").create(op.get_bind(), checkfirst=True)
+    postgresql.ENUM(*_STAGING_STATUSES, name="staging_status").create(
+        op.get_bind(), checkfirst=True
+    )
+    postgresql.ENUM(*_REVIEW_STATUSES, name="review_status").create(op.get_bind(), checkfirst=True)
+
+    op.create_table(
+        "entity",
+        sa.Column(
+            "canonical_id",
+            postgresql.UUID(as_uuid=True),
+            primary_key=True,
+        ),
+        sa.Column(
+            "entity_type",
+            _enum("entity_type", _ENTITY_TYPES),
+            nullable=False,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "is_active",
+            sa.Boolean(),
+            server_default=sa.text("true"),
+            nullable=False,
+        ),
+    )
+    op.create_index("ix_entity_entity_type", "entity", ["entity_type"])
+
+    op.create_table(
+        "entity_alias",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "canonical_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey(
+                "entity.canonical_id",
+                ondelete="CASCADE",
+                name="fk_entity_alias_canonical_id_entity",
+            ),
+            nullable=False,
+        ),
+        sa.Column(
+            "platform",
+            _enum("platform", _PLATFORMS),
+            nullable=False,
+        ),
+        sa.Column("platform_id", sa.String(255), nullable=False),
+        sa.Column("platform_name", sa.String(255), nullable=False),
+        sa.Column("confidence", sa.Float(), nullable=False),
+        sa.Column("verified_at", sa.DateTime(timezone=True), nullable=True),
+        sa.Column(
+            "valid_from",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.UniqueConstraint(
+            "platform",
+            "platform_id",
+            name="uq_entity_alias_platform_platform_id",
+        ),
+    )
+    op.create_index("ix_entity_alias_canonical_id", "entity_alias", ["canonical_id"])
+
+    op.create_table(
+        "staging_record",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("source", sa.String(64), nullable=False),
+        sa.Column(
+            "entity_type",
+            _enum("entity_type", _ENTITY_TYPES),
+            nullable=False,
+        ),
+        sa.Column(
+            "canonical_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey(
+                "entity.canonical_id",
+                ondelete="SET NULL",
+                name="fk_staging_record_canonical_id_entity",
+            ),
+            nullable=True,
+        ),
+        sa.Column("payload", postgresql.JSONB, nullable=False),
+        sa.Column(
+            "status",
+            _enum("staging_status", _STAGING_STATUSES),
+            server_default="pending",
+            nullable=False,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+    )
+    op.create_index("ix_staging_record_status", "staging_record", ["status"])
+    op.create_index("ix_staging_record_canonical_id", "staging_record", ["canonical_id"])
+
+    op.create_table(
+        "raw_record",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column("source", sa.String(64), nullable=False),
+        sa.Column(
+            "fetched_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column("payload", postgresql.JSONB, nullable=False),
+        sa.Column("content_hash", sa.String(64), nullable=False, unique=True),
+    )
+
+    op.create_table(
+        "alias_review_queue",
+        sa.Column("id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "platform",
+            _enum("platform", _PLATFORMS),
+            nullable=False,
+        ),
+        sa.Column("platform_id", sa.String(255), nullable=False),
+        sa.Column("platform_name", sa.String(255), nullable=False),
+        sa.Column("candidates", postgresql.JSONB, nullable=False),
+        sa.Column("reason", sa.String(255), nullable=False),
+        sa.Column(
+            "status",
+            _enum("review_status", _REVIEW_STATUSES),
+            server_default="pending",
+            nullable=False,
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+    )
+    op.create_index("ix_alias_review_queue_status", "alias_review_queue", ["status"])
+
+
+def downgrade() -> None:
+    # Tables first (respecting FK order), then enum types, then the extension.
+    op.drop_index("ix_alias_review_queue_status", table_name="alias_review_queue")
+    op.drop_table("alias_review_queue")
+
+    op.drop_table("raw_record")
+
+    op.drop_index("ix_staging_record_canonical_id", table_name="staging_record")
+    op.drop_index("ix_staging_record_status", table_name="staging_record")
+    op.drop_table("staging_record")
+
+    op.drop_index("ix_entity_alias_canonical_id", table_name="entity_alias")
+    op.drop_table("entity_alias")
+
+    op.drop_index("ix_entity_entity_type", table_name="entity")
+    op.drop_table("entity")
+
+    for typename in ("review_status", "staging_status", "platform", "entity_type"):
+        op.execute(f"DROP TYPE IF EXISTS {typename}")
+
+    # Leaving `CREATE EXTENSION vector` undone is friendly to other databases
+    # on the same instance — but the migration still owns it for symmetry.
+    op.execute("DROP EXTENSION IF EXISTS vector")

--- a/packages/shared/alembic/versions/20260426_0001_initial_schema.py
+++ b/packages/shared/alembic/versions/20260426_0001_initial_schema.py
@@ -221,6 +221,10 @@ def downgrade() -> None:
     for typename in ("review_status", "staging_status", "platform", "entity_type"):
         op.execute(f"DROP TYPE IF EXISTS {typename}")
 
-    # Leaving `CREATE EXTENSION vector` undone is friendly to other databases
-    # on the same instance — but the migration still owns it for symmetry.
-    op.execute("DROP EXTENSION IF EXISTS vector")
+    # Deliberately *not* dropping the `vector` extension. ``upgrade()`` uses
+    # ``CREATE EXTENSION IF NOT EXISTS``, so we can't tell from inside this
+    # migration whether the extension pre-existed. Dropping unconditionally
+    # would either error (if other objects depend on it) or silently break
+    # unrelated schemas in the same database during rollback. If an operator
+    # genuinely needs to remove it, that's a manual ``DROP EXTENSION vector``
+    # outside Alembic.

--- a/packages/shared/pyproject.toml
+++ b/packages/shared/pyproject.toml
@@ -11,7 +11,19 @@ dependencies = [
     "pydantic>=2.6",
     "PyYAML>=6.0",
     "numpy>=1.26",
+    # Database substrate (BUF-6). Async path lives in services; this package
+    # ships the models + migrations so every consumer agrees on the schema.
+    "SQLAlchemy[asyncio]>=2.0",
+    "alembic>=1.13",
+    "psycopg[binary]>=3.1",
+    "asyncpg>=0.29",
+    # pgvector Python bindings — registered as a SQLAlchemy type so BUF-28's
+    # vector tables can land without re-plumbing types here.
+    "pgvector>=0.3",
 ]
 
 [tool.hatch.build.targets.wheel]
 packages = ["src/esports_sim"]
+# Migrations live at packages/shared/alembic/ and are run from the workspace
+# root (`make migrate`), not from an installed wheel — consumers don't need
+# them at import time.

--- a/packages/shared/src/esports_sim/db/__init__.py
+++ b/packages/shared/src/esports_sim/db/__init__.py
@@ -1,0 +1,41 @@
+"""Database layer (BUF-6).
+
+Five tables form the canonical+staging substrate every other System (02–10)
+joins on:
+
+* :class:`Entity` — canonical id + entity_type, the join key everyone uses.
+* :class:`EntityAlias` — many-to-one platform handles, unique per
+  ``(platform, platform_id)`` so two scrapers can't accidentally split a
+  player into two canonical rows.
+* :class:`StagingRecord` — scraped payloads parked for the resolver (BUF-7).
+* :class:`RawRecord` — content-addressed blob store; ``content_hash`` keeps
+  re-fetches idempotent.
+* :class:`AliasReviewQueue` — items the fuzzy matcher couldn't decide; humans
+  drain it via BUF-16's CLI.
+
+The ``Base`` metadata is exported so Alembic and tests can introspect the
+schema. Migrations live at ``packages/shared/alembic/``.
+"""
+
+from esports_sim.db.base import Base
+from esports_sim.db.enums import EntityType, Platform, ReviewStatus, StagingStatus
+from esports_sim.db.models import (
+    AliasReviewQueue,
+    Entity,
+    EntityAlias,
+    RawRecord,
+    StagingRecord,
+)
+
+__all__ = [
+    "Base",
+    "EntityType",
+    "Platform",
+    "StagingStatus",
+    "ReviewStatus",
+    "Entity",
+    "EntityAlias",
+    "StagingRecord",
+    "RawRecord",
+    "AliasReviewQueue",
+]

--- a/packages/shared/src/esports_sim/db/base.py
+++ b/packages/shared/src/esports_sim/db/base.py
@@ -1,0 +1,28 @@
+"""SQLAlchemy declarative base.
+
+All BUF-6 models inherit from :class:`Base` so Alembic and tests have one
+metadata object to introspect.
+"""
+
+from __future__ import annotations
+
+from sqlalchemy import MetaData
+from sqlalchemy.orm import DeclarativeBase
+
+# Naming convention pinned so Alembic-generated and hand-written migrations
+# produce the same constraint names — otherwise rolling forward and back
+# diverges. Pattern is the SQLAlchemy default plus a length-safe primary-key
+# template.
+NAMING_CONVENTION = {
+    "ix": "ix_%(table_name)s_%(column_0_N_name)s",
+    "uq": "uq_%(table_name)s_%(column_0_N_name)s",
+    "ck": "ck_%(table_name)s_%(constraint_name)s",
+    "fk": "fk_%(table_name)s_%(column_0_N_name)s_%(referred_table_name)s",
+    "pk": "pk_%(table_name)s",
+}
+
+
+class Base(DeclarativeBase):
+    """Declarative base shared by every model in :mod:`esports_sim.db`."""
+
+    metadata = MetaData(naming_convention=NAMING_CONVENTION)

--- a/packages/shared/src/esports_sim/db/enums.py
+++ b/packages/shared/src/esports_sim/db/enums.py
@@ -1,0 +1,70 @@
+"""Canonical enums shared by SQLAlchemy models, Pydantic DTOs, and migrations.
+
+Important: when a value is added here, the corresponding Postgres ENUM type
+must be migrated explicitly via ``ALTER TYPE ... ADD VALUE``. Alembic
+autogenerate will not catch enum-value drift, so always write the migration by
+hand.
+"""
+
+from __future__ import annotations
+
+import enum
+
+
+class EntityType(enum.StrEnum):
+    """The Systems-spec covers four canonical entity classes.
+
+    Future entity classes (analyst, caster, organisation) will require an
+    explicit migration plus a forward-compatibility plan; we don't pre-empt
+    them here.
+    """
+
+    PLAYER = "player"
+    TEAM = "team"
+    COACH = "coach"
+    TOURNAMENT = "tournament"
+
+
+class Platform(enum.StrEnum):
+    """External platforms the resolver may see an alias from.
+
+    The order in BUF-12's source-priority list is *not* encoded here; that's
+    a resolver concern and lives next to the merge logic. Adding a new
+    platform requires both an ALTER TYPE migration and a priority decision in
+    BUF-12.
+    """
+
+    RIOT_API = "riot_api"
+    LIQUIPEDIA = "liquipedia"
+    VLR = "vlr"
+    ESPORTSEARNINGS = "esportsearnings"
+    TWITCH = "twitch"
+    TWITTER = "twitter"
+
+
+class StagingStatus(enum.StrEnum):
+    """Lifecycle of a row in the staging queue.
+
+    The resolver (BUF-7) only consumes ``pending``. ``review`` items land in
+    ``alias_review_queue``; ``blocked`` rows are kept for audit, never
+    re-processed automatically.
+    """
+
+    PENDING = "pending"
+    PROCESSED = "processed"
+    BLOCKED = "blocked"
+    REVIEW = "review"
+
+
+class ReviewStatus(enum.StrEnum):
+    """Lifecycle of a row in the alias review queue (BUF-16).
+
+    ``resolved`` covers both human decisions that produce a write (merge into
+    existing entity, or mint a new canonical id); the actual decision lives
+    in the row's audit trail, not on this status field.
+    """
+
+    PENDING = "pending"
+    RESOLVED = "resolved"
+    SKIPPED = "skipped"
+    BLOCKED = "blocked"

--- a/packages/shared/src/esports_sim/db/models.py
+++ b/packages/shared/src/esports_sim/db/models.py
@@ -66,7 +66,11 @@ class Entity(Base):
         primary_key=True,
         default=uuid.uuid4,
     )
-    entity_type: Mapped[EntityType] = mapped_column(_entity_type, nullable=False)
+    # ``index=True`` mirrors the ix_entity_entity_type index in the migration.
+    # Without this, alembic autogenerate would treat the DB index as drift and
+    # drop it in a future revision — costly because lots of downstream queries
+    # filter by entity_type.
+    entity_type: Mapped[EntityType] = mapped_column(_entity_type, nullable=False, index=True)
     created_at: Mapped[datetime] = mapped_column(
         DateTime(timezone=True),
         server_default=func.now(),

--- a/packages/shared/src/esports_sim/db/models.py
+++ b/packages/shared/src/esports_sim/db/models.py
@@ -1,0 +1,237 @@
+"""SQLAlchemy 2.0 models for the BUF-6 schema.
+
+Each table maps 1:1 to the Systems-spec System 01 + 02 design. Downstream code
+must import these models (or the Pydantic DTOs in
+:mod:`esports_sim.schemas.dtos`) — never reach into raw SQL.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+from sqlalchemy import (
+    Boolean,
+    DateTime,
+    Float,
+    ForeignKey,
+    String,
+    UniqueConstraint,
+    func,
+)
+from sqlalchemy.dialects.postgresql import ENUM as PgEnum
+from sqlalchemy.dialects.postgresql import JSONB, UUID
+from sqlalchemy.orm import Mapped, mapped_column, relationship
+
+from esports_sim.db.base import Base
+from esports_sim.db.enums import EntityType, Platform, ReviewStatus, StagingStatus
+
+# Reusable Postgres ENUM types. ``create_type=False`` keeps every model
+# definition from trying to recreate the type — the migration owns the
+# CREATE TYPE statement, full stop.
+_entity_type = PgEnum(
+    EntityType,
+    name="entity_type",
+    create_type=False,
+    values_callable=lambda e: [v.value for v in e],
+)
+_platform = PgEnum(
+    Platform,
+    name="platform",
+    create_type=False,
+    values_callable=lambda e: [v.value for v in e],
+)
+_staging_status = PgEnum(
+    StagingStatus,
+    name="staging_status",
+    create_type=False,
+    values_callable=lambda e: [v.value for v in e],
+)
+_review_status = PgEnum(
+    ReviewStatus,
+    name="review_status",
+    create_type=False,
+    values_callable=lambda e: [v.value for v in e],
+)
+
+
+class Entity(Base):
+    """Canonical record. Every other table joins on ``canonical_id``."""
+
+    __tablename__ = "entity"
+
+    canonical_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+    entity_type: Mapped[EntityType] = mapped_column(_entity_type, nullable=False)
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        nullable=False,
+    )
+    is_active: Mapped[bool] = mapped_column(
+        Boolean,
+        nullable=False,
+        server_default="true",
+    )
+
+    aliases: Mapped[list[EntityAlias]] = relationship(
+        back_populates="entity",
+        cascade="all, delete-orphan",
+        lazy="selectin",
+    )
+
+
+class EntityAlias(Base):
+    """Many-to-one platform handle.
+
+    The ``(platform, platform_id)`` uniqueness is the schema-level guarantee
+    that two scrapers can't accidentally split a player into two canonical
+    rows. The resolver (BUF-7) is the runtime guarantee that they don't try.
+    """
+
+    __tablename__ = "entity_alias"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+    canonical_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("entity.canonical_id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    platform: Mapped[Platform] = mapped_column(_platform, nullable=False)
+    platform_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    platform_name: Mapped[str] = mapped_column(String(255), nullable=False)
+    confidence: Mapped[float] = mapped_column(Float, nullable=False)
+    verified_at: Mapped[datetime | None] = mapped_column(
+        DateTime(timezone=True),
+        nullable=True,
+    )
+    valid_from: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        nullable=False,
+    )
+
+    entity: Mapped[Entity] = relationship(back_populates="aliases")
+
+    __table_args__ = (
+        UniqueConstraint(
+            "platform",
+            "platform_id",
+            name="uq_entity_alias_platform_platform_id",
+        ),
+    )
+
+
+class StagingRecord(Base):
+    """Scraped payload waiting for the resolver.
+
+    ``canonical_id`` is nullable so a row can be parked before the resolver
+    decides what entity it belongs to. BUF-7's ``StagingRecord.save()``
+    enforces the rule that a null ``canonical_id`` is only legal when the
+    status is ``blocked`` or ``review``.
+    """
+
+    __tablename__ = "staging_record"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+    source: Mapped[str] = mapped_column(String(64), nullable=False)
+    entity_type: Mapped[EntityType] = mapped_column(_entity_type, nullable=False)
+    canonical_id: Mapped[uuid.UUID | None] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("entity.canonical_id", ondelete="SET NULL"),
+        nullable=True,
+        index=True,
+    )
+    payload: Mapped[dict[str, Any]] = mapped_column(JSONB, nullable=False)
+    status: Mapped[StagingStatus] = mapped_column(
+        _staging_status,
+        nullable=False,
+        server_default=StagingStatus.PENDING.value,
+        index=True,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        nullable=False,
+    )
+
+
+class RawRecord(Base):
+    """Content-addressed blob store.
+
+    Scrapers hash their payload before insert; ``content_hash`` is unique so
+    the same fetch can be replayed without producing duplicates. Useful for
+    debugging "why did the resolver decide that?" without re-hitting the
+    upstream API.
+    """
+
+    __tablename__ = "raw_record"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+    source: Mapped[str] = mapped_column(String(64), nullable=False)
+    fetched_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        nullable=False,
+    )
+    payload: Mapped[dict[str, Any]] = mapped_column(JSONB, nullable=False)
+    content_hash: Mapped[str] = mapped_column(String(64), nullable=False, unique=True)
+
+
+class AliasReviewQueue(Base):
+    """Items the fuzzy matcher couldn't auto-decide.
+
+    ``candidates`` is a JSON array of plausible canonical_ids with their
+    similarity scores; the human reviewer picks one or marks the row blocked.
+    See BUF-16 for the CLI/UI that drains this.
+    """
+
+    __tablename__ = "alias_review_queue"
+
+    id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+    platform: Mapped[Platform] = mapped_column(_platform, nullable=False)
+    platform_id: Mapped[str] = mapped_column(String(255), nullable=False)
+    platform_name: Mapped[str] = mapped_column(String(255), nullable=False)
+    candidates: Mapped[list[dict[str, Any]]] = mapped_column(JSONB, nullable=False)
+    reason: Mapped[str] = mapped_column(String(255), nullable=False)
+    status: Mapped[ReviewStatus] = mapped_column(
+        _review_status,
+        nullable=False,
+        server_default=ReviewStatus.PENDING.value,
+        index=True,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        nullable=False,
+    )
+
+
+__all__ = [
+    "Entity",
+    "EntityAlias",
+    "StagingRecord",
+    "RawRecord",
+    "AliasReviewQueue",
+]

--- a/packages/shared/src/esports_sim/schemas/__init__.py
+++ b/packages/shared/src/esports_sim/schemas/__init__.py
@@ -1,0 +1,17 @@
+"""Cross-cutting schema definitions: events (BUF-78), DB DTOs (BUF-6)."""
+
+from esports_sim.schemas.dtos import (
+    AliasReviewQueueDTO,
+    EntityAliasDTO,
+    EntityDTO,
+    RawRecordDTO,
+    StagingRecordDTO,
+)
+
+__all__ = [
+    "EntityDTO",
+    "EntityAliasDTO",
+    "StagingRecordDTO",
+    "RawRecordDTO",
+    "AliasReviewQueueDTO",
+]

--- a/packages/shared/src/esports_sim/schemas/dtos.py
+++ b/packages/shared/src/esports_sim/schemas/dtos.py
@@ -1,0 +1,83 @@
+"""Pydantic DTOs for the BUF-6 schema.
+
+The Systems-spec rule: downstream code imports these DTOs and never reaches
+into raw SQL. The :class:`pydantic.BaseModel` instances are frozen so a DTO
+that escapes one layer cannot be mutated by another.
+
+``model_config = from_attributes=True`` lets us instantiate a DTO directly
+from a SQLAlchemy ORM row (``EntityDTO.model_validate(entity_row)``).
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import datetime
+from typing import Any
+
+from pydantic import BaseModel, ConfigDict, Field
+
+from esports_sim.db.enums import EntityType, Platform, ReviewStatus, StagingStatus
+
+
+class _Frozen(BaseModel):
+    model_config = ConfigDict(frozen=True, extra="forbid", from_attributes=True)
+
+
+class EntityDTO(_Frozen):
+    canonical_id: uuid.UUID
+    entity_type: EntityType
+    created_at: datetime
+    is_active: bool = True
+
+
+class EntityAliasDTO(_Frozen):
+    id: uuid.UUID
+    canonical_id: uuid.UUID
+    platform: Platform
+    platform_id: str = Field(min_length=1, max_length=255)
+    platform_name: str = Field(min_length=1, max_length=255)
+    # Confidence is the resolver's match score, bounded so a Liquipedia seed
+    # at 1.0 and a fuzzy auto-merge at 0.92 are comparable across rows.
+    confidence: float = Field(ge=0.0, le=1.0)
+    verified_at: datetime | None = None
+    valid_from: datetime
+
+
+class StagingRecordDTO(_Frozen):
+    id: uuid.UUID
+    source: str = Field(min_length=1, max_length=64)
+    entity_type: EntityType
+    canonical_id: uuid.UUID | None = None
+    payload: dict[str, Any]
+    status: StagingStatus = StagingStatus.PENDING
+    created_at: datetime
+
+
+class RawRecordDTO(_Frozen):
+    id: uuid.UUID
+    source: str = Field(min_length=1, max_length=64)
+    fetched_at: datetime
+    payload: dict[str, Any]
+    # SHA-256 hex is 64 chars; we keep the column wide enough for that and
+    # narrower variants (BLAKE2b-256 etc.) so the producer picks the algo.
+    content_hash: str = Field(min_length=1, max_length=64)
+
+
+class AliasReviewQueueDTO(_Frozen):
+    id: uuid.UUID
+    platform: Platform
+    platform_id: str = Field(min_length=1, max_length=255)
+    platform_name: str = Field(min_length=1, max_length=255)
+    candidates: list[dict[str, Any]]
+    reason: str = Field(min_length=1, max_length=255)
+    status: ReviewStatus = ReviewStatus.PENDING
+    created_at: datetime
+
+
+__all__ = [
+    "EntityDTO",
+    "EntityAliasDTO",
+    "StagingRecordDTO",
+    "RawRecordDTO",
+    "AliasReviewQueueDTO",
+]

--- a/packages/shared/tests/conftest.py
+++ b/packages/shared/tests/conftest.py
@@ -1,0 +1,119 @@
+"""Shared pytest fixtures for the BUF-6 integration tests.
+
+The integration fixtures are skipped automatically when ``TEST_DATABASE_URL``
+is not set, so a fresh clone with no Postgres running still has a green
+``uv run pytest``. Local devs typically run::
+
+    docker compose up -d --wait postgres
+    TEST_DATABASE_URL=postgresql+psycopg://nexus:nexus@localhost:5432/nexus uv run pytest
+
+CI provides a Postgres service container and exports the URL.
+"""
+
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from collections.abc import Generator
+from pathlib import Path
+
+import pytest
+from esports_sim.db.base import Base
+from sqlalchemy import Engine, create_engine, text
+from sqlalchemy.orm import Session, sessionmaker
+
+
+def _shared_pkg_root() -> Path:
+    """Path to ``packages/shared`` so we can invoke alembic from there."""
+    # tests/ is a sibling of alembic/ inside packages/shared.
+    return Path(__file__).resolve().parent.parent
+
+
+def _resolve_test_url() -> str | None:
+    """Return the TEST_DATABASE_URL with a sync driver prefix, or None."""
+    url = os.getenv("TEST_DATABASE_URL")
+    if not url:
+        return None
+    # alembic + the sync engine want psycopg, even if a service config nearby
+    # uses asyncpg. Normalise so callers don't have to maintain two URLs.
+    if url.startswith("postgresql+asyncpg://"):
+        return url.replace("postgresql+asyncpg://", "postgresql+psycopg://", 1)
+    if url.startswith("postgresql://"):
+        return url.replace("postgresql://", "postgresql+psycopg://", 1)
+    return url
+
+
+@pytest.fixture(scope="session")
+def db_engine() -> Generator[Engine, None, None]:
+    """Session-scoped engine with migrations applied to head.
+
+    Skips the test when ``TEST_DATABASE_URL`` is not configured. After the
+    session ends, migrations are rolled back to leave the DB clean for the
+    next run.
+    """
+    url = _resolve_test_url()
+    if not url:
+        pytest.skip("TEST_DATABASE_URL not set; skipping Postgres integration tests")
+
+    # Run alembic via subprocess so we exercise the same CLI path operators
+    # use, not just programmatic upgrades. The env vars override alembic.ini.
+    env = {**os.environ, "DATABASE_URL": url}
+    upgrade = subprocess.run(
+        [sys.executable, "-m", "alembic", "upgrade", "head"],
+        cwd=_shared_pkg_root(),
+        env=env,
+        capture_output=True,
+        text=True,
+    )
+    if upgrade.returncode != 0:
+        pytest.fail(
+            "alembic upgrade head failed:\n"
+            f"stdout:\n{upgrade.stdout}\n"
+            f"stderr:\n{upgrade.stderr}"
+        )
+
+    engine = create_engine(url, future=True)
+    try:
+        yield engine
+    finally:
+        # Roll back to a clean DB so re-runs are idempotent. Drop the
+        # alembic_version table too — otherwise the next run thinks it's
+        # already migrated.
+        with engine.begin() as conn:
+            Base.metadata.drop_all(bind=conn)
+            conn.execute(text("DROP TABLE IF EXISTS alembic_version"))
+            for typename in (
+                "review_status",
+                "staging_status",
+                "platform",
+                "entity_type",
+            ):
+                conn.execute(text(f"DROP TYPE IF EXISTS {typename}"))
+        engine.dispose()
+
+
+@pytest.fixture
+def db_session(db_engine: Engine) -> Generator[Session, None, None]:
+    """Function-scoped session with savepoint isolation.
+
+    Each test gets a fresh outer transaction; SQLAlchemy 2.0's
+    ``join_transaction_mode="create_savepoint"`` makes ``session.commit()``
+    inside the test create a savepoint instead of really committing, so a
+    deliberate ``IntegrityError`` doesn't leak across tests.
+    """
+    connection = db_engine.connect()
+    transaction = connection.begin()
+    SessionLocal = sessionmaker(
+        bind=connection,
+        expire_on_commit=False,
+        join_transaction_mode="create_savepoint",
+    )
+    session = SessionLocal()
+    try:
+        yield session
+    finally:
+        session.close()
+        if transaction.is_active:
+            transaction.rollback()
+        connection.close()

--- a/packages/shared/tests/fixtures.py
+++ b/packages/shared/tests/fixtures.py
@@ -1,0 +1,115 @@
+"""Factory helpers for the BUF-6 schema.
+
+Tiny by design — these are *seed* helpers, not a full Faker-style factory
+library. Each function returns a model instance with sensible defaults that
+callers override via kwargs.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import uuid
+from datetime import UTC, datetime
+from typing import Any
+
+from esports_sim.db.enums import EntityType, Platform, ReviewStatus, StagingStatus
+from esports_sim.db.models import (
+    AliasReviewQueue,
+    Entity,
+    EntityAlias,
+    RawRecord,
+    StagingRecord,
+)
+
+
+def make_entity(
+    *,
+    canonical_id: uuid.UUID | None = None,
+    entity_type: EntityType = EntityType.PLAYER,
+    is_active: bool = True,
+) -> Entity:
+    return Entity(
+        canonical_id=canonical_id or uuid.uuid4(),
+        entity_type=entity_type,
+        is_active=is_active,
+    )
+
+
+def make_entity_alias(
+    *,
+    entity: Entity,
+    platform: Platform = Platform.VLR,
+    platform_id: str = "vlr-1234",
+    platform_name: str = "TenZ",
+    confidence: float = 1.0,
+    verified_at: datetime | None = None,
+    valid_from: datetime | None = None,
+) -> EntityAlias:
+    # Set ``canonical_id`` explicitly as well as the relationship — the FK
+    # column is None on an unattached row otherwise, and the DTO requires it.
+    return EntityAlias(
+        id=uuid.uuid4(),
+        entity=entity,
+        canonical_id=entity.canonical_id,
+        platform=platform,
+        platform_id=platform_id,
+        platform_name=platform_name,
+        confidence=confidence,
+        verified_at=verified_at,
+        valid_from=valid_from or datetime.now(UTC),
+    )
+
+
+def make_staging_record(
+    *,
+    source: str = "vlr",
+    entity_type: EntityType = EntityType.PLAYER,
+    canonical_id: uuid.UUID | None = None,
+    payload: dict[str, Any] | None = None,
+    status: StagingStatus = StagingStatus.PENDING,
+) -> StagingRecord:
+    return StagingRecord(
+        id=uuid.uuid4(),
+        source=source,
+        entity_type=entity_type,
+        canonical_id=canonical_id,
+        payload=payload or {"name": "TenZ"},
+        status=status,
+    )
+
+
+def make_raw_record(
+    *,
+    source: str = "vlr",
+    payload: dict[str, Any] | None = None,
+    content_hash: str | None = None,
+) -> RawRecord:
+    body = payload or {"raw": "blob"}
+    return RawRecord(
+        id=uuid.uuid4(),
+        source=source,
+        payload=body,
+        content_hash=content_hash
+        or hashlib.sha256(repr(sorted(body.items())).encode()).hexdigest(),
+    )
+
+
+def make_review_queue_item(
+    *,
+    platform: Platform = Platform.VLR,
+    platform_id: str = "vlr-9999",
+    platform_name: str = "TenZ",
+    candidates: list[dict[str, Any]] | None = None,
+    reason: str = "fuzzy_below_auto_merge",
+    status: ReviewStatus = ReviewStatus.PENDING,
+) -> AliasReviewQueue:
+    return AliasReviewQueue(
+        id=uuid.uuid4(),
+        platform=platform,
+        platform_id=platform_id,
+        platform_name=platform_name,
+        candidates=candidates
+        or [{"canonical_id": str(uuid.uuid4()), "name": "tenz", "score": 0.78}],
+        reason=reason,
+        status=status,
+    )

--- a/packages/shared/tests/test_db_models.py
+++ b/packages/shared/tests/test_db_models.py
@@ -1,0 +1,210 @@
+"""Integration tests against a real Postgres for the BUF-6 schema.
+
+Skipped automatically when ``TEST_DATABASE_URL`` is not set — see
+``conftest.py``. CI provides a Postgres service container; locally:
+
+    docker compose up -d --wait postgres
+    TEST_DATABASE_URL=postgresql+psycopg://nexus:nexus@localhost:5432/nexus \\
+        uv run pytest -m integration
+"""
+
+from __future__ import annotations
+
+import uuid
+
+import pytest
+from esports_sim.db.enums import EntityType, Platform, ReviewStatus, StagingStatus
+from esports_sim.db.models import (
+    Entity,
+    EntityAlias,
+)
+from sqlalchemy import inspect, select, text
+from sqlalchemy.exc import IntegrityError
+
+from tests.fixtures import (
+    make_entity,
+    make_entity_alias,
+    make_raw_record,
+    make_review_queue_item,
+    make_staging_record,
+)
+
+pytestmark = pytest.mark.integration
+
+
+def test_alembic_upgrade_creates_all_tables(db_engine) -> None:
+    """`alembic upgrade head` produces every table the application expects."""
+    insp = inspect(db_engine)
+    tables = set(insp.get_table_names())
+    expected = {
+        "entity",
+        "entity_alias",
+        "staging_record",
+        "raw_record",
+        "alias_review_queue",
+        "alembic_version",  # bookkeeping table that proves the migration ran
+    }
+    missing = expected - tables
+    assert not missing, f"missing tables: {missing}"
+
+
+def test_pgvector_extension_enabled(db_engine) -> None:
+    """The `vector` extension must be live so BUF-28 can land vector tables."""
+    with db_engine.connect() as conn:
+        row = conn.execute(
+            text("SELECT extname FROM pg_extension WHERE extname = 'vector'")
+        ).first()
+    assert row is not None, "pgvector extension was not created by the migration"
+
+
+def test_player_entity_with_two_aliases(db_session) -> None:
+    """Acceptance scenario from BUF-6: insert a player + two aliases.
+
+    Two aliases with different ``(platform, platform_id)`` pairs are legal —
+    that's exactly how a player tracked on both VLR and Liquipedia ends up
+    with one canonical id and two alias rows.
+    """
+    e = make_entity(entity_type=EntityType.PLAYER)
+    make_entity_alias(entity=e, platform=Platform.VLR, platform_id="vlr-1234", platform_name="TenZ")
+    make_entity_alias(
+        entity=e,
+        platform=Platform.LIQUIPEDIA,
+        platform_id="liq-tenz",
+        platform_name="TenZ",
+        confidence=0.95,
+    )
+    db_session.add(e)
+    db_session.flush()
+
+    stored = db_session.get(Entity, e.canonical_id)
+    assert stored is not None
+    assert stored.entity_type is EntityType.PLAYER
+    assert stored.is_active is True
+    assert len(stored.aliases) == 2
+    assert {a.platform for a in stored.aliases} == {Platform.VLR, Platform.LIQUIPEDIA}
+
+
+def test_alias_unique_constraint_prevents_duplicate_platform_id(db_session) -> None:
+    """`(platform, platform_id)` is the schema-level guarantee no scraper can
+    silently split a player into two canonical rows by re-indexing the same
+    handle under a fresh entity.
+    """
+    e1 = make_entity(entity_type=EntityType.PLAYER)
+    make_entity_alias(
+        entity=e1, platform=Platform.VLR, platform_id="vlr-shared", platform_name="TenZ"
+    )
+    db_session.add(e1)
+    db_session.flush()
+
+    e2 = make_entity(entity_type=EntityType.PLAYER)
+    make_entity_alias(
+        entity=e2,
+        platform=Platform.VLR,
+        platform_id="vlr-shared",  # same (platform, platform_id) — should fail
+        platform_name="Imposter",
+        confidence=0.5,
+    )
+    db_session.add(e2)
+    with pytest.raises(IntegrityError):
+        db_session.flush()
+    db_session.rollback()
+
+
+def test_alias_same_platform_id_different_platform_is_legal(db_session) -> None:
+    """Same string is fine across two platforms — uniqueness is per platform."""
+    e = make_entity(entity_type=EntityType.PLAYER)
+    make_entity_alias(
+        entity=e,
+        platform=Platform.VLR,
+        platform_id="shared-string",
+        platform_name="TenZ",
+    )
+    make_entity_alias(
+        entity=e,
+        platform=Platform.LIQUIPEDIA,
+        platform_id="shared-string",
+        platform_name="TenZ",
+    )
+    db_session.add(e)
+    db_session.flush()  # No IntegrityError.
+
+
+def test_staging_record_defaults_pending(db_session) -> None:
+    """`status` defaults to pending so scrapers can omit it."""
+    sr = make_staging_record()
+    db_session.add(sr)
+    db_session.flush()
+    db_session.refresh(sr)
+    assert sr.status is StagingStatus.PENDING
+
+
+def test_staging_record_canonical_id_nullable(db_session) -> None:
+    """A pre-resolution row legally has no canonical_id."""
+    sr = make_staging_record(canonical_id=None, status=StagingStatus.REVIEW)
+    db_session.add(sr)
+    db_session.flush()
+    assert sr.canonical_id is None
+
+
+def test_raw_record_content_hash_unique(db_session) -> None:
+    """Re-fetching the same payload must not produce a duplicate raw_record."""
+    a = make_raw_record(content_hash="abc123")
+    b = make_raw_record(content_hash="abc123")  # same hash, different id
+    db_session.add(a)
+    db_session.flush()
+    db_session.add(b)
+    with pytest.raises(IntegrityError):
+        db_session.flush()
+    db_session.rollback()
+
+
+def test_review_queue_item_defaults_pending(db_session) -> None:
+    item = make_review_queue_item()
+    db_session.add(item)
+    db_session.flush()
+    db_session.refresh(item)
+    assert item.status is ReviewStatus.PENDING
+
+
+def test_cascade_delete_drops_aliases_with_entity(db_session) -> None:
+    """Deleting a canonical entity removes its aliases (FK ON DELETE CASCADE).
+
+    Important for the resolver's ``handle_rebrand`` (BUF-12) error path: a
+    botched merge that has to be undone shouldn't leave orphan alias rows
+    pointing at a missing canonical_id.
+    """
+    e = make_entity()
+    make_entity_alias(entity=e)
+    db_session.add(e)
+    db_session.flush()
+
+    db_session.delete(e)
+    db_session.flush()
+
+    remaining = db_session.execute(select(EntityAlias)).scalars().all()
+    assert remaining == []
+
+
+def test_staging_canonical_id_nulls_on_entity_delete(db_session) -> None:
+    """`staging_record.canonical_id` uses ON DELETE SET NULL, not CASCADE.
+
+    Staging is an audit trail; the row should survive the canonical it was
+    pointing at. Otherwise we'd lose the input that produced a bad merge.
+    """
+    e = make_entity()
+    sr = make_staging_record(canonical_id=e.canonical_id, status=StagingStatus.PROCESSED)
+    db_session.add_all([e, sr])
+    db_session.flush()
+
+    db_session.delete(e)
+    db_session.flush()
+    db_session.refresh(sr)
+    assert sr.canonical_id is None
+
+
+def test_uuid_default_for_entity(db_session) -> None:
+    """Inserting without an explicit canonical_id mints one client-side."""
+    e = Entity(entity_type=EntityType.TEAM)
+    db_session.add(e)
+    db_session.flush()
+    assert isinstance(e.canonical_id, uuid.UUID)

--- a/packages/shared/tests/test_dtos.py
+++ b/packages/shared/tests/test_dtos.py
@@ -1,0 +1,125 @@
+"""Unit tests for the BUF-6 Pydantic DTOs.
+
+These don't need a database — they exercise the validation rules and the
+``from_attributes=True`` path that lets us construct a DTO directly from a
+SQLAlchemy ORM row.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime
+
+import pytest
+from esports_sim.db.enums import EntityType, Platform, ReviewStatus, StagingStatus
+from esports_sim.schemas.dtos import (
+    AliasReviewQueueDTO,
+    EntityAliasDTO,
+    EntityDTO,
+    RawRecordDTO,
+    StagingRecordDTO,
+)
+from pydantic import ValidationError
+
+from tests.fixtures import (
+    make_entity,
+    make_entity_alias,
+    make_raw_record,
+    make_review_queue_item,
+    make_staging_record,
+)
+
+
+def test_entity_dto_from_orm() -> None:
+    e = make_entity(entity_type=EntityType.PLAYER)
+    # `from_attributes=True` lets us validate straight off the ORM row,
+    # provided the attributes are populated. Server defaults aren't applied
+    # until the row is flushed, so for this unit test we set created_at
+    # manually.
+    e.created_at = datetime.now(UTC)
+    dto = EntityDTO.model_validate(e)
+    assert dto.canonical_id == e.canonical_id
+    assert dto.entity_type is EntityType.PLAYER
+
+
+def test_entity_dto_is_frozen() -> None:
+    dto = EntityDTO(
+        canonical_id=uuid.uuid4(),
+        entity_type=EntityType.PLAYER,
+        created_at=datetime.now(UTC),
+    )
+    with pytest.raises(ValidationError):
+        dto.is_active = False  # type: ignore[misc]
+
+
+def test_entity_alias_confidence_bounds() -> None:
+    base = {
+        "id": uuid.uuid4(),
+        "canonical_id": uuid.uuid4(),
+        "platform": Platform.VLR,
+        "platform_id": "vlr-1234",
+        "platform_name": "TenZ",
+        "valid_from": datetime.now(UTC),
+    }
+    EntityAliasDTO(**base, confidence=0.0)
+    EntityAliasDTO(**base, confidence=1.0)
+    with pytest.raises(ValidationError):
+        EntityAliasDTO(**base, confidence=-0.01)
+    with pytest.raises(ValidationError):
+        EntityAliasDTO(**base, confidence=1.01)
+
+
+def test_entity_alias_dto_from_orm() -> None:
+    e = make_entity()
+    a = make_entity_alias(entity=e)
+    dto = EntityAliasDTO.model_validate(a)
+    assert dto.platform is Platform.VLR
+    assert dto.platform_id == "vlr-1234"
+
+
+def test_staging_record_default_status() -> None:
+    sr = make_staging_record()
+    sr.created_at = datetime.now(UTC)
+    dto = StagingRecordDTO.model_validate(sr)
+    assert dto.status is StagingStatus.PENDING
+
+
+def test_staging_record_canonical_id_optional() -> None:
+    """Pre-resolution rows don't have a canonical_id; the DTO must allow that."""
+    dto = StagingRecordDTO(
+        id=uuid.uuid4(),
+        source="vlr",
+        entity_type=EntityType.PLAYER,
+        canonical_id=None,
+        payload={"name": "TenZ"},
+        status=StagingStatus.REVIEW,
+        created_at=datetime.now(UTC),
+    )
+    assert dto.canonical_id is None
+
+
+def test_raw_record_dto_from_orm() -> None:
+    r = make_raw_record()
+    r.fetched_at = datetime.now(UTC)
+    dto = RawRecordDTO.model_validate(r)
+    assert dto.source == "vlr"
+    assert len(dto.content_hash) > 0
+
+
+def test_review_queue_dto_from_orm() -> None:
+    item = make_review_queue_item()
+    item.created_at = datetime.now(UTC)
+    dto = AliasReviewQueueDTO.model_validate(item)
+    assert dto.status is ReviewStatus.PENDING
+    assert dto.candidates and isinstance(dto.candidates[0], dict)
+
+
+def test_extra_fields_rejected() -> None:
+    """All DTOs use extra='forbid' so an unknown column fails loudly."""
+    with pytest.raises(ValidationError):
+        EntityDTO(
+            canonical_id=uuid.uuid4(),
+            entity_type=EntityType.PLAYER,
+            created_at=datetime.now(UTC),
+            bogus=True,  # type: ignore[call-arg]
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -31,6 +31,18 @@ dev = [
     "types-PyYAML",
 ]
 
+[tool.pytest.ini_options]
+testpaths = [
+    "packages/shared/tests",
+    "services/data_pipeline/tests",
+    "services/ecosystem/tests",
+    "services/match_wm/tests",
+]
+addopts = "-ra"
+markers = [
+    "integration: requires a running Postgres (TEST_DATABASE_URL set). Skipped by default on a fresh clone.",
+]
+
 # --- Tooling configuration shared by every workspace member -------------------
 
 [tool.ruff]
@@ -66,12 +78,3 @@ mypy_path = [
 [[tool.mypy.overrides]]
 module = ["numpy", "numpy.*"]
 ignore_missing_imports = true
-
-[tool.pytest.ini_options]
-testpaths = [
-    "packages/shared/tests",
-    "services/data_pipeline/tests",
-    "services/ecosystem/tests",
-    "services/match_wm/tests",
-]
-addopts = "-ra"

--- a/uv.lock
+++ b/uv.lock
@@ -53,12 +53,42 @@ dev = [
 ]
 
 [[package]]
+name = "alembic"
+version = "1.18.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "mako" },
+    { name = "sqlalchemy" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/94/13/8b084e0f2efb0275a1d534838844926f798bd766566b1375174e2448cd31/alembic-1.18.4.tar.gz", hash = "sha256:cb6e1fd84b6174ab8dbb2329f86d631ba9559dd78df550b57804d607672cedbc", size = 2056725, upload-time = "2026-02-10T16:00:47.195Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d2/29/6533c317b74f707ea28f8d633734dbda2119bbadfc61b2f3640ba835d0f7/alembic-1.18.4-py3-none-any.whl", hash = "sha256:a5ed4adcf6d8a4cb575f3d759f071b03cd6e5c7618eb796cb52497be25bfe19a", size = 263893, upload-time = "2026-02-10T16:00:49.997Z" },
+]
+
+[[package]]
 name = "annotated-types"
 version = "0.7.0"
 source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
+name = "asyncpg"
+version = "0.31.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/fe/cc/d18065ce2380d80b1bcce927c24a2642efd38918e33fd724bc4bca904877/asyncpg-0.31.0.tar.gz", hash = "sha256:c989386c83940bfbd787180f2b1519415e2d3d6277a70d9d0f0145ac73500735", size = 993667, upload-time = "2025-11-24T23:27:00.812Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/2a/a6/59d0a146e61d20e18db7396583242e32e0f120693b67a8de43f1557033e2/asyncpg-0.31.0-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:b44c31e1efc1c15188ef183f287c728e2046abb1d26af4d20858215d50d91fad", size = 662042, upload-time = "2025-11-24T23:25:49.578Z" },
+    { url = "https://files.pythonhosted.org/packages/36/01/ffaa189dcb63a2471720615e60185c3f6327716fdc0fc04334436fbb7c65/asyncpg-0.31.0-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0c89ccf741c067614c9b5fc7f1fc6f3b61ab05ae4aaa966e6fd6b93097c7d20d", size = 638504, upload-time = "2025-11-24T23:25:51.501Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/62/3f699ba45d8bd24c5d65392190d19656d74ff0185f42e19d0bbd973bb371/asyncpg-0.31.0-cp312-cp312-manylinux_2_28_aarch64.whl", hash = "sha256:12b3b2e39dc5470abd5e98c8d3373e4b1d1234d9fbdedf538798b2c13c64460a", size = 3426241, upload-time = "2025-11-24T23:25:53.278Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/d1/a867c2150f9c6e7af6462637f613ba67f78a314b00db220cd26ff559d532/asyncpg-0.31.0-cp312-cp312-manylinux_2_28_x86_64.whl", hash = "sha256:aad7a33913fb8bcb5454313377cc330fbb19a0cd5faa7272407d8a0c4257b671", size = 3520321, upload-time = "2025-11-24T23:25:54.982Z" },
+    { url = "https://files.pythonhosted.org/packages/7a/1a/cce4c3f246805ecd285a3591222a2611141f1669d002163abef999b60f98/asyncpg-0.31.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:3df118d94f46d85b2e434fd62c84cb66d5834d5a890725fe625f498e72e4d5ec", size = 3316685, upload-time = "2025-11-24T23:25:57.43Z" },
+    { url = "https://files.pythonhosted.org/packages/40/ae/0fc961179e78cc579e138fad6eb580448ecae64908f95b8cb8ee2f241f67/asyncpg-0.31.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:bd5b6efff3c17c3202d4b37189969acf8927438a238c6257f66be3c426beba20", size = 3471858, upload-time = "2025-11-24T23:25:59.636Z" },
+    { url = "https://files.pythonhosted.org/packages/52/b2/b20e09670be031afa4cbfabd645caece7f85ec62d69c312239de568e058e/asyncpg-0.31.0-cp312-cp312-win32.whl", hash = "sha256:027eaa61361ec735926566f995d959ade4796f6a49d3bde17e5134b9964f9ba8", size = 527852, upload-time = "2025-11-24T23:26:01.084Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/f0/f2ed1de154e15b107dc692262395b3c17fc34eafe2a78fc2115931561730/asyncpg-0.31.0-cp312-cp312-win_amd64.whl", hash = "sha256:72d6bdcbc93d608a1158f17932de2321f68b1a967a13e014998db87a72ed3186", size = 597175, upload-time = "2025-11-24T23:26:02.564Z" },
 ]
 
 [[package]]
@@ -149,16 +179,26 @@ name = "esports-sim-shared"
 version = "0.0.1"
 source = { editable = "packages/shared" }
 dependencies = [
+    { name = "alembic" },
+    { name = "asyncpg" },
     { name = "numpy" },
+    { name = "pgvector" },
+    { name = "psycopg", extra = ["binary"] },
     { name = "pydantic" },
     { name = "pyyaml" },
+    { name = "sqlalchemy", extra = ["asyncio"] },
 ]
 
 [package.metadata]
 requires-dist = [
+    { name = "alembic", specifier = ">=1.13" },
+    { name = "asyncpg", specifier = ">=0.29" },
     { name = "numpy", specifier = ">=1.26" },
+    { name = "pgvector", specifier = ">=0.3" },
+    { name = "psycopg", extras = ["binary"], specifier = ">=3.1" },
     { name = "pydantic", specifier = ">=2.6" },
     { name = "pyyaml", specifier = ">=6.0" },
+    { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0" },
 ]
 
 [[package]]
@@ -168,6 +208,24 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/b5/fe/997687a931ab51049acce6fa1f23e8f01216374ea81374ddee763c493db5/filelock-3.29.0.tar.gz", hash = "sha256:69974355e960702e789734cb4871f884ea6fe50bd8404051a3530bc07809cf90", size = 57571, upload-time = "2026-04-19T15:39:10.068Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/81/47/dd9a212ef6e343a6857485ffe25bba537304f1913bdbed446a23f7f592e1/filelock-3.29.0-py3-none-any.whl", hash = "sha256:96f5f6344709aa1572bbf631c640e4ebeeb519e08da902c39a001882f30ac258", size = 39812, upload-time = "2026-04-19T15:39:08.752Z" },
+]
+
+[[package]]
+name = "greenlet"
+version = "3.4.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/86/94/a5935717b307d7c71fe877b52b884c6af707d2d2090db118a03fbd799369/greenlet-3.4.0.tar.gz", hash = "sha256:f50a96b64dafd6169e595a5c56c9146ef80333e67d4476a65a9c55f400fc22ff", size = 195913, upload-time = "2026-04-08T17:08:00.863Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/65/8b/3669ad3b3f247a791b2b4aceb3aa5a31f5f6817bf547e4e1ff712338145a/greenlet-3.4.0-cp312-cp312-macosx_11_0_universal2.whl", hash = "sha256:1a54a921561dd9518d31d2d3db4d7f80e589083063ab4d3e2e950756ef809e1a", size = 286902, upload-time = "2026-04-08T15:52:12.138Z" },
+    { url = "https://files.pythonhosted.org/packages/38/3e/3c0e19b82900873e2d8469b590a6c4b3dfd2b316d0591f1c26b38a4879a5/greenlet-3.4.0-cp312-cp312-manylinux_2_24_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:16dec271460a9a2b154e3b1c2fa1050ce6280878430320e85e08c166772e3f97", size = 606099, upload-time = "2026-04-08T16:24:38.408Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/33/99fef65e7754fc76a4ed14794074c38c9ed3394a5bd129d7f61b705f3168/greenlet-3.4.0-cp312-cp312-manylinux_2_24_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:90036ce224ed6fe75508c1907a77e4540176dcf0744473627785dd519c6f9996", size = 618837, upload-time = "2026-04-08T16:30:58.298Z" },
+    { url = "https://files.pythonhosted.org/packages/44/57/eae2cac10421feae6c0987e3dc106c6d86262b1cb379e171b017aba893a6/greenlet-3.4.0-cp312-cp312-manylinux_2_24_s390x.manylinux_2_28_s390x.whl", hash = "sha256:6f0def07ec9a71d72315cf26c061aceee53b306c36ed38c35caba952ea1b319d", size = 624901, upload-time = "2026-04-08T16:40:38.981Z" },
+    { url = "https://files.pythonhosted.org/packages/36/f7/229f3aed6948faa20e0616a0b8568da22e365ede6a54d7d369058b128afd/greenlet-3.4.0-cp312-cp312-manylinux_2_24_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:a1c4f6b453006efb8310affb2d132832e9bbb4fc01ce6df6b70d810d38f1f6dc", size = 615062, upload-time = "2026-04-08T15:56:33.766Z" },
+    { url = "https://files.pythonhosted.org/packages/6a/8a/0e73c9b94f31d1cc257fe79a0eff621674141cdae7d6d00f40de378a1e42/greenlet-3.4.0-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:0e1254cf0cbaa17b04320c3a78575f29f3c161ef38f59c977108f19ffddaf077", size = 423927, upload-time = "2026-04-08T16:43:05.293Z" },
+    { url = "https://files.pythonhosted.org/packages/08/97/d988180011aa40135c46cd0d0cf01dd97f7162bae14139b4a3ef54889ba5/greenlet-3.4.0-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:9b2d9a138ffa0e306d0e2b72976d2fb10b97e690d40ab36a472acaab0838e2de", size = 1573511, upload-time = "2026-04-08T16:26:20.058Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/0f/a5a26fe152fb3d12e6a474181f6e9848283504d0afd095f353d85726374b/greenlet-3.4.0-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:8424683caf46eb0eb6f626cb95e008e8cc30d0cb675bdfa48200925c79b38a08", size = 1640396, upload-time = "2026-04-08T15:57:30.88Z" },
+    { url = "https://files.pythonhosted.org/packages/42/cf/bb2c32d9a100e36ee9f6e38fad6b1e082b8184010cb06259b49e1266ca01/greenlet-3.4.0-cp312-cp312-win_amd64.whl", hash = "sha256:a0a53fb071531d003b075c444014ff8f8b1a9898d36bb88abd9ac7b3524648a2", size = 238892, upload-time = "2026-04-08T17:03:10.094Z" },
+    { url = "https://files.pythonhosted.org/packages/b7/47/6c41314bac56e71436ce551c7fbe3cc830ed857e6aa9708dbb9c65142eb6/greenlet-3.4.0-cp312-cp312-win_arm64.whl", hash = "sha256:f38b81880ba28f232f1f675893a39cf7b6db25b31cc0a09bb50787ecf957e85e", size = 235599, upload-time = "2026-04-08T15:52:54.3Z" },
 ]
 
 [[package]]
@@ -207,6 +265,37 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/92/1b/ee486d244b8de6b8b5dbaefabe6bfdd4a72e08f6353edf7d16d27114da8d/librt-0.9.0-cp312-cp312-win32.whl", hash = "sha256:9edcc35d1cae9fd5320171b1a838c7da8a5c968af31e82ecc3dff30b4be0957f", size = 55986, upload-time = "2026-04-09T16:05:13.529Z" },
     { url = "https://files.pythonhosted.org/packages/89/7a/ba1737012308c17dc6d5516143b5dce9a2c7ba3474afd54e11f44a4d1ef3/librt-0.9.0-cp312-cp312-win_amd64.whl", hash = "sha256:3cc2917258e131ae5f958a4d872e07555b51cb7466a43433218061c74ef33745", size = 63260, upload-time = "2026-04-09T16:05:14.68Z" },
     { url = "https://files.pythonhosted.org/packages/36/e4/01752c113da15127f18f7bf11142f5640038f062407a611c059d0036c6aa/librt-0.9.0-cp312-cp312-win_arm64.whl", hash = "sha256:90e6d5420fc8a300518d4d2288154ff45005e920425c22cbbfe8330f3f754bd9", size = 53694, upload-time = "2026-04-09T16:05:16.095Z" },
+]
+
+[[package]]
+name = "mako"
+version = "1.3.11"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "markupsafe" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/59/8a/805404d0c0b9f3d7a326475ca008db57aea9c5c9f2e1e39ed0faa335571c/mako-1.3.11.tar.gz", hash = "sha256:071eb4ab4c5010443152255d77db7faa6ce5916f35226eb02dc34479b6858069", size = 399811, upload-time = "2026-04-14T20:19:51.493Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/68/a5/19d7aaa7e433713ffe881df33705925a196afb9532efc8475d26593921a6/mako-1.3.11-py3-none-any.whl", hash = "sha256:e372c6e333cf004aa736a15f425087ec977e1fcbd2966aae7f17c8dc1da27a77", size = 78503, upload-time = "2026-04-14T20:19:53.233Z" },
+]
+
+[[package]]
+name = "markupsafe"
+version = "3.0.3"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/7e/99/7690b6d4034fffd95959cbe0c02de8deb3098cc577c67bb6a24fe5d7caa7/markupsafe-3.0.3.tar.gz", hash = "sha256:722695808f4b6457b320fdc131280796bdceb04ab50fe1795cd540799ebe1698", size = 80313, upload-time = "2025-09-27T18:37:40.426Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/72/147da192e38635ada20e0a2e1a51cf8823d2119ce8883f7053879c2199b5/markupsafe-3.0.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:d53197da72cc091b024dd97249dfc7794d6a56530370992a5e1a08983ad9230e", size = 11615, upload-time = "2025-09-27T18:36:30.854Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/81/7e4e08678a1f98521201c3079f77db69fb552acd56067661f8c2f534a718/markupsafe-3.0.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1872df69a4de6aead3491198eaf13810b565bdbeec3ae2dc8780f14458ec73ce", size = 12020, upload-time = "2025-09-27T18:36:31.971Z" },
+    { url = "https://files.pythonhosted.org/packages/1e/2c/799f4742efc39633a1b54a92eec4082e4f815314869865d876824c257c1e/markupsafe-3.0.3-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3a7e8ae81ae39e62a41ec302f972ba6ae23a5c5396c8e60113e9066ef893da0d", size = 24332, upload-time = "2025-09-27T18:36:32.813Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/2e/8d0c2ab90a8c1d9a24f0399058ab8519a3279d1bd4289511d74e909f060e/markupsafe-3.0.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:d6dd0be5b5b189d31db7cda48b91d7e0a9795f31430b7f271219ab30f1d3ac9d", size = 22947, upload-time = "2025-09-27T18:36:33.86Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/54/887f3092a85238093a0b2154bd629c89444f395618842e8b0c41783898ea/markupsafe-3.0.3-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:94c6f0bb423f739146aec64595853541634bde58b2135f27f61c1ffd1cd4d16a", size = 21962, upload-time = "2025-09-27T18:36:35.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/2f/336b8c7b6f4a4d95e91119dc8521402461b74a485558d8f238a68312f11c/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:be8813b57049a7dc738189df53d69395eba14fb99345e0a5994914a3864c8a4b", size = 23760, upload-time = "2025-09-27T18:36:36.001Z" },
+    { url = "https://files.pythonhosted.org/packages/32/43/67935f2b7e4982ffb50a4d169b724d74b62a3964bc1a9a527f5ac4f1ee2b/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:83891d0e9fb81a825d9a6d61e3f07550ca70a076484292a70fde82c4b807286f", size = 21529, upload-time = "2025-09-27T18:36:36.906Z" },
+    { url = "https://files.pythonhosted.org/packages/89/e0/4486f11e51bbba8b0c041098859e869e304d1c261e59244baa3d295d47b7/markupsafe-3.0.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:77f0643abe7495da77fb436f50f8dab76dbc6e5fd25d39589a0f1fe6548bfa2b", size = 23015, upload-time = "2025-09-27T18:36:37.868Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/e1/78ee7a023dac597a5825441ebd17170785a9dab23de95d2c7508ade94e0e/markupsafe-3.0.3-cp312-cp312-win32.whl", hash = "sha256:d88b440e37a16e651bda4c7c2b930eb586fd15ca7406cb39e211fcff3bf3017d", size = 14540, upload-time = "2025-09-27T18:36:38.761Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/5b/bec5aa9bbbb2c946ca2733ef9c4ca91c91b6a24580193e891b5f7dbe8e1e/markupsafe-3.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:26a5784ded40c9e318cfc2bdb30fe164bdb8665ded9cd64d500a34fb42067b1c", size = 15105, upload-time = "2025-09-27T18:36:39.701Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/f1/216fc1bbfd74011693a4fd837e7026152e89c4bcf3e77b6692fba9923123/markupsafe-3.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:35add3b638a5d900e807944a078b51922212fb3dedb01633a8defc4b01a3c85f", size = 13906, upload-time = "2025-09-27T18:36:40.689Z" },
 ]
 
 [[package]]
@@ -298,6 +387,18 @@ wheels = [
 ]
 
 [[package]]
+name = "pgvector"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "numpy" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/25/6c/6d8b4b03b958c02fa8687ec6063c49d952a189f8c91ebbe51e877dfab8f7/pgvector-0.4.2.tar.gz", hash = "sha256:322cac0c1dc5d41c9ecf782bd9991b7966685dee3a00bc873631391ed949513a", size = 31354, upload-time = "2025-12-05T01:07:17.87Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/26/6cee8a1ce8c43625ec561aff19df07f9776b7525d9002c86bceb3e0ac970/pgvector-0.4.2-py3-none-any.whl", hash = "sha256:549d45f7a18593783d5eec609ea1684a724ba8405c4cb182a0b2b08aeff04e08", size = 27441, upload-time = "2025-12-05T01:07:16.536Z" },
+]
+
+[[package]]
 name = "platformdirs"
 version = "4.9.6"
 source = { registry = "https://pypi.org/simple" }
@@ -329,6 +430,42 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/8e/22/2de9408ac81acbb8a7d05d4cc064a152ccf33b3d480ebe0cd292153db239/pre_commit-4.6.0.tar.gz", hash = "sha256:718d2208cef53fdc38206e40524a6d4d9576d103eb16f0fec11c875e7716e9d9", size = 198525, upload-time = "2026-04-21T20:31:41.613Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/80/6e/4b28b62ecb6aae56769c34a8ff1d661473ec1e9519e2d5f8b2c150086b26/pre_commit-4.6.0-py2.py3-none-any.whl", hash = "sha256:e2cf246f7299edcabcf15f9b0571fdce06058527f0a06535068a86d38089f29b", size = 226472, upload-time = "2026-04-21T20:31:40.092Z" },
+]
+
+[[package]]
+name = "psycopg"
+version = "3.3.3"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+    { name = "tzdata", marker = "sys_platform == 'win32'" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/d3/b6/379d0a960f8f435ec78720462fd94c4863e7a31237cf81bf76d0af5883bf/psycopg-3.3.3.tar.gz", hash = "sha256:5e9a47458b3c1583326513b2556a2a9473a1001a56c9efe9e587245b43148dd9", size = 165624, upload-time = "2026-02-18T16:52:16.546Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c8/5b/181e2e3becb7672b502f0ed7f16ed7352aca7c109cfb94cf3878a9186db9/psycopg-3.3.3-py3-none-any.whl", hash = "sha256:f96525a72bcfade6584ab17e89de415ff360748c766f0106959144dcbb38c698", size = 212768, upload-time = "2026-02-18T16:46:27.365Z" },
+]
+
+[package.optional-dependencies]
+binary = [
+    { name = "psycopg-binary", marker = "implementation_name != 'pypy'" },
+]
+
+[[package]]
+name = "psycopg-binary"
+version = "3.3.3"
+source = { registry = "https://pypi.org/simple" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/90/15/021be5c0cbc5b7c1ab46e91cc3434eb42569f79a0592e67b8d25e66d844d/psycopg_binary-3.3.3-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:6698dbab5bcef8fdb570fc9d35fd9ac52041771bfcfe6fd0fc5f5c4e36f1e99d", size = 4591170, upload-time = "2026-02-18T16:48:55.594Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/54/a60211c346c9a2f8c6b272b5f2bbe21f6e11800ce7f61e99ba75cf8b63e1/psycopg_binary-3.3.3-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:329ff393441e75f10b673ae99ab45276887993d49e65f141da20d915c05aafd8", size = 4670009, upload-time = "2026-02-18T16:49:03.608Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/53/ac7c18671347c553362aadbf65f92786eef9540676ca24114cc02f5be405/psycopg_binary-3.3.3-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.whl", hash = "sha256:eb072949b8ebf4082ae24289a2b0fd724da9adc8f22743409d6fd718ddb379df", size = 5469735, upload-time = "2026-02-18T16:49:10.128Z" },
+    { url = "https://files.pythonhosted.org/packages/7f/c3/4f4e040902b82a344eff1c736cde2f2720f127fe939c7e7565706f96dd44/psycopg_binary-3.3.3-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.whl", hash = "sha256:263a24f39f26e19ed7fc982d7859a36f17841b05bebad3eb47bb9cd2dd785351", size = 5152919, upload-time = "2026-02-18T16:49:16.335Z" },
+    { url = "https://files.pythonhosted.org/packages/0c/e7/d929679c6a5c212bcf738806c7c89f5b3d0919f2e1685a0e08d6ff877945/psycopg_binary-3.3.3-cp312-cp312-manylinux_2_27_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:5152d50798c2fa5bd9b68ec68eb68a1b71b95126c1d70adaa1a08cd5eefdc23d", size = 6738785, upload-time = "2026-02-18T16:49:22.687Z" },
+    { url = "https://files.pythonhosted.org/packages/69/b0/09703aeb69a9443d232d7b5318d58742e8ca51ff79f90ffe6b88f1db45e7/psycopg_binary-3.3.3-cp312-cp312-manylinux_2_38_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:9d6a1e56dd267848edb824dbeb08cf5bac649e02ee0b03ba883ba3f4f0bd54f2", size = 4979008, upload-time = "2026-02-18T16:49:27.313Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/a6/e662558b793c6e13a7473b970fee327d635270e41eded3090ef14045a6a5/psycopg_binary-3.3.3-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:73eaaf4bb04709f545606c1db2f65f4000e8a04cdbf3e00d165a23004692093e", size = 4508255, upload-time = "2026-02-18T16:49:31.575Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/7f/0f8b2e1d5e0093921b6f324a948a5c740c1447fbb45e97acaf50241d0f39/psycopg_binary-3.3.3-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:162e5675efb4704192411eaf8e00d07f7960b679cd3306e7efb120bb8d9456cc", size = 4189166, upload-time = "2026-02-18T16:49:35.801Z" },
+    { url = "https://files.pythonhosted.org/packages/92/ec/ce2e91c33bc8d10b00c87e2f6b0fb570641a6a60042d6a9ae35658a3a797/psycopg_binary-3.3.3-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:fab6b5e37715885c69f5d091f6ff229be71e235f272ebaa35158d5a46fd548a0", size = 3924544, upload-time = "2026-02-18T16:49:41.129Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/2f/7718141485f73a924205af60041c392938852aa447a94c8cbd222ff389a1/psycopg_binary-3.3.3-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a4aab31bd6d1057f287c96c0effca3a25584eb9cc702f282ecb96ded7814e830", size = 4235297, upload-time = "2026-02-18T16:49:46.726Z" },
+    { url = "https://files.pythonhosted.org/packages/57/f9/1add717e2643a003bbde31b1b220172e64fbc0cb09f06429820c9173f7fc/psycopg_binary-3.3.3-cp312-cp312-win_amd64.whl", hash = "sha256:59aa31fe11a0e1d1bcc2ce37ed35fe2ac84cd65bb9036d049b1a1c39064d0f14", size = 3547659, upload-time = "2026-02-18T16:49:52.999Z" },
 ]
 
 [[package]]
@@ -484,6 +621,31 @@ wheels = [
 ]
 
 [[package]]
+name = "sqlalchemy"
+version = "2.0.49"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "greenlet", marker = "platform_machine == 'AMD64' or platform_machine == 'WIN32' or platform_machine == 'aarch64' or platform_machine == 'amd64' or platform_machine == 'ppc64le' or platform_machine == 'win32' or platform_machine == 'x86_64'" },
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/09/45/461788f35e0364a8da7bda51a1fe1b09762d0c32f12f63727998d85a873b/sqlalchemy-2.0.49.tar.gz", hash = "sha256:d15950a57a210e36dd4cec1aac22787e2a4d57ba9318233e2ef8b2daf9ff2d5f", size = 9898221, upload-time = "2026-04-03T16:38:11.704Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/49/b3/2de412451330756aaaa72d27131db6dde23995efe62c941184e15242a5fa/sqlalchemy-2.0.49-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:4bbccb45260e4ff1b7db0be80a9025bb1e6698bdb808b83fff0000f7a90b2c0b", size = 2157681, upload-time = "2026-04-03T16:53:07.132Z" },
+    { url = "https://files.pythonhosted.org/packages/50/84/b2a56e2105bd11ebf9f0b93abddd748e1a78d592819099359aa98134a8bf/sqlalchemy-2.0.49-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:fb37f15714ec2652d574f021d479e78cd4eb9d04396dca36568fdfffb3487982", size = 3338976, upload-time = "2026-04-03T17:07:40Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/fa/65fcae2ed62f84ab72cf89536c7c3217a156e71a2c111b1305ab6f0690e2/sqlalchemy-2.0.49-cp312-cp312-manylinux2014_x86_64.manylinux_2_17_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:3bb9ec6436a820a4c006aad1ac351f12de2f2dbdaad171692ee457a02429b672", size = 3351937, upload-time = "2026-04-03T17:12:23.374Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/2f/6fd118563572a7fe475925742eb6b3443b2250e346a0cc27d8d408e73773/sqlalchemy-2.0.49-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:8d6efc136f44a7e8bc8088507eaabbb8c2b55b3dbb63fe102c690da0ddebe55e", size = 3281646, upload-time = "2026-04-03T17:07:41.949Z" },
+    { url = "https://files.pythonhosted.org/packages/c5/d7/410f4a007c65275b9cf82354adb4bb8ba587b176d0a6ee99caa16fe638f8/sqlalchemy-2.0.49-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:e06e617e3d4fd9e51d385dfe45b077a41e9d1b033a7702551e3278ac597dc750", size = 3316695, upload-time = "2026-04-03T17:12:25.642Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/95/81f594aa60ded13273a844539041ccf1e66c5a7bed0a8e27810a3b52d522/sqlalchemy-2.0.49-cp312-cp312-win32.whl", hash = "sha256:83101a6930332b87653886c01d1ee7e294b1fe46a07dd9a2d2b4f91bcc88eec0", size = 2117483, upload-time = "2026-04-03T17:05:40.896Z" },
+    { url = "https://files.pythonhosted.org/packages/47/9e/fd90114059175cac64e4fafa9bf3ac20584384d66de40793ae2e2f26f3bb/sqlalchemy-2.0.49-cp312-cp312-win_amd64.whl", hash = "sha256:618a308215b6cececb6240b9abde545e3acdabac7ae3e1d4e666896bf5ba44b4", size = 2144494, upload-time = "2026-04-03T17:05:42.282Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/30/8519fdde58a7bdf155b714359791ad1dc018b47d60269d5d160d311fdc36/sqlalchemy-2.0.49-py3-none-any.whl", hash = "sha256:ec44cfa7ef1a728e88ad41674de50f6db8cfdb3e2af84af86e0041aaf02d43d0", size = 1942158, upload-time = "2026-04-03T16:53:44.135Z" },
+]
+
+[package.optional-dependencies]
+asyncio = [
+    { name = "greenlet" },
+]
+
+[[package]]
 name = "types-pyyaml"
 version = "6.0.12.20260408"
 source = { registry = "https://pypi.org/simple" }
@@ -511,6 +673,15 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
+]
+
+[[package]]
+name = "tzdata"
+version = "2026.2"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ba/19/1b9b0e29f30c6d35cb345486df41110984ea67ae69dddbc0e8a100999493/tzdata-2026.2.tar.gz", hash = "sha256:9173fde7d80d9018e02a662e168e5a2d04f87c41ea174b139fbef642eda62d10", size = 198254, upload-time = "2026-04-24T15:22:08.651Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/ce/e4/dccd7f47c4b64213ac01ef921a1337ee6e30e8c6466046018326977efd95/tzdata-2026.2-py2.py3-none-any.whl", hash = "sha256:bbe9af844f658da81a5f95019480da3a89415801f6cc966806612cc7169bffe7", size = 349321, upload-time = "2026-04-24T15:22:05.876Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes [BUF-6](https://linear.app/buffalo-studios/issue/BUF-6/postgres-schema-v1-entity-entityalias-staging-raw-store).

## Summary
- **Schema (Systems-spec System 01 + 02)**: `entity`, `entity_alias`, `staging_record`, `raw_record`, `alias_review_queue`. SQLAlchemy 2.0 typed models in `packages/shared/src/esports_sim/db/`.
- **DTOs**: frozen Pydantic v2 mirrors of every table with `extra='forbid'`, `from_attributes=True`. Downstream code imports these — never reaches into raw SQL, per the issue acceptance.
- **Migration**: hand-written initial revision at `packages/shared/alembic/versions/20260426_0001_initial_schema.py`. Lands `CREATE EXTENSION IF NOT EXISTS vector` first so BUF-28's embedding tables can ship without a second migration cycle (per the BUF-6 review comment + ADR-006).
- **Ops**:
  - `docker-compose.yml` Postgres image switched `postgres:16` → `pgvector/pgvector:pg16` (same major version, no data migration).
  - `make migrate` target added; runs `alembic upgrade head` against `$DATABASE_URL`.
  - CI workflow gets a Postgres service container with the pgvector image; `TEST_DATABASE_URL` is exported so integration tests run.

## Acceptance (live-verified locally)
- [x] `alembic upgrade head` on empty DB creates all five tables + indexes + the `vector` extension.
- [x] Insert player entity + two aliases; assert `UNIQUE(platform, platform_id)` blocks a duplicate.
- [x] Types mirror the Systems-spec exactly; downstream consumers import the DTOs.

## Tests
39 total — 12 integration (skipped without `TEST_DATABASE_URL`), 27 unit.

```
TEST_DATABASE_URL=postgresql+psycopg://nexus:nexus@localhost:5432/nexus uv run pytest
============================== 39 passed in 0.91s
```

Coverage highlights:
- `alembic upgrade head` creates every expected table on an empty DB
- pgvector extension is live after upgrade
- Player + two aliases (BUF-6 acceptance scenario)
- `UNIQUE(platform, platform_id)` blocks a duplicate from a *different* entity
- Same `platform_id` under different platforms is legal
- Server defaults: `status='pending'`, `is_active=true`
- `ON DELETE CASCADE` on `entity → entity_alias`
- `ON DELETE SET NULL` on `entity → staging_record` (audit trail survives)
- Pydantic DTO validation: `confidence ∈ [0, 1]`, `extra='forbid'`, frozen, `from_attributes`

## Test plan
- [ ] CI passes (lint + black --check + mypy + pytest with Postgres service container)
- [ ] On a fresh clone with `make dev` already run: `make migrate` succeeds and prints `Running upgrade  -> 0001`
- [ ] `psql` showing `\dt` lists the five tables
- [ ] `SELECT extname FROM pg_extension WHERE extname='vector'` returns one row

## Notes for downstream issues
- **BUF-7** (resolver) builds on these models; the FK `staging_record.canonical_id` uses `SET NULL` so the resolver can park a row before deciding what canonical id it belongs to.
- **BUF-12** (resolution worker) needs the `(platform, platform_id)` uniqueness this PR ships — that's how merges stay idempotent.
- **BUF-28** (pgvector embeddings) can now `CREATE TABLE personality_embeddings (..., vector vector(384), ...)` without re-plumbing the extension.
- The `Qdrant` service in `docker-compose.yml` is left in place — its removal is BUF-28's concern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)