### PR TITLE
Fix three pre-existing flaky tests

### DIFF
--- a/packages/shared/tests/test_resolver_worker.py
+++ b/packages/shared/tests/test_resolver_worker.py
@@ -15,7 +15,7 @@ from __future__ import annotations
 
 import logging
 import uuid
-from datetime import UTC, datetime
+from datetime import UTC, datetime, timedelta
 from typing import Any
 
 import pytest
@@ -401,7 +401,7 @@ def test_ten_known_handle_changes_produce_zero_duplicate_canonicals(
     """
     from sqlalchemy import func, select
 
-    # 10 fixture players: (old_handle, new_handle, new_display_name).
+    # 10 fixture players: (old_handle, new_handle, display_name).
     handle_changes = [
         ("tenz_2023", "tenz", "TenZ"),
         ("zekken_2024", "zekken", "Zekken"),
@@ -416,13 +416,21 @@ def test_ten_known_handle_changes_produce_zero_duplicate_canonicals(
     ]
 
     # 1. Seed the 10 originals via the resolver.
+    #
+    # Use the bare display name (not e.g. ``old.replace("_", " ").title()``)
+    # so seed rows don't share the ``2023`` / ``2024`` year suffix that
+    # rapidfuzz's WRatio token-set component treats as a strong match
+    # signal — "Less 2024" vs "Aspas 2024" scores 0.7368, above
+    # REVIEW_THRESHOLD (0.70), pushing the seed call into PENDING and
+    # breaking the canonical_id post-condition. The bare names worst-pair
+    # at 0.60, comfortably below the threshold.
     canonical_ids: list[uuid.UUID] = []
-    for old, _new, _name in handle_changes:
+    for _old, _new, name in handle_changes:
         result = resolve_entity(
             db_session,
             platform=Platform.LIQUIPEDIA,
-            platform_id=old,
-            platform_name=old.replace("_", " ").title(),
+            platform_id=_old,
+            platform_name=name,
             entity_type=EntityType.PLAYER,
         )
         assert result.canonical_id is not None
@@ -896,11 +904,17 @@ def test_process_staging_queue_logs_rebrand_conflict_without_aborting(
     assert stats.rebrands_registered == 0
     # The "newteam" alias still maps to the unrelated canonical
     # — we did NOT silently overwrite it.
+    #
+    # ``at`` must be after the seeded alias's ``valid_from`` (server
+    # default ``NOW()``); a hard-coded past date here would make this
+    # a date-bomb test that quietly starts failing once wall-clock
+    # time rolls past it. Use ``now + 1 day`` so the lookup is always
+    # in the future relative to the seed flush.
     new_alias = lookup_alias_at(
         db_session,
         platform=Platform.LIQUIPEDIA,
         platform_id="newteam",
-        at=datetime(2026, 4, 5, tzinfo=UTC),
+        at=datetime.now(UTC) + timedelta(days=1),
     )
     assert new_alias is not None
     assert new_alias.canonical_id == other.canonical_id

--- a/services/data_pipeline/tests/test_runner.py
+++ b/services/data_pipeline/tests/test_runner.py
@@ -299,11 +299,22 @@ def test_unexpected_connector_exception_logs_connector_error_and_propagates(
 
 
 def test_runner_consults_rate_limiter_per_record(db_session) -> None:
-    """Every ``fetch`` yield should trip the bucket exactly once.
+    """The runner brackets every ``next()`` on the connector's iterator with
+    one ``acquire()`` — including the final ``next()`` that raises
+    ``StopIteration``.
 
-    Use a real :class:`TokenBucket` with capacity 100 (so it never
-    blocks) but a counting wrapper so the test can assert the runner
-    actually called it.
+    The runner's ``_rate_limited`` helper documents this deliberately:
+    a connector that issues its HTTP call before yielding (the
+    documented contract) would otherwise run unmetered if the bucket
+    only fired post-yield, and refunding the token on ``StopIteration``
+    would let an empty-poll cadence bypass the limiter and exceed
+    provider quotas. The cost is one "wasted" token per pass on
+    materialised-list connectors that do no HTTP after the last yield.
+
+    So for N yielded payloads, the bucket is consulted N+1 times. Use a
+    real :class:`TokenBucket` with capacity 100 (so it never blocks)
+    plus a counting wrapper so the test can assert the runner actually
+    called it.
     """
     real_bucket = TokenBucket(capacity=100, refill_per_second=100.0)
     calls = {"n": 0}
@@ -313,12 +324,13 @@ def test_runner_consults_rate_limiter_per_record(db_session) -> None:
             calls["n"] += 1
             real_bucket.acquire()
 
+    payloads = [
+        make_player_payload(platform_id="vlr-1", platform_name="A"),
+        make_player_payload(platform_id="vlr-2", platform_name="B"),
+        make_player_payload(platform_id="vlr-3", platform_name="C"),
+    ]
     connector = FakeConnector(
-        payloads=[
-            make_player_payload(platform_id="vlr-1", platform_name="A"),
-            make_player_payload(platform_id="vlr-2", platform_name="B"),
-            make_player_payload(platform_id="vlr-3", platform_name="C"),
-        ],
+        payloads=payloads,
         rate_limit=RateLimit(capacity=10, refill_per_second=10.0),
     )
 
@@ -329,7 +341,8 @@ def test_runner_consults_rate_limiter_per_record(db_session) -> None:
         rate_limiter=CountingBucket(),  # type: ignore[arg-type]
     )
 
-    assert calls["n"] == 3
+    # 3 yields + 1 stream-end probe == 4. See docstring + ``_rate_limited``.
+    assert calls["n"] == len(payloads) + 1
 
 
 def test_runner_uses_connector_rate_limit_when_no_explicit_limiter(db_session) -> None:


### PR DESCRIPTION
## Summary

Three tests on `main` fail when run against a current Postgres dev database. All three reproduce on a clean checkout — none are caused by recent feature work. Each fix is a targeted, comment-rich patch to the test file.

### 1. `test_ten_known_handle_changes_produce_zero_duplicate_canonicals` (resolver worker)

The seed loop built display names via `old.replace("_", " ").title()`, producing names like `"Tenz 2023"`, `"Less 2024"`, `"Aspas 2024"`. rapidfuzz's `WRatio` token-set component treats the shared `2023` / `2024` suffix as a strong match signal — `"Less 2024"` vs `"Aspas 2024"` scores **0.7368**, above `REVIEW_THRESHOLD` (0.70), so the seed call landed `PENDING` with `canonical_id=None` and tripped the loop's `assert result.canonical_id is not None`.

**Fix:** use the bare display name (third tuple element). Worst pair drops to 0.60, well below threshold.

### 2. `test_runner_consults_rate_limiter_per_record` (data-pipeline runner)

The runner's `_rate_limited` helper documents — at length — that it acquires *before* each `next()`, *including* the final one that raises `StopIteration`. The reason is documented in [runner.py:266-296](https://github.com/RescuedBuffalo/agentic-esports-tycoon/blob/main/services/data_pipeline/src/data_pipeline/runner.py#L266): a connector that issues its HTTP call before yielding (the documented contract) would otherwise run unmetered, and refunding the token on `StopIteration` would let an empty-poll cadence bypass the limiter and exceed provider quotas.

So for 3 yields the bucket is consulted **4** times. The test was asserting `== 3` against the runner's actual `== 4` contract.

**Fix:** assert `len(payloads) + 1` with a comment + updated docstring matching `_rate_limited`'s behaviour.

### 3. `test_process_staging_queue_logs_rebrand_conflict_without_aborting` (resolver worker)

Date-bomb. The test passed `at=datetime(2026, 4, 5, ...)` to `lookup_alias_at`, which filters by `valid_from <= at`. The seed alias's `valid_from = NOW()` is set by the server default. When wall-clock time was before April 5 2026, the seed's `valid_from` was less than `at` and the lookup returned the row. Today (2026-05-02) wall-clock is past April 5, so `valid_from > at` and the lookup returns `None`.

**Fix:** use `datetime.now(UTC) + timedelta(days=1)` so the lookup is always after the seed flush, regardless of when the test runs.

## Verification

- `TEST_DATABASE_URL=… uv run pytest packages/shared/tests/` — **256 passed** locally
- `TEST_DATABASE_URL=… uv run pytest services/data_pipeline/tests/test_runner.py` — **21 passed** locally
- `uv run ruff check` + `uv run black --check` — clean

## Test plan

- [x] Pre-fix repro: all three tests reproduce on a fresh checkout of `main` against current Postgres
- [x] Post-fix: all three pass, and adjacent tests in their suites still pass
- [ ] CI green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)