### PR TITLE
Close coverage gaps: patch-notes runner, budget caps/CLI, connector ABC, top-level CLI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,5 +63,17 @@ jobs:
       - name: Typecheck (mypy)
         run: uv run mypy
 
-      - name: Test (pytest)
-        run: uv run pytest
+      - name: Test + coverage (pytest)
+        # ``make coverage`` runs the full suite with line+branch coverage
+        # and fails the build if it drops below COVERAGE_FAIL_UNDER (set
+        # in the Makefile). Postgres is up via the ``services`` block
+        # above, so the @pytest.mark.integration tests run here too.
+        run: make coverage
+
+      - name: Upload coverage report
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: coverage-xml
+          path: coverage.xml
+          if-no-files-found: ignore

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,12 @@
 
 SHELL := /bin/bash
 
-.PHONY: help dev up down sync migrate test lint format typecheck precommit ci clean
+.PHONY: help dev up down sync migrate test coverage lint format typecheck precommit ci clean
+
+# Minimum line coverage the ``make coverage`` / ``make ci`` targets enforce.
+# Picked to sit just under the suite's measured number so the ratchet is
+# locked in without false-failing the next PR. Bump as coverage grows.
+COVERAGE_FAIL_UNDER ?= 80
 
 help:
 	@echo "Targets:"
@@ -15,11 +20,12 @@ help:
 	@echo "  sync        Resolve and install the uv workspace (incl. dev group)."
 	@echo "  migrate     Apply Alembic migrations against \$$DATABASE_URL."
 	@echo "  test        Run pytest across all workspace members."
+	@echo "  coverage    Run pytest with line+branch coverage; fail under \$$COVERAGE_FAIL_UNDER (currently $(COVERAGE_FAIL_UNDER))."
 	@echo "  lint        Run ruff + black --check."
 	@echo "  format      Apply ruff --fix and black."
 	@echo "  typecheck   Run mypy."
 	@echo "  precommit   Run all configured pre-commit hooks on every file."
-	@echo "  ci          Lint + typecheck + test (mirrors CI)."
+	@echo "  ci          Lint + typecheck + coverage (mirrors CI)."
 	@echo "  clean       Tear down volumes and caches."
 
 dev: sync up
@@ -49,6 +55,19 @@ migrate:
 test:
 	uv run pytest
 
+coverage:
+	# Run the full suite under coverage and fail the build if the line
+	# coverage drops below ``$$COVERAGE_FAIL_UNDER``. ``term-missing``
+	# prints uncovered lines inline so a regression points straight at
+	# the file that lost coverage. Configuration (source paths, omit
+	# patterns, branch coverage) lives in pyproject.toml under
+	# ``[tool.coverage.*]``.
+	uv run pytest \
+		--cov \
+		--cov-report=term-missing \
+		--cov-report=xml \
+		--cov-fail-under=$(COVERAGE_FAIL_UNDER)
+
 lint:
 	uv run ruff check .
 	uv run black --check .
@@ -63,7 +82,7 @@ typecheck:
 precommit:
 	uv run pre-commit run --all-files
 
-ci: lint typecheck test
+ci: lint typecheck coverage
 
 clean:
 	docker compose down -v

--- a/packages/shared/tests/test_budget_caps.py
+++ b/packages/shared/tests/test_budget_caps.py
@@ -1,0 +1,130 @@
+"""Tests for ``esports_sim.budget.caps`` — env-driven cap configuration (BUF-22).
+
+The governor reads ``BudgetCaps`` on every call, including the
+break-glass override flag. Lock down the env-parsing behaviour so a
+typo in the env name (or a regression in the truthy-string set)
+doesn't silently disable enforcement.
+"""
+
+from __future__ import annotations
+
+import pytest
+from esports_sim.budget.caps import (
+    DEFAULT_PURPOSE_CAPS_USD,
+    DEFAULT_WEEKLY_HARD_CAP_USD,
+    BudgetCaps,
+    default_caps,
+)
+
+# --- defaults -------------------------------------------------------------
+
+
+def test_default_constructor_uses_module_constants() -> None:
+    caps = BudgetCaps()
+    assert caps.weekly_hard_cap_usd == DEFAULT_WEEKLY_HARD_CAP_USD
+    # The default purpose-caps dict is *copied*, not aliased — so a
+    # mutation on one ``BudgetCaps`` instance can't bleed into others.
+    assert caps.purpose_caps_usd == DEFAULT_PURPOSE_CAPS_USD
+    assert caps.purpose_caps_usd is not DEFAULT_PURPOSE_CAPS_USD
+    assert caps.override_disable_caps is False
+
+
+def test_default_caps_helper_matches_default_constructor() -> None:
+    assert default_caps() == BudgetCaps()
+
+
+def test_per_instance_purpose_caps_are_independent() -> None:
+    """Mutating one instance's purpose_caps_usd must not leak into another.
+
+    The dataclass uses ``default_factory=lambda: dict(DEFAULT_...)`` to
+    avoid the classic shared-default-dict footgun.
+    """
+    a = BudgetCaps()
+    a.purpose_caps_usd["personality"] = 999.0
+    b = BudgetCaps()
+    assert b.purpose_caps_usd["personality"] == DEFAULT_PURPOSE_CAPS_USD["personality"]
+
+
+def test_caps_is_frozen() -> None:
+    """Frozen so callers can't accidentally mutate the configured cap.
+
+    The class is ``@dataclass(frozen=True)``; reassignment must raise.
+    """
+    caps = BudgetCaps()
+    with pytest.raises(Exception):  # noqa: B017 - dataclasses raises FrozenInstanceError
+        caps.weekly_hard_cap_usd = 99.0  # type: ignore[misc]
+
+
+# --- cap_for() lookup -----------------------------------------------------
+
+
+def test_cap_for_returns_configured_value() -> None:
+    caps = BudgetCaps()
+    assert caps.cap_for("personality") == DEFAULT_PURPOSE_CAPS_USD["personality"]
+
+
+def test_cap_for_unknown_purpose_returns_none() -> None:
+    """Unknown purposes have no soft cap and are bounded only by the hard cap.
+
+    ``None`` is the documented "no soft cap" signal — the governor
+    treats it as "skip the per-purpose check, fall through to the
+    weekly hard cap".
+    """
+    assert BudgetCaps().cap_for("not-a-real-purpose") is None
+
+
+# --- from_env() parsing ---------------------------------------------------
+
+
+def test_from_env_with_no_vars_matches_defaults(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("NEXUS_BUDGET_WEEKLY_HARD_CAP_USD", raising=False)
+    monkeypatch.delenv("NEXUS_BUDGET_DISABLE_CAPS", raising=False)
+    caps = BudgetCaps.from_env()
+    assert caps.weekly_hard_cap_usd == DEFAULT_WEEKLY_HARD_CAP_USD
+    assert caps.override_disable_caps is False
+
+
+def test_from_env_overrides_weekly_cap(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("NEXUS_BUDGET_WEEKLY_HARD_CAP_USD", "12.50")
+    monkeypatch.delenv("NEXUS_BUDGET_DISABLE_CAPS", raising=False)
+    caps = BudgetCaps.from_env()
+    assert caps.weekly_hard_cap_usd == pytest.approx(12.50)
+
+
+def test_from_env_propagates_invalid_float(monkeypatch: pytest.MonkeyPatch) -> None:
+    """A garbled env value must fail loud, not silently fall back to the default.
+
+    Prefer a noisy startup error over a quiet "looks fine" config that
+    invisibly halves the cap.
+    """
+    monkeypatch.setenv("NEXUS_BUDGET_WEEKLY_HARD_CAP_USD", "not-a-number")
+    with pytest.raises(ValueError):
+        BudgetCaps.from_env()
+
+
+@pytest.mark.parametrize("value", ["1", "true", "TRUE", "True", "yes", "YES", "Yes"])
+def test_from_env_truthy_values_disable_caps(monkeypatch: pytest.MonkeyPatch, value: str) -> None:
+    """Recognised truthy strings flip the override flag, regardless of case."""
+    monkeypatch.setenv("NEXUS_BUDGET_DISABLE_CAPS", value)
+    monkeypatch.delenv("NEXUS_BUDGET_WEEKLY_HARD_CAP_USD", raising=False)
+    assert BudgetCaps.from_env().override_disable_caps is True
+
+
+@pytest.mark.parametrize("value", ["", "0", "false", "no", "off", "disabled", "FALSE"])
+def test_from_env_non_truthy_values_keep_caps_enforced(
+    monkeypatch: pytest.MonkeyPatch, value: str
+) -> None:
+    """Anything outside the canonical truthy set leaves enforcement on.
+
+    Critical for safety: a misspelled "ture" must NOT disable enforcement.
+    """
+    monkeypatch.setenv("NEXUS_BUDGET_DISABLE_CAPS", value)
+    monkeypatch.delenv("NEXUS_BUDGET_WEEKLY_HARD_CAP_USD", raising=False)
+    assert BudgetCaps.from_env().override_disable_caps is False
+
+
+def test_from_env_preserves_purpose_caps(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Per-purpose soft caps come from the module default; from_env doesn't drop them."""
+    monkeypatch.setenv("NEXUS_BUDGET_WEEKLY_HARD_CAP_USD", "100.0")
+    caps = BudgetCaps.from_env()
+    assert caps.purpose_caps_usd == DEFAULT_PURPOSE_CAPS_USD

--- a/packages/shared/tests/test_budget_cli.py
+++ b/packages/shared/tests/test_budget_cli.py
@@ -1,0 +1,107 @@
+"""``nexus budget`` CLI surface (BUF-22).
+
+Exercises the dispatcher (:func:`esports_sim.cli.main`) with the
+``budget`` subcommand so the argparse wiring, default values, and exit
+codes stay locked down independently of the underlying ``Ledger`` /
+``summarize_window`` plumbing (which has its own tests).
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from esports_sim.cli import main as cli_main
+
+
+def test_budget_report_prints_digest_with_default_window(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """``nexus budget report --db <path>`` exits 0 and prints a digest.
+
+    No ledger entries yet — the digest is the empty case, but the
+    command must succeed and the formatted output must hit stdout.
+    """
+    db = tmp_path / "budget.sqlite"
+    rc = cli_main(["budget", "report", "--db", str(db)])
+    assert rc == 0
+    out = capsys.readouterr().out
+    # ``format_digest`` always renders a header row mentioning the
+    # weekly cap; assert we got *something* rendered rather than an
+    # empty string.
+    assert out.strip() != ""
+
+
+def test_budget_report_accepts_custom_window(
+    tmp_path: Path, capsys: pytest.CaptureFixture[str]
+) -> None:
+    """``--days`` is forwarded to ``summarize_window`` as a timedelta."""
+    db = tmp_path / "budget.sqlite"
+    rc = cli_main(["budget", "report", "--db", str(db), "--days", "14"])
+    assert rc == 0
+    assert capsys.readouterr().out.strip() != ""
+
+
+def test_budget_report_creates_db_parent_directory(tmp_path: Path) -> None:
+    """Passing ``--db`` to a non-existent dir is fine — Ledger mkdirs.
+
+    Lets an operator point the CLI at a fresh path without manually
+    creating the directory first.
+    """
+    db = tmp_path / "nested" / "dir" / "budget.sqlite"
+    rc = cli_main(["budget", "report", "--db", str(db)])
+    assert rc == 0
+    assert db.exists()
+
+
+def test_budget_subcommand_requires_inner_command(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``nexus budget`` without ``report`` must fail loud, not run silently.
+
+    The subparser is configured ``required=True``; argparse will exit
+    with code 2 and print a usage error to stderr.
+    """
+    with pytest.raises(SystemExit) as exc_info:
+        cli_main(["budget"])
+    assert exc_info.value.code == 2
+    err = capsys.readouterr().err
+    assert "budget" in err.lower()
+
+
+def test_unknown_budget_subcommand_rejected_by_argparse(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """A typo in the subcommand triggers argparse's invalid-choice exit."""
+    with pytest.raises(SystemExit) as exc_info:
+        cli_main(["budget", "nope"])
+    # argparse exits 2 for an invalid-choice error.
+    assert exc_info.value.code == 2
+
+
+def test_budget_report_help_lists_known_flags(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``nexus budget report --help`` lists ``--days`` and ``--db``.
+
+    A regression that drops a flag should fail this test before it
+    reaches an operator's terminal.
+    """
+    with pytest.raises(SystemExit) as exc_info:
+        cli_main(["budget", "report", "--help"])
+    # ``--help`` exits 0.
+    assert exc_info.value.code == 0
+    out = capsys.readouterr().out
+    assert "--days" in out
+    assert "--db" in out
+
+
+def test_top_level_help_lists_budget_subcommand(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """The dispatcher's help text mentions ``budget`` so operators discover it."""
+    with pytest.raises(SystemExit) as exc_info:
+        cli_main(["--help"])
+    assert exc_info.value.code == 0
+    out = capsys.readouterr().out
+    assert "budget" in out

--- a/packages/shared/tests/test_cli.py
+++ b/packages/shared/tests/test_cli.py
@@ -1,0 +1,105 @@
+"""``esports_sim.cli`` — the top-level ``nexus`` dispatcher.
+
+Each subcommand has its own test file (``test_budget_cli`` /
+``test_registry_cli``) but the dispatcher itself — wiring up the
+``budget`` and ``run`` subparsers, exit codes, ``--help``, and
+unknown-command handling — has no other coverage. A regression that
+forgot to register a subparser, or that flipped the ``required=True``
+bit on the top-level parser, would silently break the CLI without
+failing any of the per-subcommand tests.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+from esports_sim.cli import _build_parser
+from esports_sim.cli import main as cli_main
+
+
+def test_build_parser_registers_known_subcommands() -> None:
+    """Both subcommands must be reachable from the top-level parser.
+
+    Read the choices off the ``command`` subparser action — independent
+    of help-text parsing.
+    """
+    parser = _build_parser()
+    sub_actions = [
+        a
+        for a in parser._actions  # noqa: SLF001 - argparse public surface is thin
+        if isinstance(a, type(parser._subparsers._group_actions[0]))  # type: ignore[union-attr]
+    ]
+    assert sub_actions, "expected a subparsers action on the top-level parser"
+    choices = sub_actions[0].choices  # type: ignore[attr-defined]
+    assert "budget" in choices
+    assert "run" in choices
+
+
+def test_main_with_no_argv_exits_two() -> None:
+    """Empty argv -> argparse "the following arguments are required" -> exit 2.
+
+    The dispatcher's subparser is ``required=True``; argparse converts
+    that into a ``SystemExit(2)``.
+    """
+    with pytest.raises(SystemExit) as exc_info:
+        cli_main([])
+    assert exc_info.value.code == 2
+
+
+def test_main_with_unknown_subcommand_exits_two(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    with pytest.raises(SystemExit) as exc_info:
+        cli_main(["definitely-not-a-subcommand"])
+    assert exc_info.value.code == 2
+    err = capsys.readouterr().err
+    assert "invalid choice" in err.lower()
+
+
+def test_main_routes_budget_subcommand(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """``nexus budget report`` reaches the budget runner and exits 0."""
+    db = tmp_path / "budget.sqlite"
+    rc = cli_main(["budget", "report", "--db", str(db)])
+    assert rc == 0
+    # Some output was rendered — we don't pin the exact format here
+    # (that's `test_budget_report.py`'s job).
+    assert capsys.readouterr().out.strip() != ""
+
+
+def test_main_routes_run_subcommand(tmp_path: Path, capsys: pytest.CaptureFixture[str]) -> None:
+    """``nexus run register`` reaches the registry runner and exits 0.
+
+    Mirrors the registry CLI smoke test but lives here to assert
+    *dispatch*, not registry behaviour.
+    """
+    cfg = tmp_path / "configs" / "graph" / "era_7.09.yaml"
+    cfg.parent.mkdir(parents=True)
+    cfg.write_text("kind: graph-snapshot\nera: 7.09\n", encoding="utf-8")
+
+    rc = cli_main(
+        [
+            "run",
+            "--db",
+            str(tmp_path / "registry.db"),
+            "--runs-dir",
+            str(tmp_path / "runs"),
+            "register",
+            "--kind=graph-snapshot",
+            f"--config={cfg}",
+        ]
+    )
+    assert rc == 0
+    assert capsys.readouterr().out.strip().startswith("graph-snapshot-")
+
+
+def test_main_help_lists_both_subcommands(
+    capsys: pytest.CaptureFixture[str],
+) -> None:
+    """``nexus --help`` advertises both ``budget`` and ``run`` so operators discover them."""
+    with pytest.raises(SystemExit) as exc_info:
+        cli_main(["--help"])
+    assert exc_info.value.code == 0
+    out = capsys.readouterr().out
+    assert "budget" in out
+    assert "run" in out

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -23,6 +23,7 @@ match-wm = { workspace = true }
 [dependency-groups]
 dev = [
     "pytest>=8.0",
+    "pytest-cov>=5.0",
     "pytest-picked>=0.5",
     "ruff>=0.4",
     "black>=24.0",
@@ -45,6 +46,42 @@ testpaths = [
 addopts = "-ra --import-mode=importlib"
 markers = [
     "integration: requires a running Postgres (TEST_DATABASE_URL set). Skipped by default on a fresh clone.",
+]
+
+# --- Coverage -----------------------------------------------------------------
+# ``make coverage`` and ``make ci`` enable --cov via the per-target overrides;
+# the defaults here keep the data clean (parallel-safe, branches counted) and
+# tell coverage where production code lives so reports are scoped to it.
+
+[tool.coverage.run]
+branch = true
+parallel = true
+source = [
+    "packages/shared/src",
+    "services/data_pipeline/src",
+    "services/ecosystem/src",
+    "services/match_wm/src",
+]
+omit = [
+    # Test code itself is not interesting in the report; tests/ contains
+    # support fixtures and stubs whose execution is incidental.
+    "*/tests/*",
+    # Alembic auto-generated migration scripts: production code, but
+    # exercised by ``alembic upgrade``, not by pytest. Including them
+    # would push the headline number down without a useful signal.
+    "*/alembic/versions/*",
+]
+
+[tool.coverage.report]
+show_missing = true
+skip_covered = false
+# Lines tagged ``# pragma: no cover`` are excluded; add a couple of
+# repo-wide patterns for the same intent without the magic comment.
+exclude_lines = [
+    "pragma: no cover",
+    "raise NotImplementedError",
+    "if __name__ == .__main__.:",
+    "if TYPE_CHECKING:",
 ]
 
 # --- Tooling configuration shared by every workspace member -------------------

--- a/services/data_pipeline/tests/test_connector_contract.py
+++ b/services/data_pipeline/tests/test_connector_contract.py
@@ -1,0 +1,270 @@
+"""Direct tests for the ``Connector`` ABC + ``IngestionRecord`` DTO (BUF-9).
+
+The runner trusts both contracts implicitly — `IngestionRecord` is the
+DTO the connector hands the resolver, and `Connector` is the interface
+the runner walks. Each connector test file exercises these by accident
+through end-to-end pipelines, but a regression in the contract itself
+(e.g. relaxing ``extra="forbid"``, dropping a column-length cap) would
+silently shrink the validation surface across all connectors at once.
+This file pins those contracts down.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from datetime import datetime, timedelta
+from typing import Any
+
+import pytest
+from data_pipeline.connector import Connector, IngestionRecord, RateLimit
+from esports_sim.db.enums import EntityType, Platform
+from pydantic import ValidationError
+
+# --- IngestionRecord -----------------------------------------------------
+
+
+class TestIngestionRecord:
+    def test_round_trip_with_all_fields_set(self) -> None:
+        rec = IngestionRecord(
+            entity_type=EntityType.PLAYER,
+            platform_id="riot:tenz",
+            platform_name="TenZ",
+            payload={"team": "SEN", "country": "CA"},
+        )
+        assert rec.entity_type == EntityType.PLAYER
+        assert rec.platform_id == "riot:tenz"
+        assert rec.platform_name == "TenZ"
+        assert rec.payload == {"team": "SEN", "country": "CA"}
+
+    def test_platform_id_min_length_rejected(self) -> None:
+        # ``platform_id`` is the resolver's exact-match key; an empty
+        # string would silently merge unrelated rows.
+        with pytest.raises(ValidationError):
+            IngestionRecord(
+                entity_type=EntityType.PLAYER,
+                platform_id="",
+                platform_name="x",
+                payload={},
+            )
+
+    def test_platform_id_max_length_matches_alias_column(self) -> None:
+        # 255 chars is the alias-table cap; emitting longer surfaces here
+        # rather than as a Postgres truncation that would lose context.
+        with pytest.raises(ValidationError):
+            IngestionRecord(
+                entity_type=EntityType.PLAYER,
+                platform_id="x" * 256,
+                platform_name="x",
+                payload={},
+            )
+
+    def test_platform_name_min_length_rejected(self) -> None:
+        with pytest.raises(ValidationError):
+            IngestionRecord(
+                entity_type=EntityType.PLAYER,
+                platform_id="riot:tenz",
+                platform_name="",
+                payload={},
+            )
+
+    def test_platform_name_max_length_matches_alias_column(self) -> None:
+        with pytest.raises(ValidationError):
+            IngestionRecord(
+                entity_type=EntityType.PLAYER,
+                platform_id="riot:tenz",
+                platform_name="y" * 256,
+                payload={},
+            )
+
+    def test_extra_fields_rejected(self) -> None:
+        # ``model_config = ConfigDict(extra="forbid")``: a connector
+        # silently dropping a column-name typo is exactly the regression
+        # this catches.
+        with pytest.raises(ValidationError):
+            IngestionRecord(
+                entity_type=EntityType.PLAYER,
+                platform_id="riot:tenz",
+                platform_name="TenZ",
+                payload={},
+                country="CA",  # type: ignore[call-arg]
+            )
+
+    def test_frozen_after_construction(self) -> None:
+        rec = IngestionRecord(
+            entity_type=EntityType.PLAYER,
+            platform_id="riot:tenz",
+            platform_name="TenZ",
+            payload={},
+        )
+        with pytest.raises(ValidationError):
+            rec.platform_id = "different"  # type: ignore[misc]
+
+    def test_payload_accepts_arbitrary_json_shape(self) -> None:
+        # ``payload`` is dict[str, Any] by design — the runner persists
+        # it verbatim on raw_record / staging_record. No schema checks.
+        rec = IngestionRecord(
+            entity_type=EntityType.TEAM,
+            platform_id="vlr:101",
+            platform_name="Sentinels",
+            payload={"nested": {"region": "americas"}, "rank": 1, "active": True},
+        )
+        assert rec.payload["nested"]["region"] == "americas"
+
+    def test_entity_type_must_be_known_enum_value(self) -> None:
+        # An unknown EntityType string surfaces as a ValidationError; the
+        # alternative — a silent string passthrough — would let drifting
+        # connectors mint rows the rest of the pipeline can't process.
+        with pytest.raises(ValidationError):
+            IngestionRecord(
+                entity_type="not-a-real-type",  # type: ignore[arg-type]
+                platform_id="x",
+                platform_name="x",
+                payload={},
+            )
+
+
+# --- RateLimit -----------------------------------------------------------
+
+
+class TestRateLimit:
+    """A handful of guard-rail tests; broader coverage lives in test_rate_limiter.py."""
+
+    def test_capacity_below_one_rejected(self) -> None:
+        with pytest.raises(ValueError, match="capacity"):
+            RateLimit(capacity=0, refill_per_second=1.0)
+
+    def test_negative_capacity_rejected(self) -> None:
+        with pytest.raises(ValueError, match="capacity"):
+            RateLimit(capacity=-5, refill_per_second=1.0)
+
+    def test_refill_zero_rejected(self) -> None:
+        with pytest.raises(ValueError, match="refill"):
+            RateLimit(capacity=1, refill_per_second=0.0)
+
+    def test_refill_negative_rejected(self) -> None:
+        with pytest.raises(ValueError, match="refill"):
+            RateLimit(capacity=1, refill_per_second=-1.0)
+
+    def test_frozen_dataclass_cannot_be_mutated(self) -> None:
+        rl = RateLimit(capacity=10, refill_per_second=1.0)
+        with pytest.raises(Exception):  # noqa: B017 - FrozenInstanceError
+            rl.capacity = 99  # type: ignore[misc]
+
+
+# --- Connector ABC -------------------------------------------------------
+
+
+def test_connector_cannot_be_instantiated_directly() -> None:
+    """Connector is abstract; constructing it must raise TypeError."""
+    with pytest.raises(TypeError):
+        Connector()  # type: ignore[abstract]
+
+
+def test_subclass_missing_required_property_cannot_instantiate() -> None:
+    """A partial implementation should fail at construction.
+
+    The runner has no business calling ``source_name`` on a connector
+    that forgot to declare it; Python's ABCMeta enforces this for us.
+    """
+
+    class _Incomplete(Connector):
+        # Missing source_name, platform, entity_types, cadence, rate_limit.
+        def fetch(self, since: datetime) -> Iterable[dict[str, Any]]:
+            return iter(())
+
+        def validate(self, raw_payload: dict[str, Any]) -> dict[str, Any]:
+            return raw_payload
+
+        def transform(self, validated_payload: dict[str, Any]) -> Iterable[IngestionRecord]:
+            return iter(())
+
+    with pytest.raises(TypeError):
+        _Incomplete()  # type: ignore[abstract]
+
+
+def test_subclass_missing_required_method_cannot_instantiate() -> None:
+    """A subclass that declares the metadata but omits ``fetch`` is also abstract."""
+
+    class _NoFetch(Connector):
+        @property
+        def source_name(self) -> str:
+            return "x"
+
+        @property
+        def platform(self) -> Platform:
+            return Platform.VLR
+
+        @property
+        def entity_types(self) -> tuple[EntityType, ...]:
+            return (EntityType.PLAYER,)
+
+        @property
+        def cadence(self) -> timedelta:
+            return timedelta(hours=1)
+
+        @property
+        def rate_limit(self) -> RateLimit:
+            return RateLimit(capacity=1, refill_per_second=1.0)
+
+        # Missing fetch / validate / transform.
+
+    with pytest.raises(TypeError):
+        _NoFetch()  # type: ignore[abstract]
+
+
+def test_fully_implemented_subclass_instantiates_and_exposes_metadata() -> None:
+    """Smoke-test the ABC by walking the public surface end-to-end.
+
+    A regression that drops a property from the ABC would surface as a
+    missing attribute here, well before a real connector hits prod.
+    """
+
+    class _OK(Connector):
+        @property
+        def source_name(self) -> str:
+            return "vlr"
+
+        @property
+        def platform(self) -> Platform:
+            return Platform.VLR
+
+        @property
+        def entity_types(self) -> tuple[EntityType, ...]:
+            return (EntityType.PLAYER, EntityType.TEAM)
+
+        @property
+        def cadence(self) -> timedelta:
+            return timedelta(hours=6)
+
+        @property
+        def rate_limit(self) -> RateLimit:
+            return RateLimit(capacity=10, refill_per_second=2.0)
+
+        def fetch(self, since: datetime) -> Iterable[dict[str, Any]]:
+            yield {"id": "1"}
+
+        def validate(self, raw_payload: dict[str, Any]) -> dict[str, Any]:
+            return raw_payload
+
+        def transform(self, validated_payload: dict[str, Any]) -> Iterable[IngestionRecord]:
+            yield IngestionRecord(
+                entity_type=EntityType.PLAYER,
+                platform_id=str(validated_payload["id"]),
+                platform_name="x",
+                payload=validated_payload,
+            )
+
+    connector = _OK()
+    assert connector.source_name == "vlr"
+    assert connector.platform is Platform.VLR
+    assert EntityType.PLAYER in connector.entity_types
+    assert connector.cadence == timedelta(hours=6)
+    assert connector.rate_limit.capacity == 10
+
+    payloads = list(connector.fetch(datetime(2026, 1, 1)))
+    assert payloads == [{"id": "1"}]
+
+    records = list(connector.transform(connector.validate(payloads[0])))
+    assert len(records) == 1
+    assert records[0].platform_id == "1"
+    assert records[0].entity_type == EntityType.PLAYER

--- a/services/data_pipeline/tests/test_patch_notes_runner.py
+++ b/services/data_pipeline/tests/test_patch_notes_runner.py
@@ -1,0 +1,599 @@
+"""Direct unit tests for ``data_pipeline.patch_notes_runner`` (BUF-83).
+
+The patch-notes runner is an orchestrator that mirrors the entity
+``run_ingestion`` pipeline but persists ``PatchNote`` rows rather than
+resolving aliases. Existing coverage lives inside
+:mod:`tests.test_playvalorant_connector` and is therefore implicitly
+coupled to that one connector's HTML fixtures. This module exercises
+the runner against hand-built ``PatchNoteConnector`` stubs so the
+contracts (UPSERT idempotency, schema-drift skipping, transient-error
+retry semantics, fatal connector errors, rate-limiter wiring,
+``PatchNoteRecord`` validation) stay covered independently.
+
+The runner UPSERTs through SQLAlchemy. To keep these tests runnable
+without ``TEST_DATABASE_URL``, the integration cases use a small
+in-memory ``_FakeSession`` keyed on ``(source, patch_version)`` that
+implements the slice of the Session API ``_upsert_patch_note``
+actually touches. Tests that need a real database (e.g. column-level
+checks) are marked ``@pytest.mark.integration`` and skip cleanly on a
+fresh clone.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import UTC, datetime, timedelta
+from typing import Any
+
+import pytest
+from data_pipeline.connector import RateLimit
+from data_pipeline.errors import IngestionError, SchemaDriftError, TransientFetchError
+from data_pipeline.patch_notes_runner import (
+    PatchNoteConnector,
+    PatchNoteRecord,
+    PatchNotesStats,
+    run_patch_notes_ingestion,
+)
+from data_pipeline.rate_limiter import TokenBucket
+from pydantic import ValidationError
+
+# --- helpers --------------------------------------------------------------
+
+
+def _record(
+    *,
+    patch_version: str = "8.05",
+    raw_html: str = "<html>raw</html>",
+    body_text: str = "body",
+    url: str = "https://example.test/patch/8-05",
+    published_at: datetime | None = None,
+) -> PatchNoteRecord:
+    return PatchNoteRecord(
+        patch_version=patch_version,
+        published_at=published_at or datetime(2026, 4, 1, tzinfo=UTC),
+        raw_html=raw_html,
+        body_text=body_text,
+        url=url,
+    )
+
+
+@dataclass
+class _StubRow:
+    """Minimal stand-in for ``PatchNote`` ORM rows in the fake session."""
+
+    source: str
+    patch_version: str
+    published_at: datetime
+    raw_html: str
+    body_text: str
+    url: str
+    fetched_at: datetime | None = None
+
+
+class _FakeSession:
+    """In-memory replacement for ``sqlalchemy.orm.Session``.
+
+    Stores rows in a dict keyed on ``(source, patch_version)`` and
+    inspects each ``execute(select(...))`` call by walking the compiled
+    SQLAlchemy statement to recover the WHERE values. That's just
+    enough fidelity for the SELECT-then-INSERT-or-UPDATE pattern in
+    :func:`_upsert_patch_note`; nothing else in the runner reaches the
+    session.
+    """
+
+    def __init__(self) -> None:
+        self.rows: dict[tuple[str, str], _StubRow] = {}
+
+    def execute(self, stmt: Any) -> Any:  # noqa: ANN401 - mirrors Session.execute
+        # The runner's only SELECT filters by ``source == X`` and
+        # ``patch_version == Y``. Pull the literal values out of the
+        # compiled WHERE clause so we can look up by composite key.
+        compiled = stmt.compile(compile_kwargs={"literal_binds": True})
+        text = str(compiled)
+        # Crude but enough: the runner only emits one shape of query.
+        # Extract source / patch_version literals after each ``=``.
+        source = _between(text, "patch_note.source = '", "'")
+        version = _between(text, "patch_note.patch_version = '", "'")
+        row = self.rows.get((source, version))
+
+        class _Result:
+            def __init__(self, value: Any) -> None:
+                self._value = value
+
+            def scalar_one_or_none(self) -> Any:
+                return self._value
+
+        return _Result(row)
+
+    def add(self, row: Any) -> None:
+        # Mimic the server default kicking in on flush so the runner's
+        # update path (next pass) sees a populated ``fetched_at``.
+        if row.fetched_at is None:
+            row.fetched_at = datetime.now(tz=UTC)
+        self.rows[(row.source, row.patch_version)] = _StubRow(
+            source=row.source,
+            patch_version=row.patch_version,
+            published_at=row.published_at,
+            raw_html=row.raw_html,
+            body_text=row.body_text,
+            url=row.url,
+            fetched_at=row.fetched_at,
+        )
+
+    def flush(self) -> None:
+        return None
+
+
+def _between(text: str, start: str, end: str) -> str:
+    """Return the substring between ``start`` and ``end`` markers."""
+    i = text.index(start) + len(start)
+    j = text.index(end, i)
+    return text[i:j]
+
+
+def _make_connector(
+    *,
+    payloads: Iterable[dict[str, Any]] = (),
+    records_per_payload: list[list[PatchNoteRecord]] | None = None,
+    validate_raises: list[Exception] | None = None,
+    transform_raises: list[Exception] | None = None,
+    fetch_raises: Exception | None = None,
+    source_name: str = "test-source",
+    rate_limit: RateLimit | None = None,
+) -> PatchNoteConnector:
+    """Build a ``PatchNoteConnector`` whose hooks fire from canned data."""
+    payload_list = list(payloads)
+    records_list = records_per_payload or [[_record()] for _ in payload_list]
+    validate_errors = list(validate_raises or [])
+    transform_errors = list(transform_raises or [])
+    rl = rate_limit or RateLimit(capacity=100, refill_per_second=1000.0)
+
+    class _Stub(PatchNoteConnector):
+        @property
+        def source_name(self) -> str:  # noqa: D401 - protocol property
+            return source_name
+
+        @property
+        def cadence(self) -> timedelta:
+            return timedelta(days=7)
+
+        @property
+        def rate_limit(self) -> RateLimit:
+            return rl
+
+        def fetch(self, since: datetime) -> Iterable[dict[str, Any]]:
+            if fetch_raises is not None:
+                # Match the real connector's contract: the HTTP call
+                # happens between yields, so the exception lands inside
+                # ``next(iterator)``.
+                raise fetch_raises
+                yield  # type: ignore[unreachable]  # keeps this a generator
+            yield from payload_list
+
+        def validate(self, raw_payload: dict[str, Any]) -> dict[str, Any]:
+            if validate_errors:
+                err = validate_errors.pop(0)
+                if err is not None:
+                    raise err
+            return raw_payload
+
+        def transform(self, validated_payload: dict[str, Any]) -> Iterable[PatchNoteRecord]:
+            if transform_errors:
+                err = transform_errors.pop(0)
+                if err is not None:
+                    raise err
+            # Yield the next batch of records for this payload.
+            idx = payload_list.index(validated_payload)
+            return iter(records_list[idx])
+
+    return _Stub()
+
+
+# --- PatchNoteRecord validation -------------------------------------------
+
+
+class TestPatchNoteRecord:
+    """Pydantic guarantees the runner relies on at the connector boundary."""
+
+    def test_minimum_field_lengths_enforced(self) -> None:
+        # ``patch_version`` and ``url`` carry ``min_length=1`` so an
+        # empty connector emit fails loudly here, not as a downstream
+        # NULL/empty-string footgun.
+        with pytest.raises(ValidationError):
+            PatchNoteRecord(
+                patch_version="",
+                published_at=datetime(2026, 1, 1, tzinfo=UTC),
+                raw_html="x",
+                body_text="x",
+                url="https://example.test",
+            )
+
+    def test_patch_version_max_length_matches_column(self) -> None:
+        # 32 chars is the column cap; emitting a longer string should
+        # surface here rather than as a Postgres truncation later.
+        with pytest.raises(ValidationError):
+            PatchNoteRecord(
+                patch_version="9" * 33,
+                published_at=datetime(2026, 1, 1, tzinfo=UTC),
+                raw_html="x",
+                body_text="x",
+                url="https://example.test",
+            )
+
+    def test_url_max_length_matches_column(self) -> None:
+        with pytest.raises(ValidationError):
+            PatchNoteRecord(
+                patch_version="8.05",
+                published_at=datetime(2026, 1, 1, tzinfo=UTC),
+                raw_html="x",
+                body_text="x",
+                url="https://example.test/" + ("x" * 600),
+            )
+
+    def test_extra_fields_rejected(self) -> None:
+        # ``model_config = ConfigDict(extra="forbid")`` — a connector
+        # accidentally passing an extra column name is a contract bug.
+        with pytest.raises(ValidationError):
+            PatchNoteRecord(
+                patch_version="8.05",
+                published_at=datetime(2026, 1, 1, tzinfo=UTC),
+                raw_html="x",
+                body_text="x",
+                url="https://example.test",
+                wat="oops",  # type: ignore[call-arg]
+            )
+
+    def test_frozen_after_construction(self) -> None:
+        rec = _record()
+        with pytest.raises(ValidationError):
+            rec.patch_version = "9.99"  # type: ignore[misc]
+
+
+# --- PatchNotesStats defaults --------------------------------------------
+
+
+def test_patch_notes_stats_defaults_are_zero() -> None:
+    """Default-constructed stats are a clean baseline.
+
+    The runner increments these counters in place; an accidental
+    non-zero default would silently inflate the on-call dashboard.
+    """
+    stats = PatchNotesStats()
+    assert stats.fetched == 0
+    assert stats.schema_drifts == 0
+    assert stats.transient_errors == 0
+    assert stats.upserted == 0
+    assert stats.inserted == 0
+    assert stats.updated == 0
+    assert stats.unchanged == 0
+    assert stats.by_version == {}
+
+
+# --- runner: error-handling paths ----------------------------------------
+
+
+def test_empty_fetch_returns_zero_stats() -> None:
+    """No payloads in -> no rows out, no errors logged."""
+    connector = _make_connector(payloads=[])
+    stats = run_patch_notes_ingestion(
+        connector,
+        session=_FakeSession(),  # type: ignore[arg-type]
+        since=datetime(1970, 1, 1, tzinfo=UTC),
+    )
+    assert stats.fetched == 0
+    assert stats.upserted == 0
+    assert stats.inserted == 0
+    assert stats.unchanged == 0
+
+
+def test_schema_drift_during_validate_skips_row_and_continues() -> None:
+    """SchemaDriftError on one row counts + logs but does not abort the pass.
+
+    The next payload must still flow through. Mirrors the entity
+    runner's ``test_schema_drift_logs_and_continues`` in spirit.
+    """
+    connector = _make_connector(
+        payloads=[{"url": "a"}, {"url": "b"}],
+        records_per_payload=[[_record(patch_version="8.05")], [_record(patch_version="8.06")]],
+        validate_raises=[SchemaDriftError("upstream changed shape"), None],
+    )
+    session = _FakeSession()
+    stats = run_patch_notes_ingestion(
+        connector,
+        session=session,  # type: ignore[arg-type]
+        since=datetime(1970, 1, 1, tzinfo=UTC),
+    )
+    assert stats.schema_drifts == 1
+    assert stats.fetched == 1, "drift drops the row before fetched++ on the next iteration"
+    assert stats.inserted == 1
+    assert ("test-source", "8.06") in session.rows
+    assert ("test-source", "8.05") not in session.rows
+
+
+def test_schema_drift_during_transform_skips_row_and_continues() -> None:
+    """``transform`` is the second place SchemaDriftError can fire.
+
+    The runner wraps ``validate`` + ``list(transform)`` in the same
+    ``try/except``, so a drift surfacing during projection follows the
+    same skip-and-log path.
+    """
+    connector = _make_connector(
+        payloads=[{"url": "a"}, {"url": "b"}],
+        records_per_payload=[[_record(patch_version="8.05")], [_record(patch_version="8.06")]],
+        transform_raises=[SchemaDriftError("missing version field"), None],
+    )
+    stats = run_patch_notes_ingestion(
+        connector,
+        session=_FakeSession(),  # type: ignore[arg-type]
+        since=datetime(1970, 1, 1, tzinfo=UTC),
+    )
+    assert stats.schema_drifts == 1
+    assert stats.inserted == 1
+
+
+def test_transient_error_during_fetch_is_caught_and_counted() -> None:
+    """Transient error raised inside ``next(iterator)`` doesn't abort the run.
+
+    Mirrors the BUF-83 contract: the connector's HTTP call happens in
+    the body that runs *between* yields, so a network blip lands in
+    ``next(iterator)`` and the runner has to handle it there too.
+    """
+    connector = _make_connector(fetch_raises=TransientFetchError("upstream 503"))
+    stats = run_patch_notes_ingestion(
+        connector,
+        session=_FakeSession(),  # type: ignore[arg-type]
+        since=datetime(1970, 1, 1, tzinfo=UTC),
+    )
+    assert stats.transient_errors == 1
+    assert stats.fetched == 0
+    assert stats.upserted == 0
+
+
+def test_transient_error_during_validate_is_caught_and_counted() -> None:
+    """Transient error from ``validate`` skips the row, run continues."""
+    connector = _make_connector(
+        payloads=[{"url": "a"}, {"url": "b"}],
+        records_per_payload=[[_record(patch_version="8.05")], [_record(patch_version="8.06")]],
+        validate_raises=[TransientFetchError("body fetch 504"), None],
+    )
+    stats = run_patch_notes_ingestion(
+        connector,
+        session=_FakeSession(),  # type: ignore[arg-type]
+        since=datetime(1970, 1, 1, tzinfo=UTC),
+    )
+    assert stats.transient_errors == 1
+    assert stats.inserted == 1
+
+
+def test_unknown_connector_exception_propagates() -> None:
+    """Anything other than SchemaDrift / TransientFetch is fatal-by-default.
+
+    Systems-spec rule: an unknown failure mode must not silently
+    corrupt the document store. The runner logs ``CONNECTOR_ERROR``
+    and re-raises.
+    """
+    connector = _make_connector(
+        payloads=[{"url": "a"}],
+        validate_raises=[RuntimeError("boom: parser exploded")],
+    )
+    with pytest.raises(RuntimeError, match="boom"):
+        run_patch_notes_ingestion(
+            connector,
+            session=_FakeSession(),  # type: ignore[arg-type]
+            since=datetime(1970, 1, 1, tzinfo=UTC),
+        )
+
+
+def test_ingestion_error_subclass_other_than_drift_or_transient_propagates() -> None:
+    """Custom IngestionError that isn't drift/transient is treated as fatal.
+
+    The two ``except`` clauses match exact classes (drift and transient).
+    A bespoke ``IngestionError`` subclass would fall through to the
+    bare ``except Exception`` re-raise.
+    """
+
+    class _CustomIngestion(IngestionError):
+        pass
+
+    connector = _make_connector(
+        payloads=[{"url": "a"}],
+        transform_raises=[_CustomIngestion("don't know what to do with this")],
+    )
+    with pytest.raises(_CustomIngestion):
+        run_patch_notes_ingestion(
+            connector,
+            session=_FakeSession(),  # type: ignore[arg-type]
+            since=datetime(1970, 1, 1, tzinfo=UTC),
+        )
+
+
+# --- runner: rate limiting -----------------------------------------------
+
+
+def test_rate_limiter_acquired_once_per_iteration() -> None:
+    """The runner must acquire a token before each ``next()`` call.
+
+    Without that bracketing the connector's HTTP call is unrate-limited
+    on the iterator-advance side — the same bug the entity runner
+    fixed in ``test_rate_limiter_acquired_before_fetch_advances``.
+    """
+
+    class _CountingBucket(TokenBucket):
+        def __init__(self) -> None:
+            super().__init__(capacity=10, refill_per_second=1000.0)
+            self.calls = 0
+
+        def acquire(self) -> None:
+            self.calls += 1
+            super().acquire()
+
+    bucket = _CountingBucket()
+    connector = _make_connector(
+        payloads=[{"url": "a"}, {"url": "b"}],
+        records_per_payload=[[_record(patch_version="8.05")], [_record(patch_version="8.06")]],
+    )
+    run_patch_notes_ingestion(
+        connector,
+        session=_FakeSession(),  # type: ignore[arg-type]
+        since=datetime(1970, 1, 1, tzinfo=UTC),
+        rate_limiter=bucket,
+    )
+    # Two payloads + one StopIteration probe = three acquires. The probe
+    # token is intentionally not refunded (mirrors the entity runner's
+    # ``test_eos_probe_token_is_not_refunded``).
+    assert bucket.calls == 3
+
+
+def test_runner_uses_connector_rate_limit_when_no_explicit_limiter() -> None:
+    """Default-constructed runs build a TokenBucket from connector.rate_limit.
+
+    A regression here would mean the per-source RPM declared on the
+    connector silently has no effect.
+    """
+    rl = RateLimit(capacity=5, refill_per_second=500.0)
+    connector = _make_connector(payloads=[{"url": "a"}], rate_limit=rl)
+    # No ``rate_limiter=`` kwarg — runner must build one. The assert is
+    # implicit: if the runner failed to build one, this would raise.
+    stats = run_patch_notes_ingestion(
+        connector,
+        session=_FakeSession(),  # type: ignore[arg-type]
+        since=datetime(1970, 1, 1, tzinfo=UTC),
+    )
+    assert stats.inserted == 1
+
+
+# --- runner: UPSERT outcomes ---------------------------------------------
+
+
+def test_first_pass_records_inserted_and_bumps_upserted() -> None:
+    connector = _make_connector(
+        payloads=[{"url": "a"}],
+        records_per_payload=[[_record(patch_version="8.05")]],
+    )
+    stats = run_patch_notes_ingestion(
+        connector,
+        session=_FakeSession(),  # type: ignore[arg-type]
+        since=datetime(1970, 1, 1, tzinfo=UTC),
+    )
+    assert stats.inserted == 1
+    assert stats.upserted == 1
+    assert stats.updated == 0
+    assert stats.unchanged == 0
+    assert stats.by_version == {"8.05": 1}
+
+
+def test_second_pass_with_identical_content_reports_unchanged_only() -> None:
+    """Idempotency: re-running on identical content does not inflate upserted.
+
+    BUF-83 contract — the on-call dashboard tracks ``upserted`` to
+    detect quiet weeks that suddenly start writing. Counting
+    ``unchanged`` toward ``upserted`` would false-positive every healthy
+    weekly pass.
+    """
+    payloads = [{"url": "a"}]
+    records = [[_record(patch_version="8.05")]]
+    session = _FakeSession()
+
+    first = run_patch_notes_ingestion(
+        _make_connector(payloads=payloads, records_per_payload=records),
+        session=session,  # type: ignore[arg-type]
+        since=datetime(1970, 1, 1, tzinfo=UTC),
+    )
+    assert first.inserted == 1
+
+    second = run_patch_notes_ingestion(
+        _make_connector(payloads=payloads, records_per_payload=records),
+        session=session,  # type: ignore[arg-type]
+        since=datetime(1970, 1, 1, tzinfo=UTC),
+    )
+    assert second.inserted == 0
+    assert second.unchanged == 1
+    assert second.upserted == 0
+
+
+def test_second_pass_with_changed_body_reports_updated() -> None:
+    """A real edit (typo fix, late balance change) lands in ``updated``."""
+    session = _FakeSession()
+
+    first_records = [[_record(patch_version="8.05", body_text="original")]]
+    run_patch_notes_ingestion(
+        _make_connector(payloads=[{"url": "a"}], records_per_payload=first_records),
+        session=session,  # type: ignore[arg-type]
+        since=datetime(1970, 1, 1, tzinfo=UTC),
+    )
+
+    second_records = [[_record(patch_version="8.05", body_text="edited")]]
+    second = run_patch_notes_ingestion(
+        _make_connector(payloads=[{"url": "a"}], records_per_payload=second_records),
+        session=session,  # type: ignore[arg-type]
+        since=datetime(1970, 1, 1, tzinfo=UTC),
+    )
+
+    assert second.updated == 1
+    assert second.unchanged == 0
+    assert second.upserted == 1
+    assert session.rows[("test-source", "8.05")].body_text == "edited"
+
+
+def test_two_sources_with_same_patch_version_do_not_collide() -> None:
+    """``(source, patch_version)`` is the composite key, not version alone.
+
+    Two patch-note connectors emitting "8.05" must persist as two
+    rows, not overwrite each other. Re-tested here with the fake
+    session because the integration version of this test
+    (``test_two_sources_with_same_patch_version_do_not_collide`` in
+    test_playvalorant_connector.py) requires Postgres.
+    """
+    session = _FakeSession()
+
+    run_patch_notes_ingestion(
+        _make_connector(
+            payloads=[{"url": "a"}],
+            records_per_payload=[[_record(patch_version="8.05")]],
+            source_name="game-one",
+        ),
+        session=session,  # type: ignore[arg-type]
+        since=datetime(1970, 1, 1, tzinfo=UTC),
+    )
+    run_patch_notes_ingestion(
+        _make_connector(
+            payloads=[{"url": "a"}],
+            records_per_payload=[[_record(patch_version="8.05")]],
+            source_name="game-two",
+        ),
+        session=session,  # type: ignore[arg-type]
+        since=datetime(1970, 1, 1, tzinfo=UTC),
+    )
+    assert ("game-one", "8.05") in session.rows
+    assert ("game-two", "8.05") in session.rows
+    assert len(session.rows) == 2
+
+
+def test_multiple_records_from_one_payload_are_all_persisted() -> None:
+    """``transform`` may emit zero-or-more records per payload.
+
+    A multi-version announcement post should produce two rows from a
+    single fetch.
+    """
+    connector = _make_connector(
+        payloads=[{"url": "a"}],
+        records_per_payload=[
+            [
+                _record(patch_version="8.05"),
+                _record(patch_version="8.06"),
+            ],
+        ],
+    )
+    session = _FakeSession()
+    stats = run_patch_notes_ingestion(
+        connector,
+        session=session,  # type: ignore[arg-type]
+        since=datetime(1970, 1, 1, tzinfo=UTC),
+    )
+    assert stats.fetched == 1, "fetched counts upstream payloads, not records"
+    assert stats.inserted == 2
+    assert stats.upserted == 2
+    assert stats.by_version == {"8.05": 1, "8.06": 1}
+    assert ("test-source", "8.05") in session.rows
+    assert ("test-source", "8.06") in session.rows

--- a/uv.lock
+++ b/uv.lock
@@ -28,6 +28,7 @@ dev = [
     { name = "mypy" },
     { name = "pre-commit" },
     { name = "pytest" },
+    { name = "pytest-cov" },
     { name = "pytest-picked" },
     { name = "ruff" },
     { name = "types-pyyaml" },
@@ -47,6 +48,7 @@ dev = [
     { name = "mypy", specifier = ">=1.10" },
     { name = "pre-commit", specifier = ">=3.7" },
     { name = "pytest", specifier = ">=8.0" },
+    { name = "pytest-cov", specifier = ">=5.0" },
     { name = "pytest-picked", specifier = ">=0.5" },
     { name = "ruff", specifier = ">=0.4" },
     { name = "types-pyyaml" },
@@ -195,6 +197,30 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/d8/53/6f443c9a4a8358a93a6792e2acffb9d9d5cb0a5cfd8802644b7b1c9a02e4/colorama-0.4.6.tar.gz", hash = "sha256:08695f5cb7ed6e0531a20572697297273c47b8cae5a63ffc6d6ed5c201be6e44", size = 27697, upload-time = "2022-10-25T02:36:22.414Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d1/d6/3965ed04c63042e047cb6a3e6ed1a63a35087b6a609aa3a15ed8ac56c221/colorama-0.4.6-py2.py3-none-any.whl", hash = "sha256:4f1d9991f5acc0ca119f9d443620b77f9d6b33703e51011c16baf57afb285fc6", size = 25335, upload-time = "2022-10-25T02:36:20.889Z" },
+]
+
+[[package]]
+name = "coverage"
+version = "7.13.5"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/9d/e0/70553e3000e345daff267cec284ce4cbf3fc141b6da229ac52775b5428f1/coverage-7.13.5.tar.gz", hash = "sha256:c81f6515c4c40141f83f502b07bbfa5c240ba25bbe73da7b33f1e5b6120ff179", size = 915967, upload-time = "2026-03-17T10:33:18.341Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/a0/c3/a396306ba7db865bf96fc1fb3b7fd29bcbf3d829df642e77b13555163cd6/coverage-7.13.5-cp312-cp312-macosx_10_13_x86_64.whl", hash = "sha256:460cf0114c5016fa841214ff5564aa4864f11948da9440bc97e21ad1f4ba1e01", size = 219554, upload-time = "2026-03-17T10:30:42.208Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/16/a68a19e5384e93f811dccc51034b1fd0b865841c390e3c931dcc4699e035/coverage-7.13.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:0e223ce4b4ed47f065bfb123687686512e37629be25cc63728557ae7db261422", size = 219908, upload-time = "2026-03-17T10:30:43.906Z" },
+    { url = "https://files.pythonhosted.org/packages/29/72/20b917c6793af3a5ceb7fb9c50033f3ec7865f2911a1416b34a7cfa0813b/coverage-7.13.5-cp312-cp312-manylinux1_i686.manylinux_2_28_i686.manylinux_2_5_i686.whl", hash = "sha256:6e3370441f4513c6252bf042b9c36d22491142385049243253c7e48398a15a9f", size = 251419, upload-time = "2026-03-17T10:30:45.545Z" },
+    { url = "https://files.pythonhosted.org/packages/8c/49/cd14b789536ac6a4778c453c6a2338bc0a2fb60c5a5a41b4008328b9acc1/coverage-7.13.5-cp312-cp312-manylinux1_x86_64.manylinux_2_28_x86_64.manylinux_2_5_x86_64.whl", hash = "sha256:03ccc709a17a1de074fb1d11f217342fb0d2b1582ed544f554fc9fc3f07e95f5", size = 254159, upload-time = "2026-03-17T10:30:47.204Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/00/7b0edcfe64e2ed4c0340dac14a52ad0f4c9bd0b8b5e531af7d55b703db7c/coverage-7.13.5-cp312-cp312-manylinux2014_aarch64.manylinux_2_17_aarch64.manylinux_2_28_aarch64.whl", hash = "sha256:3f4818d065964db3c1c66dc0fbdac5ac692ecbc875555e13374fdbe7eedb4376", size = 255270, upload-time = "2026-03-17T10:30:48.812Z" },
+    { url = "https://files.pythonhosted.org/packages/93/89/7ffc4ba0f5d0a55c1e84ea7cee39c9fc06af7b170513d83fbf3bbefce280/coverage-7.13.5-cp312-cp312-manylinux2014_ppc64le.manylinux_2_17_ppc64le.manylinux_2_28_ppc64le.whl", hash = "sha256:012d5319e66e9d5a218834642d6c35d265515a62f01157a45bcc036ecf947256", size = 257538, upload-time = "2026-03-17T10:30:50.77Z" },
+    { url = "https://files.pythonhosted.org/packages/81/bd/73ddf85f93f7e6fa83e77ccecb6162d9415c79007b4bc124008a4995e4a7/coverage-7.13.5-cp312-cp312-manylinux_2_31_riscv64.manylinux_2_39_riscv64.whl", hash = "sha256:8dd02af98971bdb956363e4827d34425cb3df19ee550ef92855b0acb9c7ce51c", size = 251821, upload-time = "2026-03-17T10:30:52.5Z" },
+    { url = "https://files.pythonhosted.org/packages/a0/81/278aff4e8dec4926a0bcb9486320752811f543a3ce5b602cc7a29978d073/coverage-7.13.5-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:f08fd75c50a760c7eb068ae823777268daaf16a80b918fa58eea888f8e3919f5", size = 253191, upload-time = "2026-03-17T10:30:54.543Z" },
+    { url = "https://files.pythonhosted.org/packages/70/ee/fe1621488e2e0a58d7e94c4800f0d96f79671553488d401a612bebae324b/coverage-7.13.5-cp312-cp312-musllinux_1_2_i686.whl", hash = "sha256:843ea8643cf967d1ac7e8ecd4bb00c99135adf4816c0c0593fdcc47b597fcf09", size = 251337, upload-time = "2026-03-17T10:30:56.663Z" },
+    { url = "https://files.pythonhosted.org/packages/37/a6/f79fb37aa104b562207cc23cb5711ab6793608e246cae1e93f26b2236ed9/coverage-7.13.5-cp312-cp312-musllinux_1_2_ppc64le.whl", hash = "sha256:9d44d7aa963820b1b971dbecd90bfe5fe8f81cff79787eb6cca15750bd2f79b9", size = 255404, upload-time = "2026-03-17T10:30:58.427Z" },
+    { url = "https://files.pythonhosted.org/packages/75/f0/ed15262a58ec81ce457ceb717b7f78752a1713556b19081b76e90896e8d4/coverage-7.13.5-cp312-cp312-musllinux_1_2_riscv64.whl", hash = "sha256:7132bed4bd7b836200c591410ae7d97bf7ae8be6fc87d160b2bd881df929e7bf", size = 250903, upload-time = "2026-03-17T10:31:00.093Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/e9/9129958f20e7e9d4d56d51d42ccf708d15cac355ff4ac6e736e97a9393d2/coverage-7.13.5-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:a698e363641b98843c517817db75373c83254781426e94ada3197cabbc2c919c", size = 252780, upload-time = "2026-03-17T10:31:01.916Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/d7/0ad9b15812d81272db94379fe4c6df8fd17781cc7671fdfa30c76ba5ff7b/coverage-7.13.5-cp312-cp312-win32.whl", hash = "sha256:bdba0a6b8812e8c7df002d908a9a2ea3c36e92611b5708633c50869e6d922fdf", size = 222093, upload-time = "2026-03-17T10:31:03.642Z" },
+    { url = "https://files.pythonhosted.org/packages/29/3d/821a9a5799fac2556bcf0bd37a70d1d11fa9e49784b6d22e92e8b2f85f18/coverage-7.13.5-cp312-cp312-win_amd64.whl", hash = "sha256:d2c87e0c473a10bffe991502eac389220533024c8082ec1ce849f4218dded810", size = 222900, upload-time = "2026-03-17T10:31:05.651Z" },
+    { url = "https://files.pythonhosted.org/packages/d4/fa/2238c2ad08e35cf4f020ea721f717e09ec3152aea75d191a7faf3ef009a8/coverage-7.13.5-cp312-cp312-win_arm64.whl", hash = "sha256:bf69236a9a81bdca3bff53796237aab096cdbf8d78a66ad61e992d9dac7eb2de", size = 221515, upload-time = "2026-03-17T10:31:07.293Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/ee/a4cf96b8ce1e566ed238f0659ac2d3f007ed1d14b181bcb684e19561a69a/coverage-7.13.5-py3-none-any.whl", hash = "sha256:34b02417cf070e173989b3db962f7ed56d2f644307b2cf9d5a0f258e13084a61", size = 211346, upload-time = "2026-03-17T10:33:15.691Z" },
 ]
 
 [[package]]
@@ -725,6 +751,20 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/7d/0d/549bd94f1a0a402dc8cf64563a117c0f3765662e2e668477624baeec44d5/pytest-9.0.3.tar.gz", hash = "sha256:b86ada508af81d19edeb213c681b1d48246c1a91d304c6c81a427674c17eb91c", size = 1572165, upload-time = "2026-04-07T17:16:18.027Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/d4/24/a372aaf5c9b7208e7112038812994107bc65a84cd00e0354a88c2c77a617/pytest-9.0.3-py3-none-any.whl", hash = "sha256:2c5efc453d45394fdd706ade797c0a81091eccd1d6e4bccfcd476e2b8e0ab5d9", size = 375249, upload-time = "2026-04-07T17:16:16.13Z" },
+]
+
+[[package]]
+name = "pytest-cov"
+version = "7.1.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "coverage" },
+    { name = "pluggy" },
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b1/51/a849f96e117386044471c8ec2bd6cfebacda285da9525c9106aeb28da671/pytest_cov-7.1.0.tar.gz", hash = "sha256:30674f2b5f6351aa09702a9c8c364f6a01c27aae0c1366ae8016160d1efc56b2", size = 55592, upload-time = "2026-03-21T20:11:16.284Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/9d/7a/d968e294073affff457b041c2be9868a40c1c71f4a35fcc1e45e5493067b/pytest_cov-7.1.0-py3-none-any.whl", hash = "sha256:a0461110b7865f9a271aa1b51e516c9a95de9d696734a2f71e3e78f46e1d4678", size = 22876, upload-time = "2026-03-21T20:11:14.438Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Adds five new test modules to cover surfaces that previously had only
indirect coverage (through end-to-end connector tests) or none at all,
and wires `pytest-cov` into the build with a coverage threshold
enforced by both `make ci` and GitHub Actions.

## What changed

**New test modules (75 tests added):**

- `services/data_pipeline/tests/test_patch_notes_runner.py` (20 tests) —
  direct unit tests for the BUF-83 runner against an in-memory
  `_FakeSession` so they run without `TEST_DATABASE_URL`. Covers
  schema-drift / transient-fetch skip semantics on every error site
  (fetch / validate / transform), fatal connector errors, rate-limiter
  bracketing, the inserted/updated/unchanged outcome split,
  source-scoped UPSERT, and `PatchNoteRecord` pydantic guarantees.
- `packages/shared/tests/test_budget_caps.py` (24 tests) — locks down
  `BudgetCaps` env-parsing (truthy/falsy permutations of
  `NEXUS_BUDGET_DISABLE_CAPS`, float override, copy-not-alias defaults,
  frozen dataclass).
- `packages/shared/tests/test_budget_cli.py` (7 tests) — exit codes,
  help text, and argparse routing for `nexus budget report`.
- `services/data_pipeline/tests/test_connector_contract.py` (18 tests) —
  ABCMeta / pydantic guarantees on the `Connector` + `IngestionRecord`
  + `RateLimit` contracts the runner trusts implicitly.
- `packages/shared/tests/test_cli.py` (6 tests) — top-level dispatcher
  (subparser registration, `--help`, unknown subcommand exits,
  dispatch routing).

**Build/CI:**

- `pytest-cov >= 5.0` added to the dev dep group.
- `[tool.coverage.run]` and `[tool.coverage.report]` configured in
  `pyproject.toml` — branch coverage on, scoped to `*/src`, omits
  tests + alembic versions, repo-wide `exclude_lines` patterns.
- `make coverage` target runs the suite under coverage with a
  `COVERAGE_FAIL_UNDER` threshold (default 80, override-able from the
  command line). `make ci` now invokes `make coverage` instead of
  plain `make test`.
- The CI workflow uses `make coverage` and uploads the resulting
  `coverage.xml` as a build artifact. Postgres was already provisioned
  for the integration suite — no change there.

## Coverage gaps still open (followups)

- The two stub services (`services/ecosystem`, `services/match_wm`)
  still have only empty `__init__.py` and `tests/__init__.py`. Tests
  will follow when the modules grow real implementations.
- A pre-existing FP-drift bug in `test_rate_limiter.py::test_load_does_not_exceed_capacity_plus_refill`
  causes the production token bucket to spin under the fake clock once
  iteration counts cross ~10. Surfaced incidentally while running the
  suite; not addressed here because the fix touches production code
  outside this PR's scope.

## Test plan

- [x] `uv run pytest <each new test file>` — 75/75 pass, sub-second.
- [x] `uv run ruff check` on new files — clean.
- [x] `uv run black --check` on new files — clean.
- [x] `uv run mypy` — no issues found in 40 source files.
- [ ] CI green on this PR (Postgres-gated integration suite + coverage
      threshold).

https://claude.ai/code/session_012UbWKxU1Mzo5YdhpaaXV4K

---
_Generated by [Claude Code](https://claude.ai/code/session_012UbWKxU1Mzo5YdhpaaXV4K)_