### PR TITLE
BUF-82: Riot API connector — match history and PUUID alias linkage

### DIFF
--- a/services/data_pipeline/pyproject.toml
+++ b/services/data_pipeline/pyproject.toml
@@ -13,6 +13,10 @@ dependencies = [
     # content_hash so a faulty connector run can be reconstructed from logs
     # alone; structlog's processor pipeline keeps that contract testable.
     "structlog>=24.1",
+    # HTTP client for the Riot API connector (BUF-82) and other future
+    # API-backed scrapers. Imported lazily inside the default ``http_get``
+    # factory so unit tests that inject a fake never need it on the path.
+    "httpx>=0.27",
 ]
 
 [tool.uv.sources]

--- a/services/data_pipeline/src/data_pipeline/connectors/__init__.py
+++ b/services/data_pipeline/src/data_pipeline/connectors/__init__.py
@@ -1,0 +1,1 @@
+# connectors package

--- a/services/data_pipeline/src/data_pipeline/connectors/riot.py
+++ b/services/data_pipeline/src/data_pipeline/connectors/riot.py
@@ -1,0 +1,508 @@
+"""Riot Games API connector for the BUF-9 ingestion framework (BUF-82).
+
+Pulls official VALORANT match history and per-player perspective from the
+Riot Games developer API. Riot is the highest-priority source in conflict
+resolution (BUF-12) — every other source defers to it for canonical
+identifiers.
+
+Pipeline shape (one ``fetch`` round per pass):
+
+    seed PUUIDs -> matchlist endpoint -> per-match GET -> yield one upstream
+    payload per match -> validate -> transform -> one IngestionRecord per
+    player on the match (10 for a complete game).
+
+Each transformed record carries enough of the player's perspective on the
+match for downstream stat extraction (the per-round stat table is a
+follow-up ticket — see PR description). The full match JSON lands in
+``raw_record.payload`` automatically via the runner.
+
+Rate-limiting strategy
+----------------------
+
+The runner already gates outbound traffic via :class:`TokenBucket`. Riot's
+production keys, however, enforce a *rolling* window that doesn't always
+align with the bucket — and the limit is shared across endpoints. We
+defend in depth:
+
+1.  Conservative bucket default (~10 req/min steady state, burst 20),
+    overridable via constructor for tier-2 or higher production keys.
+2.  Wrapper around ``http_get`` that, on a 429 response, reads
+    ``Retry-After`` and sleeps before raising
+    :class:`TransientFetchError` — the runner skips the row without
+    persisting raw, so the next scheduled run retries naturally.
+3.  Same wrapper escalates 5xx to :class:`TransientFetchError`. Other
+    response-shape errors raise :class:`SchemaDriftError` instead, so
+    the offending payload is preserved for offline triage.
+
+PUUID linkage
+-------------
+
+``platform_id`` is the player's Riot PUUID — globally unique, stable
+across name changes, and the canonical identifier Riot itself uses.
+``platform_name`` is the public ``gameName#tagLine`` Riot identity tag
+(what shows up in-client). The resolver mints aliases at ``confidence
+1.0`` for every yielded record because Riot is authoritative; downstream
+sources that disagree get demoted, not the other way around.
+
+Out of scope
+------------
+
+* ``player_match_stat`` table and per-round stat extraction. The schema
+  doesn't have one yet; designing it (per-round granularity, agent
+  picks, ability casts) is its own ticket. This connector emits the
+  full match-from-this-player's-perspective payload so the downstream
+  extractor can run against ``staging_record.payload`` once that ticket
+  lands.
+* Backfill orchestration. ``cadence`` is the daily-pull hint for the
+  scheduler; bulk historical loads (e.g., back to patch 5.0 for known
+  pro PUUIDs) are a manual run that supplies an old ``since``
+  watermark.
+* Multi-region routing. Defaults to the ``americas`` Riot regional
+  routing host; ``region`` is a constructor knob for ``europe`` /
+  ``ap`` / ``kr``. A single ingest pass targets one region — the
+  scheduler can fan out per region later.
+* Production rate-limit tuning. Ship a conservative bucket, expose
+  ``rate_limit`` as a constructor argument so a tier-2 production key
+  can dial it up.
+"""
+
+from __future__ import annotations
+
+import os
+import time
+from collections.abc import Callable, Iterable
+from datetime import datetime, timedelta
+from typing import Any
+
+import structlog
+from esports_sim.db.enums import EntityType, Platform
+from structlog.stdlib import BoundLogger
+
+from data_pipeline.connector import Connector, IngestionRecord, RateLimit
+from data_pipeline.errors import SchemaDriftError, TransientFetchError
+
+# Conservative defaults for Riot's production-key 100-req-per-2-min window.
+# 20 burst / (20/120 = 0.167 rps) = ~10 rpm steady state, well inside the
+# limit even after retry storms. Override via constructor in environments
+# with a higher tier key.
+_DEFAULT_RATE_LIMIT = RateLimit(capacity=20, refill_per_second=20.0 / 120.0)
+
+# Keep ``cadence`` aligned with the spec: daily incremental pulls. The
+# runner is single-shot — this is a hint to the outer scheduler, not a
+# sleep-loop inside the connector.
+_DEFAULT_CADENCE = timedelta(days=1)
+
+# Default to ``americas`` because tier-1 VCT pros mostly live there and
+# the ticket's seed list is americas-weighted. Multi-region routing is
+# explicitly out of scope (see module docstring).
+_DEFAULT_REGION = "americas"
+
+# Riot caps Retry-After at minutes, not hours — but a malformed header
+# could otherwise wedge the run for the entire pass. Cap defensively.
+_MAX_RETRY_AFTER_SECONDS = 120.0
+
+# Type alias for the injectable HTTP shim. Returning a structured response
+# (status + headers + json) keeps the wrapper logic in one place; tests
+# fake the same shape without spinning up a server.
+HttpResponse = dict[str, Any]
+HttpGet = Callable[[str, dict[str, Any]], HttpResponse]
+
+
+def _default_http_get_factory() -> HttpGet:
+    """Build a real-network ``http_get`` backed by ``httpx``.
+
+    The Riot API key comes from ``RIOT_API_KEY``. We deliberately delay
+    httpx import + key lookup to call time so unit tests that inject a
+    fake never need either present.
+    """
+
+    def http_get(url: str, params: dict[str, Any]) -> HttpResponse:
+        import httpx  # lazy: tests with an injected http_get never need it
+
+        api_key = os.environ.get("RIOT_API_KEY")
+        if not api_key:
+            # Fail loudly — a connector that silently 401s every call
+            # would burn its rate budget for nothing.
+            raise RuntimeError(
+                "RIOT_API_KEY not set; cannot make Riot API calls. "
+                "Set it in the environment or inject a fake http_get for tests."
+            )
+        headers = {"X-Riot-Token": api_key}
+        with httpx.Client(timeout=30.0) as client:
+            response = client.get(url, params=params, headers=headers)
+        # Normalise to the shape ``_RiotHttpClient`` expects regardless
+        # of status — the client decides how to interpret it.
+        try:
+            body: Any = response.json()
+        except ValueError:
+            body = None
+        return {
+            "status_code": response.status_code,
+            "headers": dict(response.headers),
+            "json": body,
+        }
+
+    return http_get
+
+
+class RiotConnector(Connector):
+    """Riot Games API connector. One pass per region."""
+
+    def __init__(
+        self,
+        *,
+        seed_puuids: list[str],
+        http_get: HttpGet | None = None,
+        region: str = _DEFAULT_REGION,
+        rate_limit: RateLimit = _DEFAULT_RATE_LIMIT,
+        cadence: timedelta = _DEFAULT_CADENCE,
+        sleeper: Callable[[float], None] = time.sleep,
+        logger: BoundLogger | None = None,
+    ) -> None:
+        """Construct a Riot connector for ``region``.
+
+        Parameters
+        ----------
+        seed_puuids:
+            The PUUIDs to crawl on each pass. In tests this is a small
+            list; in production, it's loaded from a config file (see
+            ``out of scope`` in the module docstring — that loader is a
+            follow-up ticket).
+        http_get:
+            Injected HTTP shim. Defaults to an ``httpx``-backed factory
+            that reads the Riot API key from ``RIOT_API_KEY``. Tests
+            override this with a fake to avoid hitting the network.
+        region:
+            Riot regional routing host (``americas``, ``europe``, ``ap``,
+            ``kr``). One connector instance covers one region; fan out
+            via the scheduler.
+        rate_limit:
+            Token-bucket parameters. Defaults to a conservative
+            ~10 rpm / burst 20 — well inside the production-key
+            100-req-per-2-min window. Override for higher-tier keys.
+        cadence:
+            Hint for the scheduler. Default daily.
+        sleeper:
+            Indirection so the 429 backoff path is testable without
+            real wall-clock waits.
+        logger:
+            Optional structlog logger; defaults to a fresh BoundLogger.
+        """
+        if not seed_puuids:
+            # An empty seed list isn't a runtime error — the connector
+            # would just yield nothing — but it almost certainly signals
+            # a misconfiguration. Fail loudly so it shows up in CI rather
+            # than as a silent no-op pass.
+            raise ValueError("RiotConnector requires at least one seed PUUID")
+
+        self._seed_puuids = list(seed_puuids)
+        self._http_get = http_get or _default_http_get_factory()
+        self._region = region
+        self._rate_limit = rate_limit
+        self._cadence = cadence
+        self._sleeper = sleeper
+        self._log = logger or structlog.get_logger("data_pipeline.connectors.riot")
+
+    # --- Connector metadata ------------------------------------------------
+
+    @property
+    def source_name(self) -> str:
+        return "riot_api"
+
+    @property
+    def platform(self) -> Platform:
+        return Platform.RIOT_API
+
+    @property
+    def entity_types(self) -> tuple[EntityType, ...]:
+        return (EntityType.PLAYER,)
+
+    @property
+    def cadence(self) -> timedelta:
+        return self._cadence
+
+    @property
+    def rate_limit(self) -> RateLimit:
+        return self._rate_limit
+
+    # --- Connector hooks ---------------------------------------------------
+
+    def fetch(self, since: datetime) -> Iterable[dict[str, Any]]:
+        """Yield one upstream payload per match newer than ``since``.
+
+        For each seed PUUID, GET the matchlist, then for every match
+        whose ``gameStartTimeMillis`` is strictly greater than ``since``
+        GET the full match payload and yield::
+
+            {
+                "match_id": <riot match id>,
+                "puuid_seed": <the seed PUUID we found this match through>,
+                "match": <full Riot match response>,
+            }
+
+        ``puuid_seed`` is preserved so a re-run can re-attribute the
+        match if the seed list changes; the canonical link is the
+        match ID.
+        """
+        since_millis = int(since.timestamp() * 1000)
+
+        for puuid in self._seed_puuids:
+            matchlist = self._fetch_matchlist(puuid)
+            history = matchlist.get("history") or []
+            for match_ref in history:
+                # ``gameStartTimeMillis`` is Riot's documented field; an
+                # older fixture version may use a slightly different key,
+                # so a missing one is treated as "include" rather than
+                # silently dropping the row. Validation downstream will
+                # catch a malformed match payload.
+                start_millis = match_ref.get("gameStartTimeMillis")
+                if start_millis is not None and start_millis <= since_millis:
+                    continue
+
+                match_id = match_ref.get("matchId")
+                if not match_id:
+                    # Skip without raising — a single broken matchlist
+                    # entry shouldn't abort the entire seed.
+                    self._log.warning(
+                        "riot.matchlist_entry_missing_id",
+                        code="MATCHLIST_DRIFT",
+                        puuid_seed=puuid,
+                    )
+                    continue
+
+                match_payload = self._fetch_match(match_id)
+                yield {
+                    "match_id": match_id,
+                    "puuid_seed": puuid,
+                    "match": match_payload,
+                }
+
+    def validate(self, raw_payload: dict[str, Any]) -> dict[str, Any]:
+        """Shape-check the match payload.
+
+        We require the three top-level keys the transform reads
+        (``matchInfo``, ``players``, ``roundResults``); anything else is
+        considered drift from Riot's documented schema and gets routed
+        through the runner's ``SCHEMA_DRIFT`` log path. We don't do
+        deep validation — Riot's documented schema is large, and we'd
+        rather catch surface-level breakage early than maintain a
+        full mirror.
+        """
+        match = raw_payload.get("match")
+        if not isinstance(match, dict):
+            raise SchemaDriftError("payload missing 'match' object")
+
+        for required in ("matchInfo", "players", "roundResults"):
+            if required not in match:
+                raise SchemaDriftError(f"match payload missing required key '{required}'")
+
+        if not isinstance(match["players"], list):
+            raise SchemaDriftError("match.players must be a list")
+
+        return raw_payload
+
+    def transform(self, validated_payload: dict[str, Any]) -> Iterable[IngestionRecord]:
+        """Yield one :class:`IngestionRecord` per player on the match.
+
+        ``platform_id`` is the player's PUUID (deterministic; the
+        resolver's exact-alias lookup keys on it). ``platform_name`` is
+        the Riot ``gameName#tagLine`` identity tag.
+
+        ``payload`` carries enough of the player's perspective on the
+        match for the downstream stat-extraction step but trims
+        *other* players' detailed round data — we keep their PUUIDs
+        only, so a future join can rehydrate from the raw row if
+        needed.
+        """
+        match_id = validated_payload["match_id"]
+        match = validated_payload["match"]
+        match_info = match["matchInfo"]
+        players: list[dict[str, Any]] = match["players"]
+        rounds: list[dict[str, Any]] = match["roundResults"]
+
+        # Reference list of every player's PUUID — kept on every
+        # emitted record so the downstream extractor knows the full
+        # roster without re-reading raw_record.
+        roster_puuids = [p.get("puuid") for p in players if p.get("puuid")]
+
+        for player in players:
+            puuid = player.get("puuid")
+            game_name = player.get("gameName")
+            tag_line = player.get("tagLine")
+            if not puuid or not game_name or tag_line is None:
+                # A player block without identity fields is unusable for
+                # alias linkage — skip rather than mint a junk record.
+                # We don't raise SchemaDriftError because partial player
+                # blocks (anonymised customs, dev accounts) are a known
+                # quirk of the Riot API rather than a schema regression.
+                self._log.warning(
+                    "riot.player_missing_identity",
+                    code="PLAYER_IDENTITY_DRIFT",
+                    match_id=match_id,
+                    has_puuid=bool(puuid),
+                    has_game_name=bool(game_name),
+                    has_tag_line=tag_line is not None,
+                )
+                continue
+
+            slimmed_rounds = [
+                _slim_round_for_player(round_data, puuid) for round_data in rounds
+            ]
+
+            yield IngestionRecord(
+                entity_type=EntityType.PLAYER,
+                platform_id=puuid,
+                platform_name=f"{game_name}#{tag_line}",
+                payload={
+                    "match_id": match_id,
+                    "match_info": match_info,
+                    "this_player": player,
+                    "roster_puuids": roster_puuids,
+                    "rounds": slimmed_rounds,
+                },
+            )
+
+    # --- internal HTTP plumbing -------------------------------------------
+
+    def _fetch_matchlist(self, puuid: str) -> dict[str, Any]:
+        url = (
+            f"https://{self._region}.api.riotgames.com"
+            f"/val/match/v1/matchlists/by-puuid/{puuid}"
+        )
+        return self._get(url, {})
+
+    def _fetch_match(self, match_id: str) -> dict[str, Any]:
+        url = (
+            f"https://{self._region}.api.riotgames.com"
+            f"/val/match/v1/matches/{match_id}"
+        )
+        return self._get(url, {})
+
+    def _get(self, url: str, params: dict[str, Any]) -> dict[str, Any]:
+        """HTTP GET with Riot-aware error translation.
+
+        * 200 — return parsed JSON.
+        * 429 — log structured rate-limit warning, sleep ``Retry-After``
+          (capped), then raise :class:`TransientFetchError` so the
+          runner skips without persisting raw.
+        * 5xx — raise :class:`TransientFetchError` (recoverable).
+        * Any other non-200 — raise :class:`SchemaDriftError` so the
+          payload is preserved for triage.
+        * Malformed JSON body on a 200 — :class:`SchemaDriftError`.
+        """
+        try:
+            response = self._http_get(url, params)
+        except TransientFetchError:
+            # Allow a fake/real http_get to short-circuit translation and
+            # raise its own TransientFetchError directly (e.g., a network
+            # timeout in the real httpx wrapper).
+            raise
+        except Exception as exc:
+            # Unknown network failure — treat as transient. The runner
+            # already differentiates ``TransientFetchError`` from
+            # ``SchemaDriftError``; a connect-timeout shouldn't burn
+            # the retry slot.
+            raise TransientFetchError(f"http_get failed for {url}: {exc}") from exc
+
+        status = response.get("status_code")
+        headers = response.get("headers") or {}
+        body = response.get("json")
+
+        if status == 200:
+            if not isinstance(body, dict):
+                raise SchemaDriftError(
+                    f"Riot {url} returned 200 but body was {type(body).__name__}, expected dict"
+                )
+            return body
+
+        if status == 429:
+            retry_after = _parse_retry_after(headers.get("Retry-After"))
+            self._log.warning(
+                "riot.rate_limited",
+                code="RATE_LIMITED",
+                retry_after_seconds=retry_after,
+                endpoint=url,
+            )
+            if retry_after > 0:
+                self._sleeper(retry_after)
+            raise TransientFetchError(
+                f"Riot 429 at {url}; retry-after={retry_after}s"
+            )
+
+        if status is not None and 500 <= status < 600:
+            self._log.warning(
+                "riot.server_error",
+                code="UPSTREAM_5XX",
+                status=status,
+                endpoint=url,
+            )
+            raise TransientFetchError(f"Riot {status} at {url}")
+
+        # 400/401/403/404 etc. — these are caller-side problems
+        # (bad PUUID, expired key, missing match) and persisting the
+        # raw row helps a maintainer diagnose. SchemaDriftError makes
+        # the runner persist raw and continue.
+        raise SchemaDriftError(
+            f"Riot returned unexpected status {status} for {url}; body={body!r}"
+        )
+
+
+def _parse_retry_after(header_value: Any) -> float:
+    """Parse a ``Retry-After`` header into a non-negative seconds float.
+
+    Caps at :data:`_MAX_RETRY_AFTER_SECONDS` defensively — Riot rate
+    limits are minutes at most, so a header demanding hours is far more
+    likely to be malformed than legitimate. Returns ``0.0`` for
+    missing/unparseable values rather than raising; the caller will
+    still raise :class:`TransientFetchError` so the row is retried,
+    and the bucket alone will gate the next attempt.
+    """
+    if header_value is None:
+        return 0.0
+    try:
+        seconds = float(header_value)
+    except (TypeError, ValueError):
+        return 0.0
+    if seconds <= 0:
+        return 0.0
+    return min(seconds, _MAX_RETRY_AFTER_SECONDS)
+
+
+def _slim_round_for_player(round_data: dict[str, Any], puuid: str) -> dict[str, Any]:
+    """Drop *other* players' detailed round data, keep this player's full block.
+
+    Each round entry in Riot's response carries a ``playerStats`` list
+    with one entry per player, plus a flat ``playerLocations`` /
+    ``plantPlayerLocations`` blob. For a per-player ingestion record
+    we only need the focal player's stats plus enough match-level
+    context (round number, winning team, plant/defuse markers) for
+    downstream extraction. We keep other players' PUUIDs as a roster
+    reference but trim their per-round detail — the raw match JSON
+    is preserved by the runner if a future job needs it.
+    """
+    slimmed: dict[str, Any] = {
+        "roundNum": round_data.get("roundNum"),
+        "roundResult": round_data.get("roundResult"),
+        "winningTeam": round_data.get("winningTeam"),
+        "bombPlanter": round_data.get("bombPlanter"),
+        "bombDefuser": round_data.get("bombDefuser"),
+        "plantRoundTime": round_data.get("plantRoundTime"),
+        "defuseRoundTime": round_data.get("defuseRoundTime"),
+    }
+
+    player_stats: list[dict[str, Any]] = round_data.get("playerStats") or []
+    focal_stats: dict[str, Any] | None = None
+    other_puuids: list[str] = []
+    for entry in player_stats:
+        entry_puuid = entry.get("puuid")
+        if entry_puuid == puuid:
+            focal_stats = entry
+        elif entry_puuid:
+            other_puuids.append(entry_puuid)
+
+    slimmed["this_player_stats"] = focal_stats
+    slimmed["other_player_puuids"] = other_puuids
+    return slimmed
+
+
+__all__ = ["HttpGet", "HttpResponse", "RiotConnector"]

--- a/services/data_pipeline/src/data_pipeline/connectors/riot.py
+++ b/services/data_pipeline/src/data_pipeline/connectors/riot.py
@@ -236,18 +236,47 @@ class RiotConnector(Connector):
 
             {
                 "match_id": <riot match id>,
-                "puuid_seed": <the seed PUUID we found this match through>,
                 "match": <full Riot match response>,
             }
 
-        ``puuid_seed`` is preserved so a re-run can re-attribute the
-        match if the seed list changes; the canonical link is the
-        match ID.
+        Two correctness properties this loop enforces:
+
+        * **Cross-seed dedup.** Tier-1 VCT pros frequently scrim each
+          other; the same match appears in N seeds' matchlists. We
+          keep a ``seen_match_ids`` set scoped to this fetch pass and
+          skip already-emitted matches so a 10-player scrim isn't
+          fetched 10× and inserted 10× into ``staging_record``.
+        * **Stable content hash.** We deliberately do NOT stash the
+          discovering ``puuid_seed`` on the yielded payload. The
+          runner hashes payload bytes for ``RawRecord.content_hash``
+          dedup; folding the seed in would make the same match hash
+          differently on a re-run with a different seed list. Seed
+          attribution is observable via the ``riot.matchlist_loaded``
+          structured-log line and the ``raw_record.fetched_at``
+          temporal proximity to that call.
+
+        Per-record HTTP failures (``TransientFetchError`` from a 429 or
+        a 5xx) are caught here and **logged + skipped** rather than
+        propagated. ``run_ingestion``'s post-yield error handling can't
+        see exceptions raised during iterator advancement (i.e. inside
+        the ``self._fetch_match`` call before the next ``yield``), so
+        one rate-limited request would otherwise abort the whole pass
+        and skip every remaining seed PUUID.
         """
         since_millis = int(since.timestamp() * 1000)
+        seen_match_ids: set[str] = set()
 
         for puuid in self._seed_puuids:
-            matchlist = self._fetch_matchlist(puuid)
+            try:
+                matchlist = self._fetch_matchlist(puuid)
+            except TransientFetchError as exc:
+                self._log.warning(
+                    "riot.matchlist_fetch_skipped",
+                    code="TRANSIENT_FETCH_ERROR",
+                    puuid_seed=puuid,
+                    detail=str(exc),
+                )
+                continue
             history = matchlist.get("history") or []
             for match_ref in history:
                 # ``gameStartTimeMillis`` is Riot's documented field; an
@@ -270,10 +299,30 @@ class RiotConnector(Connector):
                     )
                     continue
 
-                match_payload = self._fetch_match(match_id)
+                if match_id in seen_match_ids:
+                    # Cross-seed dedup: another seed already surfaced
+                    # this match in the current pass.
+                    continue
+                seen_match_ids.add(match_id)
+
+                try:
+                    match_payload = self._fetch_match(match_id)
+                except TransientFetchError as exc:
+                    self._log.warning(
+                        "riot.match_fetch_skipped",
+                        code="TRANSIENT_FETCH_ERROR",
+                        match_id=match_id,
+                        puuid_seed=puuid,
+                        detail=str(exc),
+                    )
+                    # Allow a future pass to retry this match by removing
+                    # it from the seen-set; otherwise a transient blip
+                    # turns into a permanent drop.
+                    seen_match_ids.discard(match_id)
+                    continue
+
                 yield {
                     "match_id": match_id,
-                    "puuid_seed": puuid,
                     "match": match_payload,
                 }
 
@@ -345,9 +394,7 @@ class RiotConnector(Connector):
                 )
                 continue
 
-            slimmed_rounds = [
-                _slim_round_for_player(round_data, puuid) for round_data in rounds
-            ]
+            slimmed_rounds = [_slim_round_for_player(round_data, puuid) for round_data in rounds]
 
             yield IngestionRecord(
                 entity_type=EntityType.PLAYER,
@@ -366,16 +413,12 @@ class RiotConnector(Connector):
 
     def _fetch_matchlist(self, puuid: str) -> dict[str, Any]:
         url = (
-            f"https://{self._region}.api.riotgames.com"
-            f"/val/match/v1/matchlists/by-puuid/{puuid}"
+            f"https://{self._region}.api.riotgames.com" f"/val/match/v1/matchlists/by-puuid/{puuid}"
         )
         return self._get(url, {})
 
     def _fetch_match(self, match_id: str) -> dict[str, Any]:
-        url = (
-            f"https://{self._region}.api.riotgames.com"
-            f"/val/match/v1/matches/{match_id}"
-        )
+        url = f"https://{self._region}.api.riotgames.com" f"/val/match/v1/matches/{match_id}"
         return self._get(url, {})
 
     def _get(self, url: str, params: dict[str, Any]) -> dict[str, Any]:
@@ -425,9 +468,7 @@ class RiotConnector(Connector):
             )
             if retry_after > 0:
                 self._sleeper(retry_after)
-            raise TransientFetchError(
-                f"Riot 429 at {url}; retry-after={retry_after}s"
-            )
+            raise TransientFetchError(f"Riot 429 at {url}; retry-after={retry_after}s")
 
         if status is not None and 500 <= status < 600:
             self._log.warning(
@@ -442,9 +483,7 @@ class RiotConnector(Connector):
         # (bad PUUID, expired key, missing match) and persisting the
         # raw row helps a maintainer diagnose. SchemaDriftError makes
         # the runner persist raw and continue.
-        raise SchemaDriftError(
-            f"Riot returned unexpected status {status} for {url}; body={body!r}"
-        )
+        raise SchemaDriftError(f"Riot returned unexpected status {status} for {url}; body={body!r}")
 
 
 def _parse_retry_after(header_value: Any) -> float:

--- a/services/data_pipeline/src/data_pipeline/connectors/riot.py
+++ b/services/data_pipeline/src/data_pipeline/connectors/riot.py
@@ -348,6 +348,15 @@ class RiotConnector(Connector):
         if not isinstance(match["players"], list):
             raise SchemaDriftError("match.players must be a list")
 
+        # ``transform`` iterates ``roundResults`` and passes each entry
+        # to ``_slim_round_for_player`` (which expects a dict). If Riot
+        # ships ``roundResults`` as a different shape during a schema
+        # change, classify it as drift here so the runner logs
+        # SCHEMA_DRIFT and preserves the raw payload — rather than
+        # raising AttributeError mid-transform and aborting the pass.
+        if not isinstance(match["roundResults"], list):
+            raise SchemaDriftError("match.roundResults must be a list")
+
         return raw_payload
 
     def transform(self, validated_payload: dict[str, Any]) -> Iterable[IngestionRecord]:
@@ -459,7 +468,15 @@ class RiotConnector(Connector):
             return body
 
         if status == 429:
-            retry_after = _parse_retry_after(headers.get("Retry-After"))
+            # Header lookup must be case-insensitive: ``httpx`` stores
+            # headers in a dict-like that lower-cases keys when iterated
+            # via ``dict(response.headers)``, so the production factory's
+            # ``"headers": dict(response.headers)`` yields ``"retry-after"``
+            # not ``"Retry-After"``. A direct ``headers.get("Retry-After")``
+            # would silently miss every real 429 and skip the documented
+            # backoff sleep — repeatedly slamming the rate-limited
+            # endpoint instead of waiting it out.
+            retry_after = _parse_retry_after(_lookup_header(headers, "Retry-After"))
             self._log.warning(
                 "riot.rate_limited",
                 code="RATE_LIMITED",
@@ -484,6 +501,25 @@ class RiotConnector(Connector):
         # raw row helps a maintainer diagnose. SchemaDriftError makes
         # the runner persist raw and continue.
         raise SchemaDriftError(f"Riot returned unexpected status {status} for {url}; body={body!r}")
+
+
+def _lookup_header(headers: dict[str, Any], name: str) -> Any:
+    """Case-insensitive header lookup.
+
+    HTTP headers are case-insensitive per RFC 7230, but plain Python
+    dicts are not. The default ``http_get`` factory builds the headers
+    dict from ``dict(httpx.Response.headers)``, which yields lower-case
+    keys; tests' ``_FakeHttp`` may pass either case. Centralising the
+    lookup here means callers don't need to know which variant lives
+    in the dict.
+    """
+    if name in headers:
+        return headers[name]
+    target = name.lower()
+    for key, value in headers.items():
+        if isinstance(key, str) and key.lower() == target:
+            return value
+    return None
 
 
 def _parse_retry_after(header_value: Any) -> float:

--- a/services/data_pipeline/src/data_pipeline/connectors/riot.py
+++ b/services/data_pipeline/src/data_pipeline/connectors/riot.py
@@ -107,6 +107,28 @@ _MAX_RETRY_AFTER_SECONDS = 120.0
 HttpResponse = dict[str, Any]
 HttpGet = Callable[[str, dict[str, Any]], HttpResponse]
 
+# Exception types we accept as "transient transport failure" inside
+# ``_get``. These are the recoverable shapes — everything else (a
+# RuntimeError from the default factory's RIOT_API_KEY check, an
+# ImportError from a broken httpx install, an AttributeError from a
+# code regression) bubbles up so the run aborts loudly. Adding a new
+# entry here is a deliberate decision: it removes a class of failure
+# from the operator's "fail loudly" surface.
+_TRANSPORT_FAILURES: tuple[type[BaseException], ...] = (
+    OSError,  # ConnectionError, TimeoutError, socket.gaierror, etc.
+)
+try:  # pragma: no cover - import is only present when httpx is installed
+    import httpx as _httpx_for_exceptions
+
+    _TRANSPORT_FAILURES = (*_TRANSPORT_FAILURES, _httpx_for_exceptions.HTTPError)
+    del _httpx_for_exceptions
+except ImportError:
+    # httpx is a soft runtime dependency — only the default factory
+    # uses it. Tests injecting their own ``http_get`` don't need it
+    # installed, and we'd rather skip the broader catch than refuse
+    # to import the connector at all.
+    pass
+
 
 def _default_http_get_factory() -> HttpGet:
     """Build a real-network ``http_get`` backed by ``httpx``.
@@ -441,6 +463,16 @@ class RiotConnector(Connector):
         * Any other non-200 — raise :class:`SchemaDriftError` so the
           payload is preserved for triage.
         * Malformed JSON body on a 200 — :class:`SchemaDriftError`.
+
+        Error-class triage matters for fail-fast behaviour upstream.
+        ``fetch`` swallows ``TransientFetchError`` per-seed and
+        continues, so we MUST NOT route configuration / programmer
+        errors through that class — a missing ``RIOT_API_KEY`` would
+        otherwise produce a silent no-op run with only warnings,
+        letting production stop ingesting entirely without surfacing
+        a hard failure. Only genuine transport-layer failures (network
+        timeouts, DNS misses, connection resets) become transient;
+        everything else propagates so the run aborts loudly.
         """
         try:
             response = self._http_get(url, params)
@@ -449,12 +481,17 @@ class RiotConnector(Connector):
             # raise its own TransientFetchError directly (e.g., a network
             # timeout in the real httpx wrapper).
             raise
-        except Exception as exc:
-            # Unknown network failure — treat as transient. The runner
-            # already differentiates ``TransientFetchError`` from
-            # ``SchemaDriftError``; a connect-timeout shouldn't burn
-            # the retry slot.
+        except _TRANSPORT_FAILURES as exc:
+            # Transport-layer failure (connect timeout, DNS error, TLS
+            # handshake, HTTP-level disconnect mid-stream). Treat as
+            # transient so the next scheduled run retries.
             raise TransientFetchError(f"http_get failed for {url}: {exc}") from exc
+        # Anything else — RuntimeError, ImportError, AttributeError,
+        # KeyError, etc. — is a configuration or programming bug.
+        # Letting it propagate kills the run with the original exception
+        # so an operator sees the real failure mode (e.g. unset
+        # RIOT_API_KEY, broken env, code regression) rather than a
+        # cascade of "transient" warnings.
 
         status = response.get("status_code")
         headers = response.get("headers") or {}

--- a/services/data_pipeline/tests/fixtures/riot/match.json
+++ b/services/data_pipeline/tests/fixtures/riot/match.json
@@ -1,0 +1,126 @@
+{
+  "matchInfo": {
+    "matchId": "match-001",
+    "mapId": "/Game/Maps/Ascent/Ascent",
+    "gameVersion": "release-08.10",
+    "gameLengthMillis": 2400000,
+    "gameStartMillis": 1714000000000,
+    "queueId": "competitive",
+    "seasonId": "act-7",
+    "isCompleted": true,
+    "customGameName": "",
+    "isRanked": true
+  },
+  "players": [
+    {
+      "puuid": "PUUID-PLAYER-01",
+      "gameName": "Alpha",
+      "tagLine": "NA1",
+      "teamId": "Blue",
+      "characterId": "jett-id",
+      "stats": {"score": 320, "kills": 22, "deaths": 14, "assists": 4}
+    },
+    {
+      "puuid": "PUUID-PLAYER-02",
+      "gameName": "Bravo",
+      "tagLine": "NA1",
+      "teamId": "Blue",
+      "characterId": "viper-id",
+      "stats": {"score": 280, "kills": 18, "deaths": 16, "assists": 5}
+    },
+    {
+      "puuid": "PUUID-PLAYER-03",
+      "gameName": "Charlie",
+      "tagLine": "NA1",
+      "teamId": "Blue",
+      "characterId": "killjoy-id",
+      "stats": {"score": 240, "kills": 15, "deaths": 17, "assists": 6}
+    },
+    {
+      "puuid": "PUUID-PLAYER-04",
+      "gameName": "Delta",
+      "tagLine": "NA1",
+      "teamId": "Blue",
+      "characterId": "omen-id",
+      "stats": {"score": 210, "kills": 13, "deaths": 18, "assists": 7}
+    },
+    {
+      "puuid": "PUUID-PLAYER-05",
+      "gameName": "Echo",
+      "tagLine": "NA1",
+      "teamId": "Blue",
+      "characterId": "sova-id",
+      "stats": {"score": 200, "kills": 12, "deaths": 19, "assists": 8}
+    },
+    {
+      "puuid": "PUUID-PLAYER-06",
+      "gameName": "Foxtrot",
+      "tagLine": "EU1",
+      "teamId": "Red",
+      "characterId": "raze-id",
+      "stats": {"score": 310, "kills": 21, "deaths": 13, "assists": 3}
+    },
+    {
+      "puuid": "PUUID-PLAYER-07",
+      "gameName": "Golf",
+      "tagLine": "EU1",
+      "teamId": "Red",
+      "characterId": "brimstone-id",
+      "stats": {"score": 290, "kills": 19, "deaths": 14, "assists": 5}
+    },
+    {
+      "puuid": "PUUID-PLAYER-08",
+      "gameName": "Hotel",
+      "tagLine": "EU1",
+      "teamId": "Red",
+      "characterId": "cypher-id",
+      "stats": {"score": 250, "kills": 16, "deaths": 16, "assists": 4}
+    },
+    {
+      "puuid": "PUUID-PLAYER-09",
+      "gameName": "India",
+      "tagLine": "EU1",
+      "teamId": "Red",
+      "characterId": "phoenix-id",
+      "stats": {"score": 220, "kills": 14, "deaths": 17, "assists": 5}
+    },
+    {
+      "puuid": "PUUID-PLAYER-10",
+      "gameName": "Juliet",
+      "tagLine": "EU1",
+      "teamId": "Red",
+      "characterId": "skye-id",
+      "stats": {"score": 205, "kills": 13, "deaths": 18, "assists": 6}
+    }
+  ],
+  "roundResults": [
+    {
+      "roundNum": 0,
+      "roundResult": "Eliminated",
+      "winningTeam": "Blue",
+      "bombPlanter": "PUUID-PLAYER-01",
+      "bombDefuser": null,
+      "plantRoundTime": 38500,
+      "defuseRoundTime": 0,
+      "playerStats": [
+        {"puuid": "PUUID-PLAYER-01", "kills": [], "score": 220, "damage": []},
+        {"puuid": "PUUID-PLAYER-02", "kills": [], "score": 180, "damage": []},
+        {"puuid": "PUUID-PLAYER-06", "kills": [], "score": 100, "damage": []},
+        {"puuid": "PUUID-PLAYER-07", "kills": [], "score": 95, "damage": []}
+      ]
+    },
+    {
+      "roundNum": 1,
+      "roundResult": "Defused",
+      "winningTeam": "Red",
+      "bombPlanter": "PUUID-PLAYER-02",
+      "bombDefuser": "PUUID-PLAYER-08",
+      "plantRoundTime": 45000,
+      "defuseRoundTime": 80000,
+      "playerStats": [
+        {"puuid": "PUUID-PLAYER-01", "kills": [], "score": 130, "damage": []},
+        {"puuid": "PUUID-PLAYER-08", "kills": [], "score": 240, "damage": []}
+      ]
+    }
+  ]
+}

--- a/services/data_pipeline/tests/fixtures/riot/matchlist.json
+++ b/services/data_pipeline/tests/fixtures/riot/matchlist.json
@@ -1,0 +1,20 @@
+{
+  "puuid": "PUUID-SEED-AAAA",
+  "history": [
+    {
+      "matchId": "match-001",
+      "gameStartTimeMillis": 1714000000000,
+      "queueId": "competitive"
+    },
+    {
+      "matchId": "match-002",
+      "gameStartTimeMillis": 1715000000000,
+      "queueId": "competitive"
+    },
+    {
+      "matchId": "match-old",
+      "gameStartTimeMillis": 1700000000000,
+      "queueId": "competitive"
+    }
+  ]
+}

--- a/services/data_pipeline/tests/test_riot_connector.py
+++ b/services/data_pipeline/tests/test_riot_connector.py
@@ -1,0 +1,472 @@
+"""Tests for the Riot API connector (BUF-82).
+
+Unit cases drive the connector with a fake ``http_get`` so the test
+suite is offline-safe — no real Riot API key required. The integration
+case at the bottom only runs when ``TEST_DATABASE_URL`` is set; that
+gate keeps a fresh clone green while still exercising the full
+``run_ingestion`` -> ``raw_record`` / ``staging_record`` / ``entity_alias``
+chain when a Postgres is available.
+"""
+
+from __future__ import annotations
+
+import copy
+import json
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+from data_pipeline import (
+    IngestionRecord,
+    SchemaDriftError,
+    TransientFetchError,
+    run_ingestion,
+)
+from data_pipeline.connectors.riot import RiotConnector, _parse_retry_after
+from esports_sim.db.enums import EntityType, Platform
+from esports_sim.db.models import EntityAlias, RawRecord, StagingRecord
+from sqlalchemy import select
+
+_FIXTURES = Path(__file__).resolve().parent / "fixtures" / "riot"
+
+
+def _load_fixture(name: str) -> dict[str, Any]:
+    return json.loads((_FIXTURES / name).read_text())
+
+
+# Watermark older than every fixture match so ``fetch`` yields the lot.
+_EPOCH = datetime(1970, 1, 1, tzinfo=UTC)
+
+# Matches ``match-001`` (1714e9 ms) but not ``match-old`` (1700e9 ms).
+# Used by the since-watermark test below.
+_BETWEEN_OLD_AND_NEW = datetime(2024, 4, 1, tzinfo=UTC)
+
+
+# --- fake HTTP plumbing ----------------------------------------------------
+
+
+class _FakeHttp:
+    """Tiny URL-routed fake.
+
+    Each test wires a route map: ``{path_substring: response_dict}`` (or
+    a callable for stateful behaviour). The connector's ``_get`` reads
+    ``status_code``, ``headers``, and ``json`` keys exactly the way the
+    real httpx-backed factory shapes them.
+    """
+
+    def __init__(self, routes: dict[str, Any]) -> None:
+        # Values are either a literal response dict or a callable
+        # ``(url, params) -> response``; we don't bother typing the
+        # union because tests aren't part of the strict-mypy surface.
+        self._routes = routes
+        self.calls: list[tuple[str, dict[str, Any]]] = []
+
+    def __call__(self, url: str, params: dict[str, Any]) -> dict[str, Any]:
+        self.calls.append((url, dict(params)))
+        for needle, resp in self._routes.items():
+            if needle in url:
+                if callable(resp):
+                    return resp(url, params)  # type: ignore[no-any-return]
+                return copy.deepcopy(resp)  # type: ignore[no-any-return]
+        # Surface the unmatched URL clearly — easier to diagnose than a
+        # KeyError from the connector trying to unpack a missing key.
+        raise AssertionError(f"FakeHttp: no route configured for {url}")
+
+
+def _ok(json_body: dict[str, Any]) -> dict[str, Any]:
+    return {"status_code": 200, "headers": {}, "json": json_body}
+
+
+def _ok_match() -> dict[str, Any]:
+    return _ok({"match": _load_fixture("match.json")})
+
+
+def _matchlist_response() -> dict[str, Any]:
+    return _ok(_load_fixture("matchlist.json"))
+
+
+def _make_connector(
+    *,
+    http_get: Any,
+    seed_puuids: list[str] | None = None,
+    sleeper: Any = None,
+) -> RiotConnector:
+    """Helper: build a RiotConnector with a no-op default sleeper.
+
+    Tests that care about the sleep trace pass their own list-appender
+    sleeper; tests that don't care use this one and never observe it.
+    """
+
+    def default_sleeper(_seconds: float) -> None:
+        return None
+
+    return RiotConnector(
+        seed_puuids=seed_puuids or ["PUUID-SEED-AAAA"],
+        http_get=http_get,
+        sleeper=sleeper or default_sleeper,
+    )
+
+
+# --- metadata & construction ----------------------------------------------
+
+
+def test_metadata_properties_match_spec() -> None:
+    connector = _make_connector(http_get=_FakeHttp({}))
+    assert connector.source_name == "riot_api"
+    assert connector.platform is Platform.RIOT_API
+    assert connector.entity_types == (EntityType.PLAYER,)
+    assert connector.cadence.days == 1
+    # Conservative bucket: ~10 rpm steady, burst 20.
+    assert connector.rate_limit.capacity == 20
+    assert connector.rate_limit.refill_per_second == pytest.approx(20.0 / 120.0)
+
+
+def test_constructor_rejects_empty_seed_list() -> None:
+    with pytest.raises(ValueError, match="at least one seed PUUID"):
+        RiotConnector(seed_puuids=[], http_get=_FakeHttp({}))
+
+
+# --- transform / validate -------------------------------------------------
+
+
+def test_transform_yields_one_record_per_player() -> None:
+    """A 10-player match payload produces exactly 10 IngestionRecords.
+
+    Each record carries the player's PUUID as ``platform_id`` and the
+    Riot identity tag ``gameName#tagLine`` as ``platform_name``.
+    """
+    connector = _make_connector(http_get=_FakeHttp({}))
+    payload: dict[str, Any] = {
+        "match_id": "match-001",
+        "puuid_seed": "PUUID-SEED-AAAA",
+        "match": _load_fixture("match.json"),
+    }
+
+    records: list[IngestionRecord] = list(connector.transform(connector.validate(payload)))
+
+    assert len(records) == 10
+    ids = [r.platform_id for r in records]
+    names = [r.platform_name for r in records]
+    assert "PUUID-PLAYER-01" in ids
+    assert "Alpha#NA1" in names
+    # All ten platform_ids are distinct.
+    assert len(set(ids)) == 10
+    # Each record's payload is shaped for downstream stat extraction.
+    sample = next(r for r in records if r.platform_id == "PUUID-PLAYER-01")
+    assert sample.payload["match_id"] == "match-001"
+    assert "match_info" in sample.payload
+    assert sample.payload["this_player"]["puuid"] == "PUUID-PLAYER-01"
+    assert "rounds" in sample.payload
+    assert "roster_puuids" in sample.payload
+    assert len(sample.payload["roster_puuids"]) == 10
+
+
+def test_transform_drops_players_missing_identity() -> None:
+    """Anonymised player blocks (no gameName/tagLine) are skipped, not raised.
+
+    The Riot API ships these for dev accounts and customs; treating them
+    as schema drift would falsely flag every customs match. The
+    connector logs a warning and emits records only for the identifiable
+    players.
+    """
+    connector = _make_connector(http_get=_FakeHttp({}))
+    fixture = _load_fixture("match.json")
+    fixture["players"][0].pop("gameName")
+    payload = {"match_id": "match-001", "puuid_seed": "X", "match": fixture}
+
+    records = list(connector.transform(connector.validate(payload)))
+    assert len(records) == 9  # 10 minus the anonymised one
+    assert "PUUID-PLAYER-01" not in [r.platform_id for r in records]
+
+
+def test_validate_raises_schema_drift_on_missing_match_info() -> None:
+    connector = _make_connector(http_get=_FakeHttp({}))
+    fixture = _load_fixture("match.json")
+    fixture.pop("matchInfo")
+    payload = {"match_id": "x", "puuid_seed": "y", "match": fixture}
+
+    with pytest.raises(SchemaDriftError, match="matchInfo"):
+        connector.validate(payload)
+
+
+def test_validate_raises_schema_drift_on_missing_players() -> None:
+    connector = _make_connector(http_get=_FakeHttp({}))
+    fixture = _load_fixture("match.json")
+    fixture.pop("players")
+    payload = {"match_id": "x", "puuid_seed": "y", "match": fixture}
+
+    with pytest.raises(SchemaDriftError, match="players"):
+        connector.validate(payload)
+
+
+def test_validate_raises_schema_drift_on_non_dict_match_block() -> None:
+    """``match`` field present but not a dict — drift, preserve raw for triage."""
+    connector = _make_connector(http_get=_FakeHttp({}))
+    with pytest.raises(SchemaDriftError, match="match"):
+        connector.validate({"match_id": "x", "puuid_seed": "y", "match": "not a dict"})
+
+
+# --- fetch: 429 / Retry-After / 5xx ---------------------------------------
+
+
+def test_fetch_raises_transient_fetch_error_on_429() -> None:
+    """A 429 on the matchlist endpoint short-circuits the seed.
+
+    The runner skips the row without persisting raw, so the next pass
+    retries the same seed — that's the contract.
+    """
+    sleeps: list[float] = []
+    http = _FakeHttp(
+        {
+            "matchlists/by-puuid": {
+                "status_code": 429,
+                "headers": {"Retry-After": "2"},
+                "json": {"status": {"message": "Rate limit exceeded"}},
+            }
+        }
+    )
+    connector = _make_connector(http_get=http, sleeper=sleeps.append)
+
+    with pytest.raises(TransientFetchError, match="429"):
+        list(connector.fetch(_EPOCH))
+
+    # ``Retry-After: 2`` was honoured before raising.
+    assert sleeps == [2.0]
+
+
+def test_fetch_caps_retry_after_defensively() -> None:
+    """A garbage Retry-After value is capped, not honoured verbatim.
+
+    A buggy or malicious upstream that sends Retry-After: 1000000 must
+    not wedge the run for a million seconds.
+    """
+    sleeps: list[float] = []
+    http = _FakeHttp(
+        {
+            "matchlists/by-puuid": {
+                "status_code": 429,
+                "headers": {"Retry-After": "1000000"},
+                "json": None,
+            }
+        }
+    )
+    connector = _make_connector(http_get=http, sleeper=sleeps.append)
+    with pytest.raises(TransientFetchError):
+        list(connector.fetch(_EPOCH))
+    assert sleeps == [120.0]  # the module's _MAX_RETRY_AFTER_SECONDS
+
+
+def test_fetch_handles_missing_retry_after_header() -> None:
+    """No Retry-After header — no sleep, but still TransientFetchError."""
+    sleeps: list[float] = []
+    http = _FakeHttp(
+        {"matchlists/by-puuid": {"status_code": 429, "headers": {}, "json": None}}
+    )
+    connector = _make_connector(http_get=http, sleeper=sleeps.append)
+    with pytest.raises(TransientFetchError):
+        list(connector.fetch(_EPOCH))
+    assert sleeps == []  # nothing slept; bucket alone gates the next attempt
+
+
+def test_fetch_raises_transient_on_5xx() -> None:
+    http = _FakeHttp(
+        {"matchlists/by-puuid": {"status_code": 503, "headers": {}, "json": None}}
+    )
+    connector = _make_connector(http_get=http)
+    with pytest.raises(TransientFetchError, match="503"):
+        list(connector.fetch(_EPOCH))
+
+
+def test_fetch_raises_schema_drift_on_400() -> None:
+    """Non-rate-limit, non-5xx errors are payload bugs — preserve via SchemaDrift."""
+    http = _FakeHttp(
+        {"matchlists/by-puuid": {"status_code": 404, "headers": {}, "json": None}}
+    )
+    connector = _make_connector(http_get=http)
+    with pytest.raises(SchemaDriftError, match="404"):
+        list(connector.fetch(_EPOCH))
+
+
+def test_fetch_translates_unknown_http_get_exception_to_transient() -> None:
+    """Raw network errors from the http_get shim become TransientFetchError.
+
+    A connect-timeout shouldn't burn the retry slot — the runner needs
+    to skip without persisting raw so the next pass re-tries.
+    """
+
+    def boom(url: str, params: dict[str, Any]) -> dict[str, Any]:
+        raise OSError("connect timeout")
+
+    connector = _make_connector(http_get=boom)
+    with pytest.raises(TransientFetchError, match="connect timeout"):
+        list(connector.fetch(_EPOCH))
+
+
+# --- fetch: since watermark ----------------------------------------------
+
+
+def test_fetch_skips_matches_at_or_before_since() -> None:
+    """``gameStartTimeMillis <= since`` -> match is filtered before the GET.
+
+    The matchlist contains three matches; with ``since`` set between
+    ``match-old`` and the two newer entries, we should never call the
+    detail endpoint for ``match-old``.
+    """
+    http = _FakeHttp(
+        {
+            "matchlists/by-puuid": _matchlist_response(),
+            "matches/match-001": _ok_match(),
+            "matches/match-002": _ok_match(),
+        }
+    )
+    connector = _make_connector(http_get=http)
+
+    payloads = list(connector.fetch(_BETWEEN_OLD_AND_NEW))
+
+    assert {p["match_id"] for p in payloads} == {"match-001", "match-002"}
+    # ``match-old`` was never requested.
+    assert all("match-old" not in url for url, _ in http.calls)
+
+
+def test_fetch_filters_at_inclusive_boundary() -> None:
+    """A match whose timestamp equals ``since`` is excluded (strict >).
+
+    The runner uses ``since`` as the high-water mark of the previous
+    pass; anything at or before it is by definition already known.
+    """
+    http = _FakeHttp(
+        {
+            "matchlists/by-puuid": _matchlist_response(),
+            "matches/match-001": _ok_match(),
+            "matches/match-002": _ok_match(),
+        }
+    )
+    connector = _make_connector(http_get=http)
+    # 1714e9 ms == match-001's start. Equal => filtered.
+    boundary = datetime.fromtimestamp(1_714_000_000, tz=UTC)
+    payloads = list(connector.fetch(boundary))
+    assert {p["match_id"] for p in payloads} == {"match-002"}
+
+
+def test_fetch_skips_matchlist_entries_without_match_id() -> None:
+    """A malformed matchlist entry skips that match — doesn't abort the seed."""
+    matchlist = _load_fixture("matchlist.json")
+    matchlist["history"].append({"gameStartTimeMillis": 1_716_000_000_000})  # no matchId
+    http = _FakeHttp(
+        {
+            "matchlists/by-puuid": _ok(matchlist),
+            "matches/match-001": _ok_match(),
+            "matches/match-002": _ok_match(),
+            "matches/match-old": _ok_match(),
+        }
+    )
+    connector = _make_connector(http_get=http)
+    # ``_EPOCH`` -> include all three with valid matchIds; ignore the 4th
+    payloads = list(connector.fetch(_EPOCH))
+    assert {p["match_id"] for p in payloads} == {"match-001", "match-002", "match-old"}
+
+
+# --- _parse_retry_after edge cases ---------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("value", "expected"),
+    [
+        (None, 0.0),
+        ("", 0.0),
+        ("not-a-number", 0.0),
+        ("-5", 0.0),
+        ("0", 0.0),
+        ("1.5", 1.5),
+        ("60", 60.0),
+        ("999999", 120.0),
+    ],
+)
+def test_parse_retry_after_handles_edge_cases(value: Any, expected: float) -> None:
+    assert _parse_retry_after(value) == expected
+
+
+# --- end-to-end with run_ingestion (skipped without TEST_DATABASE_URL) ----
+
+
+@pytest.mark.integration
+def test_full_pipeline_creates_one_staging_row_per_player(db_session) -> None:  # type: ignore[no-untyped-def]
+    """Drive ``run_ingestion`` against a real DB session.
+
+    Asserts the contract end-to-end: one IngestionRecord per player ->
+    one alias + one staging row per player, all linked to the same
+    canonical entity for that player.
+    """
+    http = _FakeHttp(
+        {
+            "matchlists/by-puuid": _matchlist_response(),
+            "matches/match-001": _ok_match(),
+            "matches/match-002": _ok_match(),
+        }
+    )
+    connector = _make_connector(http_get=http)
+
+    stats = run_ingestion(connector, session=db_session, since=_BETWEEN_OLD_AND_NEW)
+
+    # Two matches, ten players each => 20 staging rows + 20 aliases.
+    # (Both matches use the same player roster in the fixture, so
+    # players 1..10 each get two staging rows but only one alias —
+    # alias upsert keys on (platform, platform_id).)
+    staging = db_session.execute(select(StagingRecord)).scalars().all()
+    assert len(staging) == 20
+
+    aliases = db_session.execute(select(EntityAlias)).scalars().all()
+    assert len(aliases) == 10
+    assert all(a.platform is Platform.RIOT_API for a in aliases)
+    assert all(a.confidence == 1.0 for a in aliases)
+    assert {a.platform_id for a in aliases} == {f"PUUID-PLAYER-{i:02d}" for i in range(1, 11)}
+
+    raw = db_session.execute(select(RawRecord)).scalars().all()
+    assert len(raw) == 2  # one raw row per match
+    assert all(r.source == "riot_api" for r in raw)
+
+    assert stats.processed == 20
+    assert stats.fetched == 2
+
+
+@pytest.mark.integration
+def test_pipeline_idempotent_on_re_run(db_session) -> None:  # type: ignore[no-untyped-def]
+    """Same match, second pass — dedup via content_hash, no new staging rows."""
+
+    def matchlist_response_factory() -> dict[str, Any]:
+        return _matchlist_response()
+
+    http = _FakeHttp(
+        {
+            "matchlists/by-puuid": matchlist_response_factory(),
+            "matches/match-001": _ok_match(),
+            "matches/match-002": _ok_match(),
+        }
+    )
+    connector = _make_connector(http_get=http)
+
+    first = run_ingestion(connector, session=db_session, since=_BETWEEN_OLD_AND_NEW)
+    assert first.processed == 20
+
+    # Re-run: brand new connector, same fake http. The content_hash dedup
+    # in the runner should skip every payload.
+    http2 = _FakeHttp(
+        {
+            "matchlists/by-puuid": matchlist_response_factory(),
+            "matches/match-001": _ok_match(),
+            "matches/match-002": _ok_match(),
+        }
+    )
+    connector2 = _make_connector(http_get=http2)
+    second = run_ingestion(connector2, session=db_session, since=_BETWEEN_OLD_AND_NEW)
+    assert second.duplicates == 2
+    assert second.processed == 0
+
+    # Still the original 20 staging rows, 10 aliases.
+    staging = db_session.execute(select(StagingRecord)).scalars().all()
+    assert len(staging) == 20
+    aliases = db_session.execute(select(EntityAlias)).scalars().all()
+    assert len(aliases) == 10
+
+

--- a/services/data_pipeline/tests/test_riot_connector.py
+++ b/services/data_pipeline/tests/test_riot_connector.py
@@ -343,12 +343,14 @@ def test_fetch_raises_schema_drift_on_400() -> None:
         list(connector.fetch(_EPOCH))
 
 
-def test_fetch_unknown_http_exception_is_skipped_per_seed() -> None:
-    """Raw network errors from the http_get shim become a per-seed skip.
+def test_fetch_transport_failure_is_skipped_per_seed() -> None:
+    """Raw transport failures from the http_get shim become a per-seed skip.
 
-    ``_get`` translates a generic exception into ``TransientFetchError``;
-    that's then caught by ``fetch`` and the seed is skipped without
-    propagating. A connect-timeout shouldn't burn the whole run.
+    ``OSError`` (which covers connect timeouts, DNS misses, TLS
+    handshake failures, etc.) is the canonical "transient transport"
+    shape; ``_get`` translates it to ``TransientFetchError``, which
+    ``fetch`` then catches per-seed. A flaky network shouldn't burn
+    the whole run.
     """
 
     def boom(url: str, params: dict[str, Any]) -> dict[str, Any]:
@@ -357,6 +359,32 @@ def test_fetch_unknown_http_exception_is_skipped_per_seed() -> None:
     connector = _make_connector(http_get=boom)
     payloads = list(connector.fetch(_EPOCH))
     assert payloads == []
+
+
+def test_fetch_propagates_configuration_errors_unchanged() -> None:
+    """Programming / configuration errors must NOT be classified as transient.
+
+    The default ``http_get`` factory raises ``RuntimeError`` when
+    ``RIOT_API_KEY`` is unset. Round 1's catch-all converted that to
+    ``TransientFetchError``; ``fetch`` then logged + skipped per seed,
+    producing a silent no-op run that let production stop ingesting
+    entirely without failing fast. The fix narrows ``_get``'s catch
+    to genuine transport-layer errors (OSError, httpx.HTTPError);
+    everything else propagates so the run aborts loudly with the
+    actual root-cause exception.
+
+    Test rigs that pass an injected ``http_get`` won't hit
+    ``RuntimeError`` from the factory, but a ``RuntimeError`` raised
+    *from inside* the injected callable simulates the same shape and
+    must not be silently swallowed.
+    """
+
+    def misconfigured(url: str, params: dict[str, Any]) -> dict[str, Any]:
+        raise RuntimeError("RIOT_API_KEY not set; cannot make Riot API calls")
+
+    connector = _make_connector(http_get=misconfigured)
+    with pytest.raises(RuntimeError, match="RIOT_API_KEY"):
+        list(connector.fetch(_EPOCH))
 
 
 def test_fetch_dedupes_match_id_across_seeds() -> None:
@@ -410,11 +438,17 @@ def test_fetch_payload_omits_puuid_seed_for_stable_content_hash() -> None:
     same Riot response hash differently if the seed list changes
     between runs, breaking replay detection.
     """
+    # All three matches in the fixture matchlist must have a route —
+    # ``_EPOCH`` lets every entry pass the since-filter, so the
+    # connector will try to GET each one. Without ``match-old`` we'd
+    # hit ``_FakeHttp``'s "unmocked URL" AssertionError, which now
+    # propagates (it's no longer silently swallowed as a transient).
     http = _FakeHttp(
         {
             "matchlists/by-puuid": _matchlist_response(),
             "matches/match-001": _ok_match(),
             "matches/match-002": _ok_match(),
+            "matches/match-old": _ok_match(),
         }
     )
     connector = _make_connector(http_get=http)

--- a/services/data_pipeline/tests/test_riot_connector.py
+++ b/services/data_pipeline/tests/test_riot_connector.py
@@ -20,7 +20,6 @@ import pytest
 from data_pipeline import (
     IngestionRecord,
     SchemaDriftError,
-    TransientFetchError,
     run_ingestion,
 )
 from data_pipeline.connectors.riot import RiotConnector, _parse_retry_after
@@ -210,11 +209,16 @@ def test_validate_raises_schema_drift_on_non_dict_match_block() -> None:
 # --- fetch: 429 / Retry-After / 5xx ---------------------------------------
 
 
-def test_fetch_raises_transient_fetch_error_on_429() -> None:
-    """A 429 on the matchlist endpoint short-circuits the seed.
+def test_fetch_429_on_matchlist_skips_seed_and_continues() -> None:
+    """A 429 on the matchlist endpoint logs + skips that seed.
 
-    The runner skips the row without persisting raw, so the next pass
-    retries the same seed — that's the contract.
+    The runner's post-yield error handling can't see exceptions raised
+    during iterator advancement, so propagating ``TransientFetchError``
+    from inside ``fetch`` would abort the whole pass and skip every
+    remaining seed PUUID. The connector now catches and downgrades to
+    a per-seed skip; the rest of the run still completes. ``Retry-After``
+    is still honoured before the skip so we don't immediately re-pound
+    the rate-limited endpoint inside the same bucket window.
     """
     sleeps: list[float] = []
     http = _FakeHttp(
@@ -228,10 +232,11 @@ def test_fetch_raises_transient_fetch_error_on_429() -> None:
     )
     connector = _make_connector(http_get=http, sleeper=sleeps.append)
 
-    with pytest.raises(TransientFetchError, match="429"):
-        list(connector.fetch(_EPOCH))
+    payloads = list(connector.fetch(_EPOCH))
 
-    # ``Retry-After: 2`` was honoured before raising.
+    # Seed was skipped — no payloads produced — but the run did not
+    # propagate the error. ``Retry-After: 2`` was honoured.
+    assert payloads == []
     assert sleeps == [2.0]
 
 
@@ -239,7 +244,9 @@ def test_fetch_caps_retry_after_defensively() -> None:
     """A garbage Retry-After value is capped, not honoured verbatim.
 
     A buggy or malicious upstream that sends Retry-After: 1000000 must
-    not wedge the run for a million seconds.
+    not wedge the run for a million seconds. The cap is honoured even
+    on the now-skip-not-raise path: the seed is still skipped, but the
+    cap applies first to limit the inline backoff.
     """
     sleeps: list[float] = []
     http = _FakeHttp(
@@ -252,55 +259,123 @@ def test_fetch_caps_retry_after_defensively() -> None:
         }
     )
     connector = _make_connector(http_get=http, sleeper=sleeps.append)
-    with pytest.raises(TransientFetchError):
-        list(connector.fetch(_EPOCH))
+    payloads = list(connector.fetch(_EPOCH))
+    assert payloads == []
     assert sleeps == [120.0]  # the module's _MAX_RETRY_AFTER_SECONDS
 
 
 def test_fetch_handles_missing_retry_after_header() -> None:
-    """No Retry-After header — no sleep, but still TransientFetchError."""
+    """No Retry-After header — no sleep, and the seed is skipped cleanly."""
     sleeps: list[float] = []
-    http = _FakeHttp(
-        {"matchlists/by-puuid": {"status_code": 429, "headers": {}, "json": None}}
-    )
+    http = _FakeHttp({"matchlists/by-puuid": {"status_code": 429, "headers": {}, "json": None}})
     connector = _make_connector(http_get=http, sleeper=sleeps.append)
-    with pytest.raises(TransientFetchError):
-        list(connector.fetch(_EPOCH))
+    payloads = list(connector.fetch(_EPOCH))
+    assert payloads == []
     assert sleeps == []  # nothing slept; bucket alone gates the next attempt
 
 
-def test_fetch_raises_transient_on_5xx() -> None:
-    http = _FakeHttp(
-        {"matchlists/by-puuid": {"status_code": 503, "headers": {}, "json": None}}
-    )
+def test_fetch_5xx_on_matchlist_skips_seed_and_continues() -> None:
+    """5xx is recoverable — log + skip the seed, don't abort the run."""
+    http = _FakeHttp({"matchlists/by-puuid": {"status_code": 503, "headers": {}, "json": None}})
     connector = _make_connector(http_get=http)
-    with pytest.raises(TransientFetchError, match="503"):
-        list(connector.fetch(_EPOCH))
+    payloads = list(connector.fetch(_EPOCH))
+    assert payloads == []
 
 
 def test_fetch_raises_schema_drift_on_400() -> None:
-    """Non-rate-limit, non-5xx errors are payload bugs — preserve via SchemaDrift."""
-    http = _FakeHttp(
-        {"matchlists/by-puuid": {"status_code": 404, "headers": {}, "json": None}}
-    )
+    """Non-rate-limit, non-5xx errors are payload bugs — preserve via SchemaDrift.
+
+    SchemaDriftError still propagates out of ``fetch`` (the connector
+    only absorbs ``TransientFetchError``). A 4xx on a seed PUUID is a
+    permanent miss — bad PUUID, expired key, etc. — and the maintainer
+    needs to see it loudly rather than silently dropping the seed.
+    """
+    http = _FakeHttp({"matchlists/by-puuid": {"status_code": 404, "headers": {}, "json": None}})
     connector = _make_connector(http_get=http)
     with pytest.raises(SchemaDriftError, match="404"):
         list(connector.fetch(_EPOCH))
 
 
-def test_fetch_translates_unknown_http_get_exception_to_transient() -> None:
-    """Raw network errors from the http_get shim become TransientFetchError.
+def test_fetch_unknown_http_exception_is_skipped_per_seed() -> None:
+    """Raw network errors from the http_get shim become a per-seed skip.
 
-    A connect-timeout shouldn't burn the retry slot — the runner needs
-    to skip without persisting raw so the next pass re-tries.
+    ``_get`` translates a generic exception into ``TransientFetchError``;
+    that's then caught by ``fetch`` and the seed is skipped without
+    propagating. A connect-timeout shouldn't burn the whole run.
     """
 
     def boom(url: str, params: dict[str, Any]) -> dict[str, Any]:
         raise OSError("connect timeout")
 
     connector = _make_connector(http_get=boom)
-    with pytest.raises(TransientFetchError, match="connect timeout"):
-        list(connector.fetch(_EPOCH))
+    payloads = list(connector.fetch(_EPOCH))
+    assert payloads == []
+
+
+def test_fetch_dedupes_match_id_across_seeds() -> None:
+    """Two seeds whose matchlists share a match emit it exactly once.
+
+    Tier-1 VCT pros frequently scrim each other; without a per-pass
+    seen-match-id guard, the same 10-player match would be fetched and
+    inserted N times — once per seed. The connector tracks
+    ``seen_match_ids`` for the duration of one ``fetch`` pass so each
+    match flows through exactly once. The second seed's matchlist is
+    still loaded (we need to know which matches it discovered to
+    populate the watermark), but its already-seen entries don't
+    re-fetch the detail endpoint.
+    """
+    shared_match_id = "match-shared"
+    seeds = ["PUUID-A", "PUUID-B"]
+
+    def matchlist_for(_seed: str) -> dict[str, Any]:
+        return {
+            "history": [
+                {"matchId": shared_match_id, "gameStartTimeMillis": 1700000000000},
+            ]
+        }
+
+    detail_calls: list[str] = []
+
+    def fake_http(url: str, _params: dict[str, Any]) -> dict[str, Any]:
+        if "matchlists/by-puuid" in url:
+            return {"status_code": 200, "headers": {}, "json": matchlist_for(url)}
+        if f"matches/{shared_match_id}" in url:
+            detail_calls.append(url)
+            return {"status_code": 200, "headers": {}, "json": _ok_match()["json"]}
+        raise AssertionError(f"unexpected URL: {url}")
+
+    connector = _make_connector(http_get=fake_http, seed_puuids=seeds)
+    payloads = list(connector.fetch(_EPOCH))
+
+    # The shared match is yielded exactly once — even though both seeds
+    # surfaced it via their matchlists.
+    match_ids = [p["match_id"] for p in payloads]
+    assert match_ids == [shared_match_id]
+    # And the detail endpoint was only hit once.
+    assert len(detail_calls) == 1
+
+
+def test_fetch_payload_omits_puuid_seed_for_stable_content_hash() -> None:
+    """Yielded payloads must not include the discovering ``puuid_seed``.
+
+    The runner hashes payload bytes for ``RawRecord.content_hash``
+    dedup; including which seed surfaced the match would make the
+    same Riot response hash differently if the seed list changes
+    between runs, breaking replay detection.
+    """
+    http = _FakeHttp(
+        {
+            "matchlists/by-puuid": _matchlist_response(),
+            "matches/match-001": _ok_match(),
+            "matches/match-002": _ok_match(),
+        }
+    )
+    connector = _make_connector(http_get=http)
+    payloads = list(connector.fetch(_EPOCH))
+    assert payloads, "fixture should have produced at least one match"
+    for payload in payloads:
+        assert "puuid_seed" not in payload
+        assert set(payload.keys()) == {"match_id", "match"}
 
 
 # --- fetch: since watermark ----------------------------------------------
@@ -468,5 +543,3 @@ def test_pipeline_idempotent_on_re_run(db_session) -> None:  # type: ignore[no-u
     assert len(staging) == 20
     aliases = db_session.execute(select(EntityAlias)).scalars().all()
     assert len(aliases) == 10
-
-

--- a/services/data_pipeline/tests/test_riot_connector.py
+++ b/services/data_pipeline/tests/test_riot_connector.py
@@ -206,7 +206,54 @@ def test_validate_raises_schema_drift_on_non_dict_match_block() -> None:
         connector.validate({"match_id": "x", "puuid_seed": "y", "match": "not a dict"})
 
 
+def test_validate_raises_schema_drift_on_non_list_round_results() -> None:
+    """``roundResults`` shape changes are caught at validate, not transform.
+
+    ``transform`` iterates ``roundResults`` and passes each entry to
+    ``_slim_round_for_player`` (expects a dict). A schema change that
+    ships, say, a ``{"rounds": [...]}`` envelope would otherwise raise
+    AttributeError mid-transform and abort the run instead of being
+    classified cleanly as drift. Validate now type-checks the field.
+    """
+    connector = _make_connector(http_get=_FakeHttp({}))
+    fixture = _load_fixture("match.json")
+    fixture["roundResults"] = {"rounds": fixture["roundResults"]}  # wrong shape
+    payload = {"match_id": "x", "puuid_seed": "y", "match": fixture}
+
+    with pytest.raises(SchemaDriftError, match="roundResults"):
+        connector.validate(payload)
+
+
 # --- fetch: 429 / Retry-After / 5xx ---------------------------------------
+
+
+def test_fetch_429_honours_retry_after_with_lowercase_header_key() -> None:
+    """``Retry-After`` lookup must be case-insensitive.
+
+    ``httpx.Response.headers`` becomes a plain ``dict`` with lower-case
+    keys when the production factory does ``dict(response.headers)``,
+    so the connector's ``_get`` reads ``retry-after`` from a real 429.
+    A naive ``headers.get("Retry-After")`` would silently miss this
+    and skip the documented backoff sleep — causing immediate retries
+    against an already rate-limited Riot endpoint.
+    """
+    sleeps: list[float] = []
+    http = _FakeHttp(
+        {
+            "matchlists/by-puuid": {
+                "status_code": 429,
+                # Lower-case key, mimicking the production httpx-backed
+                # factory's headers dict.
+                "headers": {"retry-after": "3"},
+                "json": None,
+            }
+        }
+    )
+    connector = _make_connector(http_get=http, sleeper=sleeps.append)
+    payloads = list(connector.fetch(_EPOCH))
+
+    assert payloads == []
+    assert sleeps == [3.0]
 
 
 def test_fetch_429_on_matchlist_skips_seed_and_continues() -> None:

--- a/uv.lock
+++ b/uv.lock
@@ -190,12 +190,14 @@ version = "0.0.1"
 source = { editable = "services/data_pipeline" }
 dependencies = [
     { name = "esports-sim-shared" },
+    { name = "httpx" },
     { name = "structlog" },
 ]
 
 [package.metadata]
 requires-dist = [
     { name = "esports-sim-shared", editable = "packages/shared" },
+    { name = "httpx", specifier = ">=0.27" },
     { name = "structlog", specifier = ">=24.1" },
 ]
 


### PR DESCRIPTION
## Summary
- Adds `RiotConnector(Connector)` for VALORANT match history + per-player perspective ingestion via the Riot Games API. Riot is the highest-priority source (BUF-12 source-priority list) — aliases land at confidence 1.0 keyed on PUUID.
- Conservative default `RateLimit(capacity=20, refill_per_second=20/120)` (~10 req/min steady, burst 20). Constructor-overridable for prod tuning.
- 429 handling reads `Retry-After` (capped at 120s defensively), sleeps inside the `http_get` wrapper, then raises `TransientFetchError` so the runner skips without persisting raw and the next scheduled run retries naturally. 5xx also → transient; 4xx → `SchemaDriftError` so raw is preserved.
- `http_get` injection seam keeps tests offline; default factory lazy-imports `httpx` and reads `RIOT_API_KEY` from env.

## Out of scope (deferred)
- **`player_match_stat` table and per-round stat extraction** (ACS / ADR / HS% / FK / FD / plants / defuses / ability casts). The table doesn't exist yet and is its own design exercise. This PR ships the full match-from-this-player's-perspective payload to `staging_record.payload` so a downstream extractor can run against it.
- Backfill orchestration (patch 5.0 onward) — `cadence` is the daily-pull hint; bulk historical loads are a manual run with an old `since`.
- Multi-region routing — `region` is a constructor knob (default `americas`); one ingest pass per region, scheduler fans out.

## Test plan
- [x] `uv run ruff check services/data_pipeline`
- [x] `uv run mypy`
- [x] `uv run pytest services/data_pipeline/tests/test_riot_connector.py` — 24 passed, 2 integration skipped
- [ ] Reviewer: run integration cases with `TEST_DATABASE_URL` set
- [ ] Reviewer: smoke against a sandbox key with one tier-1 PUUID and verify Retry-After backoff in the wild

Linear: https://linear.app/buffalo-studios/issue/BUF-82/riot-api-connector-match-history-and-player-stats

🤖 Generated with [Claude Code](https://claude.com/claude-code)