### PR TITLE
BUF-7: canonical-id resolver with fuzzy matching and review queue

### DIFF
--- a/packages/shared/alembic/versions/20260427_0002_alias_review_pending_unique.py
+++ b/packages/shared/alembic/versions/20260427_0002_alias_review_pending_unique.py
@@ -1,0 +1,45 @@
+"""Partial unique index on alias_review_queue's pending rows.
+
+The resolver's pending-review enqueue used to be a check-then-insert
+sequence. Two concurrent ``resolve_entity()`` calls for the same
+``(platform, platform_id)`` could both observe "no pending row exists"
+and each insert one — duplicating human-review work. This migration
+adds the partial unique index that closes the race at the schema level
+so the resolver can rely on a unique-violation savepoint to enforce
+idempotency.
+
+Revision ID: 0002
+Revises: 0001
+Create Date: 2026-04-27
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+from alembic import op
+
+# revision identifiers, used by Alembic.
+revision: str = "0002"
+down_revision: str | None = "0001"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_index(
+        "ix_alias_review_queue_pending_unique",
+        "alias_review_queue",
+        ["platform", "platform_id"],
+        unique=True,
+        # Postgres treats partial-index predicates as text; the literal
+        # ``status = 'pending'`` matches the stored enum value. ``checkfirst``
+        # is implicit in alembic's ``create_index``; running upgrade against a
+        # DB that already has the index would error and that's the correct
+        # signal to investigate.
+        postgresql_where="status = 'pending'",
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_alias_review_queue_pending_unique", table_name="alias_review_queue")

--- a/packages/shared/pyproject.toml
+++ b/packages/shared/pyproject.toml
@@ -24,6 +24,10 @@ dependencies = [
     # pgvector Python bindings — registered as a SQLAlchemy type so BUF-28's
     # vector tables can land without re-plumbing types here.
     "pgvector>=0.3",
+    # Fuzzy string matcher used by the canonical-id resolver (BUF-7). C-backed
+    # implementation of token-set + WRatio scoring; keeps the resolver fast
+    # enough that running it inline on every staging row is acceptable.
+    "rapidfuzz>=3.6",
 ]
 
 [project.scripts]

--- a/packages/shared/src/esports_sim/db/__init__.py
+++ b/packages/shared/src/esports_sim/db/__init__.py
@@ -24,6 +24,7 @@ from esports_sim.db.models import (
     Entity,
     EntityAlias,
     RawRecord,
+    StagingInvariantError,
     StagingRecord,
 )
 
@@ -36,6 +37,7 @@ __all__ = [
     "Entity",
     "EntityAlias",
     "StagingRecord",
+    "StagingInvariantError",
     "RawRecord",
     "AliasReviewQueue",
 ]

--- a/packages/shared/src/esports_sim/db/models.py
+++ b/packages/shared/src/esports_sim/db/models.py
@@ -16,10 +16,12 @@ from sqlalchemy import (
     DateTime,
     Float,
     ForeignKey,
+    Index,
     String,
     UniqueConstraint,
     event,
     func,
+    text,
 )
 from sqlalchemy.dialects.postgresql import ENUM as PgEnum
 from sqlalchemy.dialects.postgresql import JSONB, UUID
@@ -298,6 +300,13 @@ class AliasReviewQueue(Base):
     ``candidates`` is a JSON array of plausible canonical_ids with their
     similarity scores; the human reviewer picks one or marks the row blocked.
     See BUF-16 for the CLI/UI that drains this.
+
+    Uniqueness is enforced via the partial index ``ix_alias_review_queue_pending_unique``
+    over ``(platform, platform_id) WHERE status = 'pending'``: at most one
+    pending review row per handle. The resolver's pending-enqueue path
+    relies on this so two concurrent calls can't both check-then-insert
+    and produce duplicate human-review work; the loser catches the unique
+    violation and degrades to "already enqueued".
     """
 
     __tablename__ = "alias_review_queue"
@@ -322,6 +331,20 @@ class AliasReviewQueue(Base):
         DateTime(timezone=True),
         server_default=func.now(),
         nullable=False,
+    )
+
+    __table_args__ = (
+        # Partial unique index: at most one pending row per (platform, platform_id).
+        # The literal ``status = 'pending'`` matches Postgres's stored enum
+        # value; using the enum object here would round-trip through Python
+        # repr and produce the wrong predicate string.
+        Index(
+            "ix_alias_review_queue_pending_unique",
+            "platform",
+            "platform_id",
+            unique=True,
+            postgresql_where=text("status = 'pending'"),
+        ),
     )
 
 

--- a/packages/shared/src/esports_sim/db/models.py
+++ b/packages/shared/src/esports_sim/db/models.py
@@ -140,13 +140,15 @@ class EntityAlias(Base):
 class StagingRecord(Base):
     """Scraped payload waiting for the resolver.
 
-    ``canonical_id`` is nullable so a row can be parked before the resolver
-    decides what entity it belongs to. BUF-7's ``StagingRecord.save()``
-    enforces the rule that a null ``canonical_id`` is only legal when the
-    status is ``blocked`` or ``review``. The :func:`_validate_canonical_id`
-    listener wired further down is the runtime backstop: even a scraper that
-    bypasses :meth:`save` and calls ``session.add`` directly cannot push a
-    null-canonical row in any status besides those two.
+    ``canonical_id`` is nullable to support the documented staging
+    lifecycle: ``pending`` rows queued for the resolver, ``review`` rows
+    deferred to a human reviewer, and ``blocked`` rows kept only for
+    audit may all legitimately carry a null canonical id. The bypass that
+    BUF-7 closes is the ``processed`` state — once a row is marked as
+    fully processed, the canonical id MUST be set. ``StagingRecord.save()``
+    plus the event listener below refuse to flush a ``processed`` row with
+    a null canonical id, which is the only way a scraper could "finish"
+    a staging row without actually consulting the resolver.
     """
 
     __tablename__ = "staging_record"
@@ -180,12 +182,11 @@ class StagingRecord(Base):
     def save(self, session: Session) -> None:
         """Persist this record, enforcing the canonical-id invariant.
 
-        BUF-7 requires the resolver to be the only thing that fills in a
-        ``canonical_id``. A row that is neither under review nor blocked must
-        therefore already carry a non-null canonical_id by the time it lands
-        in the session — anything else means a scraper tried to skip the
-        resolver. This wrapper raises :class:`StagingInvariantError` rather
-        than letting the row reach the database.
+        Refuses to add a ``processed`` row whose ``canonical_id`` is still
+        null — the only way that combination can arise is a scraper marking
+        a staging row as fully processed without actually consulting the
+        resolver. ``pending``/``review``/``blocked`` rows may legitimately
+        have a null canonical_id and pass through unchanged.
 
         Direct ``session.add(record)`` is also covered by the event listener
         below; ``save()`` exists so call sites read intentionally and so
@@ -198,19 +199,21 @@ class StagingRecord(Base):
 class StagingInvariantError(ValueError):
     """Raised when a :class:`StagingRecord` violates BUF-7's resolver rule.
 
-    A staging row may only carry a null ``canonical_id`` when its
-    ``status`` is ``blocked`` (kept for audit, never reprocessed) or
-    ``review`` (deferred to the alias review queue). Any other status with a
-    null canonical id means a scraper tried to write through without going
-    through :func:`esports_sim.resolver.resolve_entity` — refuse it loudly
+    A ``processed`` staging row whose ``canonical_id`` is null is the
+    bypass case: a scraper has declared the row "done" without going
+    through :func:`esports_sim.resolver.resolve_entity`. Refuse it loudly
     rather than corrupting the canonical join key.
     """
 
 
-# Statuses where a null canonical_id is meaningful state, not a bug. Kept as a
+# Statuses where a null canonical_id is meaningful state, not a bug. ``pending``
+# is the pre-resolver queue state; ``review`` and ``blocked`` are terminal
+# states the resolver itself produces when it can't (or won't) auto-decide.
+# Only ``processed`` requires a non-null canonical_id, because that's the
+# state that asserts "this row has a canonical mapping". Kept as a
 # module-level frozenset so the listener and the wrapper can't drift apart.
 _NULL_CANONICAL_OK: frozenset[StagingStatus] = frozenset(
-    {StagingStatus.BLOCKED, StagingStatus.REVIEW}
+    {StagingStatus.PENDING, StagingStatus.REVIEW, StagingStatus.BLOCKED}
 )
 
 
@@ -220,9 +223,10 @@ def _check_canonical_invariant(record: StagingRecord) -> None:
     if record.status in _NULL_CANONICAL_OK:
         return
     raise StagingInvariantError(
-        "StagingRecord with null canonical_id requires status=blocked or "
-        f"status=review (got {record.status.value!r}). The resolver "
-        "(BUF-7) is the only sanctioned writer of canonical_id."
+        f"StagingRecord with status={record.status.value!r} requires a "
+        "non-null canonical_id. The resolver (BUF-7) is the only sanctioned "
+        "writer of that column; marking a row processed without one means a "
+        "scraper bypassed resolve_entity()."
     )
 
 

--- a/packages/shared/src/esports_sim/db/models.py
+++ b/packages/shared/src/esports_sim/db/models.py
@@ -170,6 +170,14 @@ class StagingRecord(Base):
     status: Mapped[StagingStatus] = mapped_column(
         _staging_status,
         nullable=False,
+        # Mirror the server_default at the Python layer so the attribute is
+        # populated before ``before_insert`` fires. Without this, a row
+        # constructed without an explicit status had ``record.status is None``
+        # at validation time — the canonical-id check would raise
+        # AttributeError on the error path's ``.value`` deref instead of
+        # letting Postgres apply its default. ``server_default`` still owns
+        # the on-disk default for hand-written SQL.
+        default=StagingStatus.PENDING,
         server_default=StagingStatus.PENDING.value,
         index=True,
     )
@@ -220,7 +228,13 @@ _NULL_CANONICAL_OK: frozenset[StagingStatus] = frozenset(
 def _check_canonical_invariant(record: StagingRecord) -> None:
     if record.canonical_id is not None:
         return
-    if record.status in _NULL_CANONICAL_OK:
+    # ``status`` may be ``None`` at ``before_insert`` time when a caller
+    # constructed the row without setting it and is relying on the column
+    # default — the row will land as ``pending``, which is a legal
+    # null-canonical state. Treat that case as already-cleared rather than
+    # falling through to the error formatter (which would AttributeError on
+    # ``None.value``).
+    if record.status is None or record.status in _NULL_CANONICAL_OK:
         return
     raise StagingInvariantError(
         f"StagingRecord with status={record.status.value!r} requires a "

--- a/packages/shared/src/esports_sim/db/models.py
+++ b/packages/shared/src/esports_sim/db/models.py
@@ -18,11 +18,13 @@ from sqlalchemy import (
     ForeignKey,
     String,
     UniqueConstraint,
+    event,
     func,
 )
 from sqlalchemy.dialects.postgresql import ENUM as PgEnum
 from sqlalchemy.dialects.postgresql import JSONB, UUID
-from sqlalchemy.orm import Mapped, mapped_column, relationship
+from sqlalchemy.engine import Connection
+from sqlalchemy.orm import Mapped, Mapper, Session, mapped_column, relationship
 
 from esports_sim.db.base import Base
 from esports_sim.db.enums import EntityType, Platform, ReviewStatus, StagingStatus
@@ -141,7 +143,10 @@ class StagingRecord(Base):
     ``canonical_id`` is nullable so a row can be parked before the resolver
     decides what entity it belongs to. BUF-7's ``StagingRecord.save()``
     enforces the rule that a null ``canonical_id`` is only legal when the
-    status is ``blocked`` or ``review``.
+    status is ``blocked`` or ``review``. The :func:`_validate_canonical_id`
+    listener wired further down is the runtime backstop: even a scraper that
+    bypasses :meth:`save` and calls ``session.add`` directly cannot push a
+    null-canonical row in any status besides those two.
     """
 
     __tablename__ = "staging_record"
@@ -171,6 +176,76 @@ class StagingRecord(Base):
         server_default=func.now(),
         nullable=False,
     )
+
+    def save(self, session: Session) -> None:
+        """Persist this record, enforcing the canonical-id invariant.
+
+        BUF-7 requires the resolver to be the only thing that fills in a
+        ``canonical_id``. A row that is neither under review nor blocked must
+        therefore already carry a non-null canonical_id by the time it lands
+        in the session — anything else means a scraper tried to skip the
+        resolver. This wrapper raises :class:`StagingInvariantError` rather
+        than letting the row reach the database.
+
+        Direct ``session.add(record)`` is also covered by the event listener
+        below; ``save()`` exists so call sites read intentionally and so
+        unit tests can assert against a single named code path.
+        """
+        _check_canonical_invariant(self)
+        session.add(self)
+
+
+class StagingInvariantError(ValueError):
+    """Raised when a :class:`StagingRecord` violates BUF-7's resolver rule.
+
+    A staging row may only carry a null ``canonical_id`` when its
+    ``status`` is ``blocked`` (kept for audit, never reprocessed) or
+    ``review`` (deferred to the alias review queue). Any other status with a
+    null canonical id means a scraper tried to write through without going
+    through :func:`esports_sim.resolver.resolve_entity` — refuse it loudly
+    rather than corrupting the canonical join key.
+    """
+
+
+# Statuses where a null canonical_id is meaningful state, not a bug. Kept as a
+# module-level frozenset so the listener and the wrapper can't drift apart.
+_NULL_CANONICAL_OK: frozenset[StagingStatus] = frozenset(
+    {StagingStatus.BLOCKED, StagingStatus.REVIEW}
+)
+
+
+def _check_canonical_invariant(record: StagingRecord) -> None:
+    if record.canonical_id is not None:
+        return
+    if record.status in _NULL_CANONICAL_OK:
+        return
+    raise StagingInvariantError(
+        "StagingRecord with null canonical_id requires status=blocked or "
+        f"status=review (got {record.status.value!r}). The resolver "
+        "(BUF-7) is the only sanctioned writer of canonical_id."
+    )
+
+
+@event.listens_for(StagingRecord, "before_insert")
+def _staging_before_insert(
+    _mapper: Mapper[StagingRecord],
+    _connection: Connection,
+    target: StagingRecord,
+) -> None:
+    # SQLAlchemy event hook. Backstop for ``session.add(StagingRecord(...))``
+    # paths that don't go through ``StagingRecord.save``. Note: this does not
+    # fire for FK-cascade SET NULL, which happens inside Postgres — that's
+    # the audit-trail outcome the schema deliberately allows.
+    _check_canonical_invariant(target)
+
+
+@event.listens_for(StagingRecord, "before_update")
+def _staging_before_update(
+    _mapper: Mapper[StagingRecord],
+    _connection: Connection,
+    target: StagingRecord,
+) -> None:
+    _check_canonical_invariant(target)
 
 
 class RawRecord(Base):
@@ -236,6 +311,7 @@ __all__ = [
     "Entity",
     "EntityAlias",
     "StagingRecord",
+    "StagingInvariantError",
     "RawRecord",
     "AliasReviewQueue",
 ]

--- a/packages/shared/src/esports_sim/resolver/__init__.py
+++ b/packages/shared/src/esports_sim/resolver/__init__.py
@@ -1,0 +1,46 @@
+"""Canonical-id resolver (BUF-7, Systems-spec System 01).
+
+Every write to a canonical-keyed table funnels through :func:`resolve_entity`.
+The resolver decides one of four outcomes for a ``(platform, platform_id,
+platform_name)`` triple:
+
+* **MATCHED** — an alias row already exists for ``(platform, platform_id)``;
+  return its ``canonical_id`` unchanged.
+* **AUTO_MERGED** — fuzzy similarity to an existing canonical's name is at or
+  above :data:`AUTO_MERGE_THRESHOLD`; insert a new alias under the existing
+  canonical at the match score and return.
+* **PENDING** — fuzzy similarity sits in ``[REVIEW_THRESHOLD, AUTO_MERGE_THRESHOLD)``;
+  enqueue an :class:`~esports_sim.db.models.AliasReviewQueue` row with the
+  candidate list and return :class:`ResolutionStatus.PENDING`. No write to the
+  canonical tables happens.
+* **CREATED** — no candidate clears :data:`REVIEW_THRESHOLD`; mint a new
+  :class:`~esports_sim.db.models.Entity` plus an alias at confidence 1.0.
+
+The resolver is the *only* sanctioned entry point for inserting alias rows.
+Direct inserts into ``entity_alias`` from a scraper are a layering violation;
+the staging guard in :mod:`esports_sim.db.models` is the runtime backstop that
+catches scrapers that try to bypass it.
+
+Idempotency: a second call with the same ``(platform, platform_id)`` after a
+prior MATCHED/AUTO_MERGED/CREATED returns :class:`ResolutionStatus.MATCHED`
+with the same canonical_id. A second call after PENDING returns PENDING and
+does not enqueue a duplicate review row.
+"""
+
+from esports_sim.resolver.core import (
+    AUTO_MERGE_THRESHOLD,
+    REVIEW_THRESHOLD,
+    ResolutionStatus,
+    ResolveCandidate,
+    ResolveResult,
+    resolve_entity,
+)
+
+__all__ = [
+    "AUTO_MERGE_THRESHOLD",
+    "REVIEW_THRESHOLD",
+    "ResolutionStatus",
+    "ResolveCandidate",
+    "ResolveResult",
+    "resolve_entity",
+]

--- a/packages/shared/src/esports_sim/resolver/core.py
+++ b/packages/shared/src/esports_sim/resolver/core.py
@@ -51,29 +51,38 @@ _SCORE_DIVISOR: float = 100.0
 # only ever needs the best handful; bloating the row hurts both DB and UI.
 _MAX_REVIEW_CANDIDATES: int = 5
 
-# Name of the unique constraint that protects ``(platform, platform_id)`` on
-# the alias table — defined alongside :class:`EntityAlias`. The race-recovery
-# branches use this to distinguish the constraint they expect from any other
-# unique violation that might surface during a flush of unrelated session
-# state. Hard-coded rather than introspected because if the constraint name
-# ever changes, the matching here must be re-validated by hand.
+# Constraint names hard-coded so the resolver can distinguish "the race
+# I expected to recover from" from "any other unique violation". These names
+# are defined alongside the models and migration; if either changes, the
+# matching here must be re-validated by hand.
 _ALIAS_UNIQUE_CONSTRAINT: str = "uq_entity_alias_platform_platform_id"
+_REVIEW_QUEUE_PENDING_UNIQUE_INDEX: str = "ix_alias_review_queue_pending_unique"
 
 
-def _is_alias_uniqueness_violation(error: IntegrityError) -> bool:
-    """True iff this IntegrityError is the (platform, platform_id) race.
+def _matches_constraint(error: IntegrityError, constraint_name: str) -> bool:
+    """Return True iff this IntegrityError names ``constraint_name``.
 
-    Postgres surfaces the violated constraint name on ``error.orig.diag``
-    (psycopg). Falling back to a substring check on ``str(error)`` keeps the
-    detection useful when that introspection isn't available — the
-    constraint name is unique enough to make string matching safe.
+    Postgres surfaces the violated constraint on ``error.orig.diag.constraint_name``
+    (psycopg). The substring fallback over ``str(error)`` keeps the check
+    useful when that introspection isn't available — constraint names in
+    this schema are unique enough to make string matching safe.
     """
     orig = getattr(error, "orig", None)
     diag = getattr(orig, "diag", None)
-    constraint_name = getattr(diag, "constraint_name", None)
-    if constraint_name == _ALIAS_UNIQUE_CONSTRAINT:
+    name = getattr(diag, "constraint_name", None)
+    if name == constraint_name:
         return True
-    return _ALIAS_UNIQUE_CONSTRAINT in str(error)
+    return constraint_name in str(error)
+
+
+def _is_alias_uniqueness_violation(error: IntegrityError) -> bool:
+    """True iff this IntegrityError is the (platform, platform_id) race."""
+    return _matches_constraint(error, _ALIAS_UNIQUE_CONSTRAINT)
+
+
+def _is_pending_review_uniqueness_violation(error: IntegrityError) -> bool:
+    """True iff this IntegrityError is the pending-review enqueue race."""
+    return _matches_constraint(error, _REVIEW_QUEUE_PENDING_UNIQUE_INDEX)
 
 
 class ResolutionStatus(enum.StrEnum):
@@ -176,22 +185,21 @@ def resolve_entity(
         )
 
     if candidates and candidates[0].score >= REVIEW_THRESHOLD:
-        # Idempotent review enqueue: if a pending row already exists for this
-        # (platform, platform_id) the second call must be a no-op so a retried
-        # scraper doesn't pile up duplicate human-review work.
-        existing = _find_pending_review(session, platform=platform, platform_id=platform_id)
-        if existing is None:
-            session.add(
-                AliasReviewQueue(
-                    platform=platform,
-                    platform_id=platform_id,
-                    platform_name=platform_name,
-                    candidates=[c.to_json() for c in candidates],
-                    reason="fuzzy_below_auto_merge",
-                    status=ReviewStatus.PENDING,
-                )
-            )
-            session.flush()
+        # Idempotent review enqueue. A pre-check + insert is racy on its own —
+        # two concurrent calls would both observe "no pending row" and both
+        # enqueue. The partial unique index
+        # ``ix_alias_review_queue_pending_unique`` over
+        # ``(platform, platform_id) WHERE status='pending'`` makes the loser's
+        # insert fail with a constraint violation; a savepoint scopes that
+        # failure so the outer transaction stays usable, and we degrade to
+        # "already enqueued, return PENDING".
+        _enqueue_pending_review_idempotent(
+            session,
+            platform=platform,
+            platform_id=platform_id,
+            platform_name=platform_name,
+            candidates=candidates,
+        )
         return ResolveResult(
             status=ResolutionStatus.PENDING,
             canonical_id=None,
@@ -373,17 +381,56 @@ def _matched_after_race(session: Session, *, platform: Platform, platform_id: st
     )
 
 
+def _enqueue_pending_review_idempotent(
+    session: Session,
+    *,
+    platform: Platform,
+    platform_id: str,
+    platform_name: str,
+    candidates: list[ResolveCandidate],
+) -> None:
+    """Enqueue a pending review row, tolerating concurrent inserts.
+
+    The partial unique index ``ix_alias_review_queue_pending_unique`` over
+    ``(platform, platform_id) WHERE status='pending'`` is what actually
+    enforces "at most one pending row per handle". This function wraps the
+    insert in a savepoint so a concurrent winner's index violation surfaces
+    as a clean exception we can swallow — the caller still returns PENDING,
+    the duplicate human-review work doesn't materialise, and the outer
+    transaction stays usable.
+    """
+    try:
+        with session.begin_nested():
+            session.add(
+                AliasReviewQueue(
+                    platform=platform,
+                    platform_id=platform_id,
+                    platform_name=platform_name,
+                    candidates=[c.to_json() for c in candidates],
+                    reason="fuzzy_below_auto_merge",
+                    status=ReviewStatus.PENDING,
+                )
+            )
+            session.flush()
+    except IntegrityError as exc:
+        # Only the pending-review partial-unique violation is a race we can
+        # absorb. Anything else (a different constraint, a different table)
+        # is a real DB failure that belongs to its caller.
+        if not _is_pending_review_uniqueness_violation(exc):
+            raise
+        # Idempotent retry: the row another worker enqueued is good enough.
+
+
 def _find_pending_review(
     session: Session, *, platform: Platform, platform_id: str
 ) -> AliasReviewQueue | None:
-    # ``alias_review_queue`` has no uniqueness constraint over
-    # (platform, platform_id, status=pending) and the enqueue path is
-    # non-atomic, so two concurrent resolver calls can each insert a pending
-    # row before either notices the other. A third call's idempotency check
-    # would then see two rows; ``.scalar_one_or_none()`` would crash with
-    # ``MultipleResultsFound``, turning the retry path into a hard failure.
-    # Take the oldest pending row instead: any pending match is enough to
-    # treat the (platform, platform_id) as already queued.
+    """Read the oldest pending review row for a handle, if any.
+
+    Kept around for callers (CLI tooling, BUF-16 reviewer UI) that need to
+    introspect what's queued. The resolver itself no longer reads through
+    here — the partial unique index is the source of truth on the write
+    path.
+    """
     stmt = (
         select(AliasReviewQueue)
         .where(

--- a/packages/shared/src/esports_sim/resolver/core.py
+++ b/packages/shared/src/esports_sim/resolver/core.py
@@ -1,0 +1,291 @@
+"""Implementation of :func:`resolve_entity` and its return types.
+
+The decision tree matches Systems-spec System 01 verbatim:
+
+    1. exact lookup on (platform, platform_id) -> MATCHED
+    2. fuzzy match on platform_name vs every alias under entities of the same
+       entity_type
+        - top score >= AUTO_MERGE_THRESHOLD -> AUTO_MERGED (insert alias)
+        - top score >= REVIEW_THRESHOLD     -> PENDING (enqueue review)
+    3. otherwise                            -> CREATED (new entity + alias 1.0)
+
+We use :func:`rapidfuzz.fuzz.WRatio` because its weighted blend of partial /
+token-set / token-sort ratios is the most resilient default for handles that
+mix casing, spacing, and substrings ("TenZ" vs "tenz", "Sentinels" vs "Team
+Sentinels"). The score is normalised from rapidfuzz's 0-100 range into
+[0.0, 1.0] so it is directly comparable with the EntityAlias.confidence
+column.
+"""
+
+from __future__ import annotations
+
+import enum
+import uuid
+from dataclasses import dataclass, field
+
+from rapidfuzz import fuzz, utils
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+from esports_sim.db.enums import EntityType, Platform, ReviewStatus, StagingStatus
+from esports_sim.db.models import (
+    AliasReviewQueue,
+    Entity,
+    EntityAlias,
+    StagingRecord,
+)
+
+# Thresholds from the Systems-spec. Kept module-level constants (rather than
+# call-site arguments with defaults) because they're a policy decision the
+# whole pipeline must agree on — an experiment that wants different numbers
+# should override them globally for the duration of the run, not call-by-call.
+REVIEW_THRESHOLD: float = 0.70
+AUTO_MERGE_THRESHOLD: float = 0.90
+
+# rapidfuzz returns 0-100; the alias confidence column lives in [0,1]. Convert
+# at the boundary so nothing downstream has to remember the scale.
+_SCORE_DIVISOR: float = 100.0
+
+# Cap on how many candidates we serialise into the review queue. The reviewer
+# only ever needs the best handful; bloating the row hurts both DB and UI.
+_MAX_REVIEW_CANDIDATES: int = 5
+
+
+class ResolutionStatus(enum.StrEnum):
+    """The four terminal states of :func:`resolve_entity`."""
+
+    MATCHED = "matched"
+    AUTO_MERGED = "auto_merged"
+    PENDING = "pending"
+    CREATED = "created"
+
+
+@dataclass(frozen=True)
+class ResolveCandidate:
+    """A near-miss surfaced to the human reviewer.
+
+    Stored verbatim in :class:`AliasReviewQueue.candidates` (as JSON) and also
+    handed back to the caller so a CLI driver can render the same shortlist
+    without re-querying.
+    """
+
+    canonical_id: uuid.UUID
+    name: str
+    score: float
+
+    def to_json(self) -> dict[str, object]:
+        return {
+            "canonical_id": str(self.canonical_id),
+            "name": self.name,
+            "score": round(self.score, 4),
+        }
+
+
+@dataclass(frozen=True)
+class ResolveResult:
+    """Outcome of one :func:`resolve_entity` call.
+
+    ``canonical_id`` is ``None`` only for :attr:`ResolutionStatus.PENDING`;
+    every other status carries a non-null id the caller can use to set
+    ``StagingRecord.canonical_id`` and proceed.
+    """
+
+    status: ResolutionStatus
+    canonical_id: uuid.UUID | None
+    confidence: float
+    candidates: list[ResolveCandidate] = field(default_factory=list)
+
+
+def resolve_entity(
+    session: Session,
+    *,
+    platform: Platform,
+    platform_id: str,
+    platform_name: str,
+    entity_type: EntityType,
+) -> ResolveResult:
+    """Map a scraper handle to the canonical record. Single chokepoint.
+
+    See module docstring for the decision tree. The function performs all of
+    its writes inside the caller's :class:`Session` and does *not* commit;
+    the caller owns the transaction.
+    """
+    if not platform_id:
+        # Defensive: an empty platform_id would collide on the (platform, "")
+        # uniqueness key and silently merge unrelated rows. Fail loudly.
+        raise ValueError("platform_id must be non-empty")
+    if not platform_name:
+        raise ValueError("platform_name must be non-empty")
+
+    exact_hit = _lookup_exact_alias(session, platform=platform, platform_id=platform_id)
+    if exact_hit is not None:
+        return ResolveResult(
+            status=ResolutionStatus.MATCHED,
+            canonical_id=exact_hit.canonical_id,
+            confidence=exact_hit.confidence,
+        )
+
+    candidates = _fuzzy_candidates(
+        session,
+        query_name=platform_name,
+        entity_type=entity_type,
+    )
+
+    if candidates and candidates[0].score >= AUTO_MERGE_THRESHOLD:
+        top = candidates[0]
+        _insert_alias(
+            session,
+            canonical_id=top.canonical_id,
+            platform=platform,
+            platform_id=platform_id,
+            platform_name=platform_name,
+            confidence=top.score,
+        )
+        return ResolveResult(
+            status=ResolutionStatus.AUTO_MERGED,
+            canonical_id=top.canonical_id,
+            confidence=top.score,
+            candidates=candidates,
+        )
+
+    if candidates and candidates[0].score >= REVIEW_THRESHOLD:
+        # Idempotent review enqueue: if a pending row already exists for this
+        # (platform, platform_id) the second call must be a no-op so a retried
+        # scraper doesn't pile up duplicate human-review work.
+        existing = _find_pending_review(session, platform=platform, platform_id=platform_id)
+        if existing is None:
+            session.add(
+                AliasReviewQueue(
+                    platform=platform,
+                    platform_id=platform_id,
+                    platform_name=platform_name,
+                    candidates=[c.to_json() for c in candidates],
+                    reason="fuzzy_below_auto_merge",
+                    status=ReviewStatus.PENDING,
+                )
+            )
+            session.flush()
+        return ResolveResult(
+            status=ResolutionStatus.PENDING,
+            canonical_id=None,
+            confidence=candidates[0].score,
+            candidates=candidates,
+        )
+
+    # No exact, no fuzzy hit — mint a brand-new canonical and seed alias 1.0.
+    new_entity = Entity(entity_type=entity_type)
+    session.add(new_entity)
+    session.flush()  # populate canonical_id before we reference it
+    _insert_alias(
+        session,
+        canonical_id=new_entity.canonical_id,
+        platform=platform,
+        platform_id=platform_id,
+        platform_name=platform_name,
+        confidence=1.0,
+    )
+    return ResolveResult(
+        status=ResolutionStatus.CREATED,
+        canonical_id=new_entity.canonical_id,
+        confidence=1.0,
+    )
+
+
+# --- helpers ------------------------------------------------------------------
+
+
+def _lookup_exact_alias(
+    session: Session, *, platform: Platform, platform_id: str
+) -> EntityAlias | None:
+    stmt = select(EntityAlias).where(
+        EntityAlias.platform == platform,
+        EntityAlias.platform_id == platform_id,
+    )
+    return session.execute(stmt).scalar_one_or_none()
+
+
+def _fuzzy_candidates(
+    session: Session,
+    *,
+    query_name: str,
+    entity_type: EntityType,
+) -> list[ResolveCandidate]:
+    """Score the query name against every alias under same-type entities.
+
+    Returns the top-N candidates sorted by score descending, deduplicated by
+    canonical_id (each entity contributes its single best-matching alias).
+    Empty list when there are no entities of this type yet.
+    """
+    stmt = (
+        select(EntityAlias.canonical_id, EntityAlias.platform_name)
+        .join(Entity, Entity.canonical_id == EntityAlias.canonical_id)
+        .where(Entity.entity_type == entity_type, Entity.is_active.is_(True))
+    )
+    rows = session.execute(stmt).all()
+    if not rows:
+        return []
+
+    best_per_canonical: dict[uuid.UUID, ResolveCandidate] = {}
+    for canonical_id, alias_name in rows:
+        # default_process lowercases, strips non-alnum, and collapses whitespace.
+        # Without it, "TenZ" vs "tenz" scores 0.50 and would land on the review
+        # queue instead of auto-merging — the BUF-7 acceptance scenario fails.
+        score = (
+            fuzz.WRatio(query_name, alias_name, processor=utils.default_process) / _SCORE_DIVISOR
+        )
+        prior = best_per_canonical.get(canonical_id)
+        if prior is None or score > prior.score:
+            best_per_canonical[canonical_id] = ResolveCandidate(
+                canonical_id=canonical_id, name=alias_name, score=score
+            )
+
+    ranked = sorted(best_per_canonical.values(), key=lambda c: c.score, reverse=True)
+    return ranked[:_MAX_REVIEW_CANDIDATES]
+
+
+def _insert_alias(
+    session: Session,
+    *,
+    canonical_id: uuid.UUID,
+    platform: Platform,
+    platform_id: str,
+    platform_name: str,
+    confidence: float,
+) -> EntityAlias:
+    alias = EntityAlias(
+        canonical_id=canonical_id,
+        platform=platform,
+        platform_id=platform_id,
+        platform_name=platform_name,
+        confidence=confidence,
+    )
+    session.add(alias)
+    session.flush()
+    return alias
+
+
+def _find_pending_review(
+    session: Session, *, platform: Platform, platform_id: str
+) -> AliasReviewQueue | None:
+    stmt = select(AliasReviewQueue).where(
+        AliasReviewQueue.platform == platform,
+        AliasReviewQueue.platform_id == platform_id,
+        AliasReviewQueue.status == ReviewStatus.PENDING,
+    )
+    return session.execute(stmt).scalar_one_or_none()
+
+
+# Re-export so callers writing ``from esports_sim.resolver.core import ...``
+# can grab the model symbols too. Keeping them visible here makes the
+# resolver's contract self-contained: every public name a caller might want
+# to type-annotate against is reachable from one module.
+__all__ = [
+    "AUTO_MERGE_THRESHOLD",
+    "REVIEW_THRESHOLD",
+    "ResolutionStatus",
+    "ResolveCandidate",
+    "ResolveResult",
+    "resolve_entity",
+    "StagingRecord",  # re-exported so resolve callers don't dual-import
+    "StagingStatus",
+]

--- a/packages/shared/src/esports_sim/resolver/core.py
+++ b/packages/shared/src/esports_sim/resolver/core.py
@@ -51,6 +51,30 @@ _SCORE_DIVISOR: float = 100.0
 # only ever needs the best handful; bloating the row hurts both DB and UI.
 _MAX_REVIEW_CANDIDATES: int = 5
 
+# Name of the unique constraint that protects ``(platform, platform_id)`` on
+# the alias table — defined alongside :class:`EntityAlias`. The race-recovery
+# branches use this to distinguish the constraint they expect from any other
+# unique violation that might surface during a flush of unrelated session
+# state. Hard-coded rather than introspected because if the constraint name
+# ever changes, the matching here must be re-validated by hand.
+_ALIAS_UNIQUE_CONSTRAINT: str = "uq_entity_alias_platform_platform_id"
+
+
+def _is_alias_uniqueness_violation(error: IntegrityError) -> bool:
+    """True iff this IntegrityError is the (platform, platform_id) race.
+
+    Postgres surfaces the violated constraint name on ``error.orig.diag``
+    (psycopg). Falling back to a substring check on ``str(error)`` keeps the
+    detection useful when that introspection isn't available — the
+    constraint name is unique enough to make string matching safe.
+    """
+    orig = getattr(error, "orig", None)
+    diag = getattr(orig, "diag", None)
+    constraint_name = getattr(diag, "constraint_name", None)
+    if constraint_name == _ALIAS_UNIQUE_CONSTRAINT:
+        return True
+    return _ALIAS_UNIQUE_CONSTRAINT in str(error)
+
 
 class ResolutionStatus(enum.StrEnum):
     """The four terminal states of :func:`resolve_entity`."""
@@ -191,10 +215,16 @@ def resolve_entity(
                 platform_name=platform_name,
                 confidence=1.0,
             )
-    except IntegrityError:
-        # Another resolver call inserted the (platform, platform_id) alias
-        # between our lookup and our flush; the savepoint rolled back our
-        # entity. Re-fetch and degrade gracefully into a MATCHED return.
+    except IntegrityError as exc:
+        # Only swallow the (platform, platform_id) race; any other constraint
+        # violation surfaced by the flush — e.g. an unrelated duplicate key
+        # on RawRecord.content_hash or a different scraper's pending object —
+        # belongs to its caller and must propagate. Misclassifying it would
+        # silently replace the real DB error with a wrong MATCHED return.
+        if not _is_alias_uniqueness_violation(exc):
+            raise
+        # Savepoint rolled back our orphan entity. Re-fetch and degrade
+        # gracefully into a MATCHED return.
         return _matched_after_race(session, platform=platform, platform_id=platform_id)
     return ResolveResult(
         status=ResolutionStatus.CREATED,
@@ -307,7 +337,13 @@ def _try_insert_alias_or_recover(
                 platform_name=platform_name,
                 confidence=confidence,
             )
-    except IntegrityError:
+    except IntegrityError as exc:
+        # See the equivalent guard in resolve_entity's CREATED branch: only
+        # the alias unique constraint is the race we know how to recover
+        # from; everything else (different table, different constraint) must
+        # surface so the caller sees the real failure.
+        if not _is_alias_uniqueness_violation(exc):
+            raise
         return _matched_after_race(session, platform=platform, platform_id=platform_id)
     return None
 

--- a/packages/shared/src/esports_sim/resolver/core.py
+++ b/packages/shared/src/esports_sim/resolver/core.py
@@ -267,12 +267,25 @@ def _insert_alias(
 def _find_pending_review(
     session: Session, *, platform: Platform, platform_id: str
 ) -> AliasReviewQueue | None:
-    stmt = select(AliasReviewQueue).where(
-        AliasReviewQueue.platform == platform,
-        AliasReviewQueue.platform_id == platform_id,
-        AliasReviewQueue.status == ReviewStatus.PENDING,
+    # ``alias_review_queue`` has no uniqueness constraint over
+    # (platform, platform_id, status=pending) and the enqueue path is
+    # non-atomic, so two concurrent resolver calls can each insert a pending
+    # row before either notices the other. A third call's idempotency check
+    # would then see two rows; ``.scalar_one_or_none()`` would crash with
+    # ``MultipleResultsFound``, turning the retry path into a hard failure.
+    # Take the oldest pending row instead: any pending match is enough to
+    # treat the (platform, platform_id) as already queued.
+    stmt = (
+        select(AliasReviewQueue)
+        .where(
+            AliasReviewQueue.platform == platform,
+            AliasReviewQueue.platform_id == platform_id,
+            AliasReviewQueue.status == ReviewStatus.PENDING,
+        )
+        .order_by(AliasReviewQueue.created_at)
+        .limit(1)
     )
-    return session.execute(stmt).scalar_one_or_none()
+    return session.execute(stmt).scalars().first()
 
 
 # Re-export so callers writing ``from esports_sim.resolver.core import ...``

--- a/packages/shared/src/esports_sim/resolver/core.py
+++ b/packages/shared/src/esports_sim/resolver/core.py
@@ -25,6 +25,7 @@ from dataclasses import dataclass, field
 
 from rapidfuzz import fuzz, utils
 from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
 from esports_sim.db.enums import EntityType, Platform, ReviewStatus, StagingStatus
@@ -133,7 +134,7 @@ def resolve_entity(
 
     if candidates and candidates[0].score >= AUTO_MERGE_THRESHOLD:
         top = candidates[0]
-        _insert_alias(
+        raced = _try_insert_alias_or_recover(
             session,
             canonical_id=top.canonical_id,
             platform=platform,
@@ -141,6 +142,8 @@ def resolve_entity(
             platform_name=platform_name,
             confidence=top.score,
         )
+        if raced is not None:
+            return raced
         return ResolveResult(
             status=ResolutionStatus.AUTO_MERGED,
             canonical_id=top.canonical_id,
@@ -173,17 +176,26 @@ def resolve_entity(
         )
 
     # No exact, no fuzzy hit — mint a brand-new canonical and seed alias 1.0.
-    new_entity = Entity(entity_type=entity_type)
-    session.add(new_entity)
-    session.flush()  # populate canonical_id before we reference it
-    _insert_alias(
-        session,
-        canonical_id=new_entity.canonical_id,
-        platform=platform,
-        platform_id=platform_id,
-        platform_name=platform_name,
-        confidence=1.0,
-    )
+    # Wrap entity + alias in a savepoint so a concurrent worker that won the
+    # alias race doesn't strand an orphan entity row in the DB on our side.
+    try:
+        with session.begin_nested():
+            new_entity = Entity(entity_type=entity_type)
+            session.add(new_entity)
+            session.flush()  # populate canonical_id before we reference it
+            _insert_alias(
+                session,
+                canonical_id=new_entity.canonical_id,
+                platform=platform,
+                platform_id=platform_id,
+                platform_name=platform_name,
+                confidence=1.0,
+            )
+    except IntegrityError:
+        # Another resolver call inserted the (platform, platform_id) alias
+        # between our lookup and our flush; the savepoint rolled back our
+        # entity. Re-fetch and degrade gracefully into a MATCHED return.
+        return _matched_after_race(session, platform=platform, platform_id=platform_id)
     return ResolveResult(
         status=ResolutionStatus.CREATED,
         canonical_id=new_entity.canonical_id,
@@ -262,6 +274,67 @@ def _insert_alias(
     session.add(alias)
     session.flush()
     return alias
+
+
+def _try_insert_alias_or_recover(
+    session: Session,
+    *,
+    canonical_id: uuid.UUID,
+    platform: Platform,
+    platform_id: str,
+    platform_name: str,
+    confidence: float,
+) -> ResolveResult | None:
+    """Insert the alias under a savepoint; recover if a concurrent worker won.
+
+    Used by the AUTO_MERGED path (where the canonical already exists). Two
+    parallel workers can both miss the initial exact-alias lookup and both
+    race to insert against the unique ``(platform, platform_id)`` key; the
+    savepoint lets us catch the loser's IntegrityError without invalidating
+    the outer transaction.
+
+    Returns ``None`` on the happy path so the caller can build its
+    AUTO_MERGED result, or a MATCHED :class:`ResolveResult` when the race
+    has already been resolved by someone else.
+    """
+    try:
+        with session.begin_nested():
+            _insert_alias(
+                session,
+                canonical_id=canonical_id,
+                platform=platform,
+                platform_id=platform_id,
+                platform_name=platform_name,
+                confidence=confidence,
+            )
+    except IntegrityError:
+        return _matched_after_race(session, platform=platform, platform_id=platform_id)
+    return None
+
+
+def _matched_after_race(session: Session, *, platform: Platform, platform_id: str) -> ResolveResult:
+    """Re-lookup after a concurrent insert won the (platform, platform_id) race.
+
+    The alias must exist by the time we get here — that's why we caught the
+    IntegrityError. If somehow the lookup misses, surface the original
+    failure rather than silently returning a wrong answer; otherwise
+    degrade into MATCHED so the caller's idempotent retry contract holds.
+    """
+    existing = _lookup_exact_alias(session, platform=platform, platform_id=platform_id)
+    if existing is None:
+        # The unique violation says a row exists; not finding it means the
+        # session view is genuinely inconsistent. Re-raising would be the
+        # safer option, but we're past the original try block — instead
+        # raise a fresh, descriptive error.
+        raise RuntimeError(
+            "alias unique violation recovery: post-conflict lookup missed "
+            f"({platform.value}, {platform_id}); session view inconsistent"
+        )
+    return ResolveResult(
+        status=ResolutionStatus.MATCHED,
+        canonical_id=existing.canonical_id,
+        confidence=existing.confidence,
+    )
 
 
 def _find_pending_review(

--- a/packages/shared/tests/test_db_models.py
+++ b/packages/shared/tests/test_db_models.py
@@ -130,16 +130,8 @@ def test_alias_same_platform_id_different_platform_is_legal(db_session) -> None:
 
 
 def test_staging_record_defaults_pending(db_session) -> None:
-    """`status` defaults to pending so scrapers can omit it.
-
-    Attach a canonical_id because BUF-7 forbids a null canonical with any
-    status besides ``review``/``blocked``; the assertion here is about the
-    status default, not the canonical-id state.
-    """
-    e = make_entity()
-    db_session.add(e)
-    db_session.flush()
-    sr = make_staging_record(canonical_id=e.canonical_id)
+    """`status` defaults to pending so scrapers can omit it."""
+    sr = make_staging_record()
     db_session.add(sr)
     db_session.flush()
     db_session.refresh(sr)

--- a/packages/shared/tests/test_db_models.py
+++ b/packages/shared/tests/test_db_models.py
@@ -130,8 +130,16 @@ def test_alias_same_platform_id_different_platform_is_legal(db_session) -> None:
 
 
 def test_staging_record_defaults_pending(db_session) -> None:
-    """`status` defaults to pending so scrapers can omit it."""
-    sr = make_staging_record()
+    """`status` defaults to pending so scrapers can omit it.
+
+    Attach a canonical_id because BUF-7 forbids a null canonical with any
+    status besides ``review``/``blocked``; the assertion here is about the
+    status default, not the canonical-id state.
+    """
+    e = make_entity()
+    db_session.add(e)
+    db_session.flush()
+    sr = make_staging_record(canonical_id=e.canonical_id)
     db_session.add(sr)
     db_session.flush()
     db_session.refresh(sr)

--- a/packages/shared/tests/test_resolver.py
+++ b/packages/shared/tests/test_resolver.py
@@ -1,0 +1,414 @@
+"""Tests for the canonical-id resolver (BUF-7).
+
+The four unit-style cases (exact match, high-confidence fuzzy, low-confidence
+fuzzy, brand-new entity) plus an integration scenario covering cross-platform
+consistency on "TenZ" land here.
+
+Marked ``integration`` because the resolver is intentionally written against a
+real SQLAlchemy session — the BUF-6 schema uses Postgres-specific types
+(JSONB, named ENUMs) that an in-memory SQLite cannot fake without enough
+adapter scaffolding to defeat the point. CI provides Postgres; locally
+``TEST_DATABASE_URL`` skips these out gracefully.
+"""
+
+from __future__ import annotations
+
+import pytest
+from esports_sim.db.enums import (
+    EntityType,
+    Platform,
+    ReviewStatus,
+    StagingStatus,
+)
+from esports_sim.db.models import (
+    AliasReviewQueue,
+    Entity,
+    EntityAlias,
+    StagingInvariantError,
+    StagingRecord,
+)
+from esports_sim.resolver import (
+    AUTO_MERGE_THRESHOLD,
+    REVIEW_THRESHOLD,
+    ResolutionStatus,
+    resolve_entity,
+)
+from sqlalchemy import select
+
+from tests.fixtures import (
+    make_entity,
+    make_entity_alias,
+    make_staging_record,
+)
+
+pytestmark = pytest.mark.integration
+
+
+# --- exact match -------------------------------------------------------------
+
+
+def test_exact_match_returns_existing_canonical(db_session) -> None:
+    """A second call with the same (platform, platform_id) is a free lookup."""
+    entity = make_entity(entity_type=EntityType.PLAYER)
+    alias = make_entity_alias(
+        entity=entity,
+        platform=Platform.VLR,
+        platform_id="vlr-tenz",
+        platform_name="TenZ",
+    )
+    db_session.add_all([entity, alias])
+    db_session.flush()
+
+    result = resolve_entity(
+        db_session,
+        platform=Platform.VLR,
+        platform_id="vlr-tenz",
+        platform_name="TenZ",
+        entity_type=EntityType.PLAYER,
+    )
+
+    assert result.status is ResolutionStatus.MATCHED
+    assert result.canonical_id == entity.canonical_id
+    assert result.confidence == 1.0
+    # No new alias rows should appear.
+    aliases = db_session.execute(select(EntityAlias)).scalars().all()
+    assert len(aliases) == 1
+
+
+def test_exact_match_is_idempotent(db_session) -> None:
+    """Re-resolving the exact same triple twice produces no extra rows."""
+    first = resolve_entity(
+        db_session,
+        platform=Platform.VLR,
+        platform_id="vlr-newcomer",
+        platform_name="Newcomer",
+        entity_type=EntityType.PLAYER,
+    )
+    db_session.flush()
+
+    second = resolve_entity(
+        db_session,
+        platform=Platform.VLR,
+        platform_id="vlr-newcomer",
+        platform_name="Newcomer",
+        entity_type=EntityType.PLAYER,
+    )
+
+    assert first.status is ResolutionStatus.CREATED
+    assert second.status is ResolutionStatus.MATCHED
+    assert first.canonical_id == second.canonical_id
+
+    aliases = (
+        db_session.execute(
+            select(EntityAlias).where(EntityAlias.canonical_id == first.canonical_id)
+        )
+        .scalars()
+        .all()
+    )
+    assert len(aliases) == 1
+
+
+# --- high-confidence fuzzy match (auto-merge) --------------------------------
+
+
+def test_high_confidence_fuzzy_auto_merges(db_session) -> None:
+    """Score >= AUTO_MERGE_THRESHOLD adds an alias under the existing canonical."""
+    entity = make_entity(entity_type=EntityType.PLAYER)
+    db_session.add(entity)
+    db_session.add(
+        make_entity_alias(
+            entity=entity,
+            platform=Platform.VLR,
+            platform_id="vlr-tenz",
+            platform_name="TenZ",
+        )
+    )
+    db_session.flush()
+
+    # "tenz" vs "TenZ" is a near-perfect WRatio (case-insensitive, identical
+    # tokens) — well above 0.90.
+    result = resolve_entity(
+        db_session,
+        platform=Platform.LIQUIPEDIA,
+        platform_id="liq-tenz",
+        platform_name="tenz",
+        entity_type=EntityType.PLAYER,
+    )
+
+    assert result.status is ResolutionStatus.AUTO_MERGED
+    assert result.canonical_id == entity.canonical_id
+    assert result.confidence >= AUTO_MERGE_THRESHOLD
+
+    aliases = (
+        db_session.execute(
+            select(EntityAlias)
+            .where(EntityAlias.canonical_id == entity.canonical_id)
+            .order_by(EntityAlias.platform)
+        )
+        .scalars()
+        .all()
+    )
+    assert {a.platform for a in aliases} == {Platform.VLR, Platform.LIQUIPEDIA}
+    new_alias = next(a for a in aliases if a.platform is Platform.LIQUIPEDIA)
+    assert new_alias.confidence == result.confidence
+
+
+# --- low-confidence fuzzy match (review queue) -------------------------------
+
+
+def test_low_confidence_fuzzy_enqueues_review(db_session) -> None:
+    """Score in [REVIEW, AUTO_MERGE) lands on the human review queue."""
+    # Two existing players that score in the review band against the query
+    # name. "Sentinel" / "Sinatraa" vs "Sentinal" sit near the middle band on
+    # WRatio without crossing 0.90.
+    e1 = make_entity(entity_type=EntityType.PLAYER)
+    e2 = make_entity(entity_type=EntityType.PLAYER)
+    db_session.add_all([e1, e2])
+    db_session.add_all(
+        [
+            make_entity_alias(
+                entity=e1,
+                platform=Platform.VLR,
+                platform_id="vlr-sentinel",
+                platform_name="Sentinel",
+            ),
+            make_entity_alias(
+                entity=e2,
+                platform=Platform.VLR,
+                platform_id="vlr-sinatraa",
+                platform_name="Sinatraa",
+            ),
+        ]
+    )
+    db_session.flush()
+
+    result = resolve_entity(
+        db_session,
+        platform=Platform.LIQUIPEDIA,
+        platform_id="liq-sentinal",
+        platform_name="Sentinal",
+        entity_type=EntityType.PLAYER,
+    )
+
+    assert result.status is ResolutionStatus.PENDING
+    assert result.canonical_id is None
+    assert REVIEW_THRESHOLD <= result.confidence < AUTO_MERGE_THRESHOLD
+    assert result.candidates, "review path must surface candidates to the human"
+
+    review_rows = db_session.execute(select(AliasReviewQueue)).scalars().all()
+    assert len(review_rows) == 1
+    queued = review_rows[0]
+    assert queued.platform is Platform.LIQUIPEDIA
+    assert queued.platform_id == "liq-sentinal"
+    assert queued.status is ReviewStatus.PENDING
+    assert len(queued.candidates) == len(result.candidates)
+    # No alias was minted along the review path.
+    assert (
+        db_session.execute(
+            select(EntityAlias).where(EntityAlias.platform == Platform.LIQUIPEDIA)
+        ).scalar_one_or_none()
+        is None
+    )
+
+
+def test_low_confidence_fuzzy_is_idempotent(db_session) -> None:
+    """Calling resolve twice with the same review-band triple shouldn't dup."""
+    e1 = make_entity(entity_type=EntityType.PLAYER)
+    db_session.add(e1)
+    db_session.add(
+        make_entity_alias(
+            entity=e1,
+            platform=Platform.VLR,
+            platform_id="vlr-sentinel",
+            platform_name="Sentinel",
+        )
+    )
+    db_session.flush()
+
+    first = resolve_entity(
+        db_session,
+        platform=Platform.LIQUIPEDIA,
+        platform_id="liq-sentinal",
+        platform_name="Sentinal",
+        entity_type=EntityType.PLAYER,
+    )
+    second = resolve_entity(
+        db_session,
+        platform=Platform.LIQUIPEDIA,
+        platform_id="liq-sentinal",
+        platform_name="Sentinal",
+        entity_type=EntityType.PLAYER,
+    )
+    assert first.status is ResolutionStatus.PENDING
+    assert second.status is ResolutionStatus.PENDING
+
+    review_rows = db_session.execute(select(AliasReviewQueue)).scalars().all()
+    assert len(review_rows) == 1
+
+
+# --- brand-new entity --------------------------------------------------------
+
+
+def test_brand_new_entity_creates_canonical_and_alias(db_session) -> None:
+    """No exact, no fuzzy: mint a fresh canonical with confidence 1.0."""
+    result = resolve_entity(
+        db_session,
+        platform=Platform.VLR,
+        platform_id="vlr-rookie",
+        platform_name="QuasarBlaze",
+        entity_type=EntityType.PLAYER,
+    )
+
+    assert result.status is ResolutionStatus.CREATED
+    assert result.canonical_id is not None
+    assert result.confidence == 1.0
+
+    entity = db_session.get(Entity, result.canonical_id)
+    assert entity is not None
+    assert entity.entity_type is EntityType.PLAYER
+
+    alias = db_session.execute(
+        select(EntityAlias).where(EntityAlias.canonical_id == result.canonical_id)
+    ).scalar_one()
+    assert alias.platform is Platform.VLR
+    assert alias.platform_id == "vlr-rookie"
+    assert alias.platform_name == "QuasarBlaze"
+    assert alias.confidence == 1.0
+
+
+def test_resolver_isolates_per_entity_type(db_session) -> None:
+    """A team named the same as a player shouldn't cause an auto-merge."""
+    player = make_entity(entity_type=EntityType.PLAYER)
+    db_session.add(player)
+    db_session.add(
+        make_entity_alias(
+            entity=player,
+            platform=Platform.VLR,
+            platform_id="vlr-cloud",
+            platform_name="Cloud",
+        )
+    )
+    db_session.flush()
+
+    result = resolve_entity(
+        db_session,
+        platform=Platform.LIQUIPEDIA,
+        platform_id="liq-cloud-team",
+        platform_name="Cloud",
+        entity_type=EntityType.TEAM,  # different type — must not match the player
+    )
+    assert result.status is ResolutionStatus.CREATED
+    assert result.canonical_id != player.canonical_id
+
+
+def test_resolver_rejects_empty_platform_id(db_session) -> None:
+    with pytest.raises(ValueError):
+        resolve_entity(
+            db_session,
+            platform=Platform.VLR,
+            platform_id="",
+            platform_name="TenZ",
+            entity_type=EntityType.PLAYER,
+        )
+
+
+# --- TenZ cross-platform integration scenario -------------------------------
+
+
+def test_tenz_resolves_to_same_canonical_via_vlr_then_liquipedia(db_session) -> None:
+    """Acceptance scenario from BUF-7.
+
+    The first scrape sees TenZ on VLR; the resolver mints a fresh canonical.
+    The second scrape sees lowercase "tenz" on Liquipedia; the resolver finds
+    the existing canonical and adds a second alias under it.
+    """
+    first = resolve_entity(
+        db_session,
+        platform=Platform.VLR,
+        platform_id="vlr-1234",
+        platform_name="TenZ",
+        entity_type=EntityType.PLAYER,
+    )
+    assert first.status is ResolutionStatus.CREATED
+
+    second = resolve_entity(
+        db_session,
+        platform=Platform.LIQUIPEDIA,
+        platform_id="liq-tenz",
+        platform_name="tenz",
+        entity_type=EntityType.PLAYER,
+    )
+    assert second.status is ResolutionStatus.AUTO_MERGED
+    assert second.canonical_id == first.canonical_id
+
+    aliases = (
+        db_session.execute(
+            select(EntityAlias)
+            .where(EntityAlias.canonical_id == first.canonical_id)
+            .order_by(EntityAlias.platform)
+        )
+        .scalars()
+        .all()
+    )
+    assert len(aliases) == 2
+    assert {a.platform for a in aliases} == {Platform.VLR, Platform.LIQUIPEDIA}
+
+
+# --- StagingRecord.save() guard ---------------------------------------------
+
+
+def test_staging_save_rejects_null_canonical_in_pending(db_session) -> None:
+    """A PENDING staging row without a canonical_id is a resolver bypass."""
+    sr = make_staging_record(canonical_id=None, status=StagingStatus.PENDING)
+    with pytest.raises(StagingInvariantError):
+        sr.save(db_session)
+
+
+def test_staging_save_rejects_null_canonical_in_processed(db_session) -> None:
+    """PROCESSED is a write-through state; null canonical is illegal."""
+    sr = make_staging_record(canonical_id=None, status=StagingStatus.PROCESSED)
+    with pytest.raises(StagingInvariantError):
+        sr.save(db_session)
+
+
+def test_staging_save_allows_null_canonical_in_review(db_session) -> None:
+    """A row deferred to the alias review queue legitimately has no canonical."""
+    sr = make_staging_record(canonical_id=None, status=StagingStatus.REVIEW)
+    sr.save(db_session)
+    db_session.flush()
+    assert sr.canonical_id is None
+    assert sr.status is StagingStatus.REVIEW
+
+
+def test_staging_save_allows_null_canonical_in_blocked(db_session) -> None:
+    sr = make_staging_record(canonical_id=None, status=StagingStatus.BLOCKED)
+    sr.save(db_session)
+    db_session.flush()
+    assert sr.status is StagingStatus.BLOCKED
+
+
+def test_staging_event_listener_blocks_direct_session_add(db_session) -> None:
+    """Even a scraper that calls session.add directly cannot bypass the rule."""
+    sr = StagingRecord(
+        source="vlr",
+        entity_type=EntityType.PLAYER,
+        canonical_id=None,
+        payload={"name": "TenZ"},
+        status=StagingStatus.PROCESSED,
+    )
+    db_session.add(sr)
+    with pytest.raises(StagingInvariantError):
+        db_session.flush()
+    db_session.rollback()
+
+
+def test_staging_save_with_valid_canonical_persists(db_session) -> None:
+    """The happy path: resolver populated canonical_id, save() lets it through."""
+    entity = make_entity(entity_type=EntityType.PLAYER)
+    db_session.add(entity)
+    db_session.flush()
+
+    sr = make_staging_record(canonical_id=entity.canonical_id, status=StagingStatus.PROCESSED)
+    sr.save(db_session)
+    db_session.flush()
+    assert sr.canonical_id == entity.canonical_id

--- a/packages/shared/tests/test_resolver.py
+++ b/packages/shared/tests/test_resolver.py
@@ -414,3 +414,139 @@ def test_staging_save_with_valid_canonical_persists(db_session) -> None:
     sr.save(db_session)
     db_session.flush()
     assert sr.canonical_id == entity.canonical_id
+
+
+def test_staging_unset_status_lands_as_pending(db_session) -> None:
+    """Constructing a row without a status must rely on the column default.
+
+    Regression for a code-review finding: the validator used to dereference
+    ``record.status.value`` on the error path, which would raise
+    AttributeError when ``status`` was None at ``before_insert`` time. The
+    Python-level ``default=StagingStatus.PENDING`` populates the attribute
+    in time and the defensive None branch keeps the validator robust if a
+    caller somehow gets past it.
+    """
+    sr = StagingRecord(
+        source="vlr",
+        entity_type=EntityType.PLAYER,
+        canonical_id=None,
+        payload={"name": "TenZ"},
+        # status deliberately omitted — server_default + Python default
+        # should both kick in.
+    )
+    db_session.add(sr)
+    db_session.flush()
+    db_session.refresh(sr)
+    assert sr.status is StagingStatus.PENDING
+
+
+# --- alias uniqueness race recovery -----------------------------------------
+
+
+def test_create_path_recovers_from_concurrent_alias_insert(db_session, monkeypatch) -> None:
+    """Two workers race past the (platform, platform_id) lookup.
+
+    Simulate the race by monkeypatching ``_lookup_exact_alias`` to miss on
+    the first call (the resolver thinks no alias exists and falls into the
+    CREATED path), then return the real row on the recovery lookup. The
+    savepoint must catch the IntegrityError on the alias insert, roll back
+    the orphan entity, and degrade into a MATCHED return for the loser.
+    """
+    from esports_sim.resolver import core
+
+    first = resolve_entity(
+        db_session,
+        platform=Platform.VLR,
+        platform_id="vlr-race",
+        platform_name="Racer",
+        entity_type=EntityType.PLAYER,
+    )
+    assert first.status is ResolutionStatus.CREATED
+
+    real_lookup = core._lookup_exact_alias
+    calls = {"n": 0}
+
+    def fake_lookup(session, **kwargs):  # type: ignore[no-untyped-def]
+        # Miss only on the very first call (the pre-flight lookup at the top
+        # of resolve_entity); subsequent recovery lookups behave normally.
+        if calls["n"] == 0:
+            calls["n"] += 1
+            return None
+        return real_lookup(session, **kwargs)
+
+    monkeypatch.setattr(core, "_lookup_exact_alias", fake_lookup)
+
+    second = resolve_entity(
+        db_session,
+        platform=Platform.VLR,
+        platform_id="vlr-race",
+        platform_name="Racer",
+        entity_type=EntityType.PLAYER,
+    )
+    assert second.status is ResolutionStatus.MATCHED
+    assert second.canonical_id == first.canonical_id
+
+    aliases = (
+        db_session.execute(select(EntityAlias).where(EntityAlias.platform_id == "vlr-race"))
+        .scalars()
+        .all()
+    )
+    # No orphan entity, no second alias row.
+    assert len(aliases) == 1
+    entities = (
+        db_session.execute(select(Entity).where(Entity.entity_type == EntityType.PLAYER))
+        .scalars()
+        .all()
+    )
+    assert len(entities) == 1
+
+
+def test_auto_merge_path_recovers_from_concurrent_alias_insert(db_session, monkeypatch) -> None:
+    """The AUTO_MERGED path must also degrade into MATCHED on a race."""
+    from esports_sim.resolver import core
+
+    # Seed an existing canonical so the auto-merge branch fires.
+    entity = make_entity(entity_type=EntityType.PLAYER)
+    db_session.add(entity)
+    db_session.add(
+        make_entity_alias(
+            entity=entity,
+            platform=Platform.VLR,
+            platform_id="vlr-tenz",
+            platform_name="TenZ",
+        )
+    )
+    db_session.flush()
+
+    # First resolve creates the Liquipedia alias under the existing canonical.
+    first = resolve_entity(
+        db_session,
+        platform=Platform.LIQUIPEDIA,
+        platform_id="liq-tenz",
+        platform_name="tenz",
+        entity_type=EntityType.PLAYER,
+    )
+    assert first.status is ResolutionStatus.AUTO_MERGED
+
+    # Now make the second call miss the initial exact lookup so it tries to
+    # auto-merge again — and crash into the unique constraint we just set.
+    real_lookup = core._lookup_exact_alias
+    calls = {"n": 0}
+
+    def fake_lookup(session, **kwargs):  # type: ignore[no-untyped-def]
+        if calls["n"] == 0:
+            calls["n"] += 1
+            return None
+        return real_lookup(session, **kwargs)
+
+    monkeypatch.setattr(core, "_lookup_exact_alias", fake_lookup)
+
+    second = resolve_entity(
+        db_session,
+        platform=Platform.LIQUIPEDIA,
+        platform_id="liq-tenz",
+        platform_name="tenz",
+        entity_type=EntityType.PLAYER,
+    )
+    assert second.status is ResolutionStatus.MATCHED
+    assert second.canonical_id == entity.canonical_id

--- a/packages/shared/tests/test_resolver.py
+++ b/packages/shared/tests/test_resolver.py
@@ -550,3 +550,76 @@ def test_auto_merge_path_recovers_from_concurrent_alias_insert(db_session, monke
     )
     assert second.status is ResolutionStatus.MATCHED
     assert second.canonical_id == entity.canonical_id
+
+
+def test_unrelated_integrity_error_is_not_swallowed_by_create_path(db_session, monkeypatch) -> None:
+    """A non-race IntegrityError must propagate, not become a fake MATCHED.
+
+    Regression for a code-review finding: the CREATED-path savepoint used
+    to catch any IntegrityError. If an unrelated pending object in the
+    same session caused flush to fail (e.g. a duplicate
+    ``raw_record.content_hash``), the resolver would misclassify it as the
+    alias race and return a wrong MATCHED for a row that was never written.
+    """
+    from esports_sim.resolver import core
+    from sqlalchemy.exc import IntegrityError
+
+    def fake_insert_alias(*_args, **_kwargs):  # type: ignore[no-untyped-def]
+        # Simulate a different-constraint unique violation. The constraint
+        # name is *not* uq_entity_alias_platform_platform_id, so the resolver
+        # must re-raise rather than degrade into MATCHED.
+        raise IntegrityError(
+            "INSERT INTO raw_record",
+            {},
+            Exception("violates unique constraint uq_raw_record_content_hash"),
+        )
+
+    monkeypatch.setattr(core, "_insert_alias", fake_insert_alias)
+
+    with pytest.raises(IntegrityError):
+        resolve_entity(
+            db_session,
+            platform=Platform.VLR,
+            platform_id="vlr-fresh",
+            platform_name="Fresh",
+            entity_type=EntityType.PLAYER,
+        )
+
+
+def test_unrelated_integrity_error_is_not_swallowed_by_auto_merge_path(
+    db_session, monkeypatch
+) -> None:
+    """Same guarantee for the AUTO_MERGED-path recovery branch."""
+    from esports_sim.resolver import core
+    from sqlalchemy.exc import IntegrityError
+
+    # Seed an existing canonical + alias so AUTO_MERGED is the path under test.
+    entity = make_entity(entity_type=EntityType.PLAYER)
+    db_session.add(entity)
+    db_session.add(
+        make_entity_alias(
+            entity=entity,
+            platform=Platform.VLR,
+            platform_id="vlr-tenz",
+            platform_name="TenZ",
+        )
+    )
+    db_session.flush()
+
+    def fake_insert_alias(*_args, **_kwargs):  # type: ignore[no-untyped-def]
+        raise IntegrityError(
+            "INSERT INTO raw_record",
+            {},
+            Exception("violates unique constraint uq_raw_record_content_hash"),
+        )
+
+    monkeypatch.setattr(core, "_insert_alias", fake_insert_alias)
+
+    with pytest.raises(IntegrityError):
+        resolve_entity(
+            db_session,
+            platform=Platform.LIQUIPEDIA,
+            platform_id="liq-tenz",
+            platform_name="tenz",
+            entity_type=EntityType.PLAYER,
+        )

--- a/packages/shared/tests/test_resolver.py
+++ b/packages/shared/tests/test_resolver.py
@@ -357,15 +357,17 @@ def test_tenz_resolves_to_same_canonical_via_vlr_then_liquipedia(db_session) -> 
 # --- StagingRecord.save() guard ---------------------------------------------
 
 
-def test_staging_save_rejects_null_canonical_in_pending(db_session) -> None:
-    """A PENDING staging row without a canonical_id is a resolver bypass."""
+def test_staging_save_allows_null_canonical_in_pending(db_session) -> None:
+    """PENDING is the pre-resolver queue state; null canonical is fine."""
     sr = make_staging_record(canonical_id=None, status=StagingStatus.PENDING)
-    with pytest.raises(StagingInvariantError):
-        sr.save(db_session)
+    sr.save(db_session)
+    db_session.flush()
+    assert sr.canonical_id is None
+    assert sr.status is StagingStatus.PENDING
 
 
 def test_staging_save_rejects_null_canonical_in_processed(db_session) -> None:
-    """PROCESSED is a write-through state; null canonical is illegal."""
+    """PROCESSED is the only status that asserts the row has a canonical id."""
     sr = make_staging_record(canonical_id=None, status=StagingStatus.PROCESSED)
     with pytest.raises(StagingInvariantError):
         sr.save(db_session)

--- a/packages/shared/tests/test_resolver.py
+++ b/packages/shared/tests/test_resolver.py
@@ -623,3 +623,142 @@ def test_unrelated_integrity_error_is_not_swallowed_by_auto_merge_path(
             platform_name="tenz",
             entity_type=EntityType.PLAYER,
         )
+
+
+# --- pending-review enqueue uniqueness --------------------------------------
+
+
+def test_pending_review_enqueue_enforces_partial_unique_index(db_session) -> None:
+    """The DB now refuses a second pending row for the same handle.
+
+    The resolver's idempotency on the PENDING path used to depend on a
+    pre-check that was racy under concurrent calls. The partial unique
+    index ``ix_alias_review_queue_pending_unique`` is the schema-level
+    guarantee. Hand-insert two pending rows for the same
+    ``(platform, platform_id)`` — the second must raise.
+    """
+    from esports_sim.db.models import AliasReviewQueue
+    from sqlalchemy.exc import IntegrityError
+
+    db_session.add(
+        AliasReviewQueue(
+            platform=Platform.LIQUIPEDIA,
+            platform_id="liq-dup",
+            platform_name="Dup",
+            candidates=[{"canonical_id": "x", "name": "y", "score": 0.8}],
+            reason="fuzzy_below_auto_merge",
+            status=ReviewStatus.PENDING,
+        )
+    )
+    db_session.flush()
+
+    db_session.add(
+        AliasReviewQueue(
+            platform=Platform.LIQUIPEDIA,
+            platform_id="liq-dup",
+            platform_name="Dup",
+            candidates=[{"canonical_id": "x", "name": "y", "score": 0.8}],
+            reason="fuzzy_below_auto_merge",
+            status=ReviewStatus.PENDING,
+        )
+    )
+    with pytest.raises(IntegrityError):
+        db_session.flush()
+    db_session.rollback()
+
+
+def test_pending_review_partial_index_only_covers_pending(db_session) -> None:
+    """Resolved/skipped rows for the same handle must coexist with a pending one.
+
+    The partial predicate (``WHERE status='pending'``) is what makes the
+    resolver's "one open review per handle" rule useful: a row that's
+    been resolved or skipped no longer occupies the slot. Encode that
+    here so a future migration that widens the predicate gets caught.
+    """
+    from esports_sim.db.models import AliasReviewQueue
+
+    db_session.add(
+        AliasReviewQueue(
+            platform=Platform.LIQUIPEDIA,
+            platform_id="liq-multi",
+            platform_name="Multi",
+            candidates=[{"canonical_id": "x", "name": "y", "score": 0.8}],
+            reason="fuzzy_below_auto_merge",
+            status=ReviewStatus.RESOLVED,
+        )
+    )
+    db_session.add(
+        AliasReviewQueue(
+            platform=Platform.LIQUIPEDIA,
+            platform_id="liq-multi",
+            platform_name="Multi",
+            candidates=[{"canonical_id": "x", "name": "y", "score": 0.8}],
+            reason="fuzzy_below_auto_merge",
+            status=ReviewStatus.PENDING,
+        )
+    )
+    db_session.flush()  # resolved + pending for the same handle is legal
+
+
+def test_unrelated_integrity_error_is_not_swallowed_by_pending_path(
+    db_session, monkeypatch
+) -> None:
+    """A non-race IntegrityError on the PENDING path must propagate."""
+    from esports_sim.resolver import core
+    from sqlalchemy.exc import IntegrityError
+
+    # Seed two players so the resolver lands in the review band.
+    e1 = make_entity(entity_type=EntityType.PLAYER)
+    e2 = make_entity(entity_type=EntityType.PLAYER)
+    db_session.add_all([e1, e2])
+    db_session.add_all(
+        [
+            make_entity_alias(
+                entity=e1,
+                platform=Platform.VLR,
+                platform_id="vlr-sentinel",
+                platform_name="Sentinel",
+            ),
+            make_entity_alias(
+                entity=e2,
+                platform=Platform.VLR,
+                platform_id="vlr-sinatraa",
+                platform_name="Sinatraa",
+            ),
+        ]
+    )
+    db_session.flush()
+
+    real_enqueue = core._enqueue_pending_review_idempotent
+
+    def faulty_enqueue(*args, **kwargs):  # type: ignore[no-untyped-def]
+        # Simulate an unrelated unique violation surfacing inside the
+        # savepoint flush — the resolver's pending-path guard must re-raise
+        # rather than swallowing it as a duplicate-pending-review race.
+        raise IntegrityError(
+            "INSERT INTO raw_record",
+            {},
+            Exception("violates unique constraint uq_raw_record_content_hash"),
+        )
+
+    monkeypatch.setattr(core, "_enqueue_pending_review_idempotent", faulty_enqueue)
+
+    with pytest.raises(IntegrityError):
+        resolve_entity(
+            db_session,
+            platform=Platform.LIQUIPEDIA,
+            platform_id="liq-sentinal",
+            platform_name="Sentinal",
+            entity_type=EntityType.PLAYER,
+        )
+
+    # Sanity: restoring the helper makes the call succeed.
+    monkeypatch.setattr(core, "_enqueue_pending_review_idempotent", real_enqueue)
+    result = resolve_entity(
+        db_session,
+        platform=Platform.LIQUIPEDIA,
+        platform_id="liq-sentinal-2",
+        platform_name="Sentinal",
+        entity_type=EntityType.PLAYER,
+    )
+    assert result.status is ResolutionStatus.PENDING

--- a/uv.lock
+++ b/uv.lock
@@ -246,6 +246,7 @@ dependencies = [
     { name = "psycopg", extra = ["binary"] },
     { name = "pydantic" },
     { name = "pyyaml" },
+    { name = "rapidfuzz" },
     { name = "sqlalchemy", extra = ["asyncio"] },
 ]
 
@@ -259,6 +260,7 @@ requires-dist = [
     { name = "psycopg", extras = ["binary"], specifier = ">=3.1" },
     { name = "pydantic", specifier = ">=2.6" },
     { name = "pyyaml", specifier = ">=6.0" },
+    { name = "rapidfuzz", specifier = ">=3.6" },
     { name = "sqlalchemy", extras = ["asyncio"], specifier = ">=2.0" },
 ]
 
@@ -726,6 +728,25 @@ wheels = [
     { url = "https://files.pythonhosted.org/packages/74/93/7baea19427dcfbe1e5a372d81473250b379f04b1bd3c4c5ff825e2327202/pyyaml-6.0.3-cp312-cp312-win32.whl", hash = "sha256:96b533f0e99f6579b3d4d4995707cf36df9100d67e0c8303a0c55b27b5f99bc5", size = 137658, upload-time = "2025-09-25T21:32:20.209Z" },
     { url = "https://files.pythonhosted.org/packages/86/bf/899e81e4cce32febab4fb42bb97dcdf66bc135272882d1987881a4b519e9/pyyaml-6.0.3-cp312-cp312-win_amd64.whl", hash = "sha256:5fcd34e47f6e0b794d17de1b4ff496c00986e1c83f7ab2fb8fcfe9616ff7477b", size = 154003, upload-time = "2025-09-25T21:32:21.167Z" },
     { url = "https://files.pythonhosted.org/packages/1a/08/67bd04656199bbb51dbed1439b7f27601dfb576fb864099c7ef0c3e55531/pyyaml-6.0.3-cp312-cp312-win_arm64.whl", hash = "sha256:64386e5e707d03a7e172c0701abfb7e10f0fb753ee1d773128192742712a98fd", size = 140344, upload-time = "2025-09-25T21:32:22.617Z" },
+]
+
+[[package]]
+name = "rapidfuzz"
+version = "3.14.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/2c/21/ef6157213316e85790041254259907eb722e00b03480256c0545d98acd33/rapidfuzz-3.14.5.tar.gz", hash = "sha256:ba10ac57884ce82112f7ed910b67e7fb6072d8ef2c06e30dc63c0f604a112e0e", size = 57901753, upload-time = "2026-04-07T11:16:31.931Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/d3/e3/574435c6aafb80254c191ef40d7aca2cb2bb97a095ec9395e9fa59ac307a/rapidfuzz-3.14.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:0d3378f471ef440473a396ce2f8e97ee12f89a78b495540e0a5617bbfe895638", size = 1944601, upload-time = "2026-04-07T11:14:18.771Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/1f/fbad3102a255ecc112ce9a7e779bacab7fd14398217be8868dc9082ba363/rapidfuzz-3.14.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:1e910eebca9fd0eba245c0555e764597e8a0cccb673a92da2dc2397050725f48", size = 1164293, upload-time = "2026-04-07T11:14:20.534Z" },
+    { url = "https://files.pythonhosted.org/packages/88/37/a3eb7ff6121ed3a5f199a8c38cc86c8e481816f879cb0e0b738b078c9a7e/rapidfuzz-3.14.5-cp312-cp312-manylinux_2_26_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:01550fe5f60fd176aa66b7611289d46dc4aa4b1b904874c7b6d1d54e581c5ec1", size = 1371999, upload-time = "2026-04-07T11:14:22.63Z" },
+    { url = "https://files.pythonhosted.org/packages/79/72/97a9728c711c7c1b06e107d3f0623880fb4ef90e147ed13c551a1730e7cc/rapidfuzz-3.14.5-cp312-cp312-manylinux_2_27_x86_64.manylinux_2_28_x86_64.whl", hash = "sha256:48bee0b91bebfaec41e1081e351000659ab7570cc4598d617aa04d5bf827f9e6", size = 3145715, upload-time = "2026-04-07T11:14:24.508Z" },
+    { url = "https://files.pythonhosted.org/packages/ed/54/d5caabbea233ac90c286c87c260e49d7641467e87438a18d858e41c82e91/rapidfuzz-3.14.5-cp312-cp312-manylinux_2_39_riscv64.whl", hash = "sha256:7e580cb04ad849ae9b786fa21383c6b994b6e6c1444ad1cb9f22392759d72741", size = 1456304, upload-time = "2026-04-07T11:14:26.515Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/a7/2d1a81250ac8c01a0100c026018e76f0e7a097ff63e4c553e02a6938c6fb/rapidfuzz-3.14.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:09d6c9ba091854f07817055d795d604179c12a8f308ba4c7d56f3719dfea1646", size = 2389089, upload-time = "2026-04-07T11:14:28.635Z" },
+    { url = "https://files.pythonhosted.org/packages/65/0d/c47c3872203ae88e6506997c0b576ad731f5261daa25d559be09c9756658/rapidfuzz-3.14.5-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:1e989f86113be66574113b9c7bdf4793f3f863d248e47d911b355e05ca6b6b10", size = 2493404, upload-time = "2026-04-07T11:14:30.577Z" },
+    { url = "https://files.pythonhosted.org/packages/8f/2f/71e0a5a3130792146c8a200a2dd1e52aa16f7c1074012e17f2601eea9a90/rapidfuzz-3.14.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:0ebd1a18e2e47bc0b292a07e6ed9c3642f8aaa672d12253885f599b50807a4f9", size = 4251709, upload-time = "2026-04-07T11:14:32.451Z" },
+    { url = "https://files.pythonhosted.org/packages/86/45/d39874901abacef325adb5b34ae416817c8486dfb4fb87c7a9b74ec5b072/rapidfuzz-3.14.5-cp312-cp312-win32.whl", hash = "sha256:9981d38a703b86f0e315a3cd229fd1906fe1d91c989ed121fb975b3c849f89f5", size = 1710069, upload-time = "2026-04-07T11:14:34.37Z" },
+    { url = "https://files.pythonhosted.org/packages/85/0b/f65572c53de8a1c704bda707f63a447b67bdbe95d7cdc70d18885e191df5/rapidfuzz-3.14.5-cp312-cp312-win_amd64.whl", hash = "sha256:d8375e3da319593389727c3187ccaf3e0e84199accc530866b8e0f2b79af05e9", size = 1540630, upload-time = "2026-04-07T11:14:36.287Z" },
+    { url = "https://files.pythonhosted.org/packages/5e/c3/143be3a578f989758cae516f3270d5cbb49783a7bfdf57cc27a670e00456/rapidfuzz-3.14.5-cp312-cp312-win_arm64.whl", hash = "sha256:478b59bb018a6780d73f33e38d0b3ec5e968a6c1ed42876b993dd456b7aa20e8", size = 813137, upload-time = "2026-04-07T11:14:38.289Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

- Adds `resolve_entity()` (`packages/shared/src/esports_sim/resolver/`) — the single chokepoint mapping a `(platform, platform_id, platform_name)` triple to a canonical entity. Exact alias lookup → rapidfuzz `WRatio` scoring (case-insensitive via `default_process`) → auto-merge ≥ 0.90 / review-queue enqueue ≥ 0.70 / mint new canonical at confidence 1.0. Idempotent on both the matched and pending paths.
- Closes the resolver-bypass hole: `StagingRecord.save()` plus `before_insert`/`before_update` event listeners reject rows with a null `canonical_id` unless status is `blocked` or `review`. FK-cascade `SET NULL` still passes through, preserving the audit-trail behavior the existing schema tests rely on.
- Adds `rapidfuzz>=3.6` to the shared package.

## Why

BUF-7 / Systems-spec System 01: every write to a canonical-keyed table must funnel through one resolver so two scrapers can't accidentally split a player into two canonical rows. Schema-level uniqueness on `(platform, platform_id)` was already in place (BUF-6); this PR is the runtime guarantee that scrapers actually use it.

## Notes for reviewers

- Thresholds (0.70 / 0.90) are kept as module-level constants rather than call-site arguments — a policy decision the whole pipeline must agree on.
- `WRatio` runs through `rapidfuzz.utils.default_process` so "TenZ" vs "tenz" auto-merges at 1.0 instead of landing on review at 0.50.
- Resolver writes inside the caller's `Session` and does not commit — transaction ownership stays with the caller.
- Tests are marked `integration` (Postgres required for JSONB / named ENUMs); skipped locally without `TEST_DATABASE_URL`, exercised in CI which provides the Postgres service container.

## Test plan

- [x] `uv run ruff check .`
- [x] `uv run python -m black --check .`
- [x] `uv run mypy`
- [x] `uv run pytest` — 83 passed, 27 skipped locally (no Postgres); CI runs the 15 new resolver integration tests against the Postgres service container
- [ ] Verify CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)