### PR TITLE
BUF-53: PyG HeteroData schema finalization (System 08)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,14 @@ __pycache__/
 .ruff_cache/
 .mypy_cache/
 
+# Coverage artifacts (`make coverage` / pytest-cov). The XML report is
+# uploaded by CI as an artifact; the binary ``.coverage`` file is a
+# per-run intermediate that should not land in source control.
+.coverage
+.coverage.*
+coverage.xml
+htmlcov/
+
 # Virtualenvs
 .venv/
 venv/

--- a/Makefile
+++ b/Makefile
@@ -63,6 +63,7 @@ coverage:
 	# patterns, branch coverage) lives in pyproject.toml under
 	# ``[tool.coverage.*]``.
 	uv run pytest \
+		-v \
 		--cov \
 		--cov-report=term-missing \
 		--cov-report=xml \

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -119,3 +119,11 @@ mypy_path = [
 [[tool.mypy.overrides]]
 module = ["numpy", "numpy.*"]
 ignore_missing_imports = true
+
+# torch / torch_geometric are *optional* — the graph exporter
+# (BUF-53) imports them lazily inside ``GraphSnapshot.to_pyg`` so a
+# downstream trainer can opt into PyG without forcing every CI job to
+# install the heavy stack. Tell mypy not to fail on the missing stubs.
+[[tool.mypy.overrides]]
+module = ["torch", "torch.*", "torch_geometric", "torch_geometric.*"]
+ignore_missing_imports = true

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,6 +25,12 @@ dev = [
     "pytest>=8.0",
     "pytest-cov>=5.0",
     "pytest-picked>=0.5",
+    # Per-test timeout so a hanging test surfaces as a fail-with-traceback
+    # instead of stalling CI for the full 6-hour job budget. Limit set
+    # in ``addopts`` below; integration tests can override per-test
+    # via ``@pytest.mark.timeout(...)`` if a legitimately slow path
+    # ever needs more headroom.
+    "pytest-timeout>=2.3",
     "ruff>=0.4",
     "black>=24.0",
     "mypy>=1.10",
@@ -43,7 +49,7 @@ testpaths = [
 # directories — one per workspace member — without colliding on the shared
 # module name. Without it, the second ``conftest.py`` import raises
 # ImportPathMismatchError because two paths resolve to ``tests.conftest``.
-addopts = "-ra --import-mode=importlib"
+addopts = "-ra --import-mode=importlib --timeout=120 --timeout-method=thread"
 markers = [
     "integration: requires a running Postgres (TEST_DATABASE_URL set). Skipped by default on a fresh clone.",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -49,7 +49,7 @@ testpaths = [
 # directories — one per workspace member — without colliding on the shared
 # module name. Without it, the second ``conftest.py`` import raises
 # ImportPathMismatchError because two paths resolve to ``tests.conftest``.
-addopts = "-ra --import-mode=importlib --timeout=120 --timeout-method=thread"
+addopts = "-ra --import-mode=importlib --timeout=300"
 markers = [
     "integration: requires a running Postgres (TEST_DATABASE_URL set). Skipped by default on a fresh clone.",
 ]

--- a/services/data_pipeline/src/data_pipeline/rate_limiter.py
+++ b/services/data_pipeline/src/data_pipeline/rate_limiter.py
@@ -94,11 +94,22 @@ class TokenBucket:
         the lock first, even though the wait itself doesn't need the
         lock held.
         """
+        # Float-precision floor: a sleep-then-refill round-trip can leave
+        # ``self._tokens`` at e.g. 0.9999999999999991 instead of exactly
+        # 1.0 (the FakeClock advance + clock subtraction in tests, and
+        # any real-clock equivalent, both round at the ULP level). Without
+        # an epsilon the next iteration computes a sub-ULP ``wait``, the
+        # sleep is a no-op against ``time.monotonic`` (or the FakeClock's
+        # ``+=`` of a value below its precision), and the bucket spins
+        # forever. ``1e-9`` is comfortably above any realistic
+        # accumulated rounding error and well below any meaningful
+        # rate-limit budget.
+        _TOKEN_EPS = 1e-9
         while True:
             with self._lock:
                 self._refill()
-                if self._tokens >= 1.0:
-                    self._tokens -= 1.0
+                if self._tokens >= 1.0 - _TOKEN_EPS:
+                    self._tokens = max(0.0, self._tokens - 1.0)
                     return
                 # ``self._tokens`` is in [0, 1); we need ``1 - self._tokens``
                 # more tokens, each takes ``1 / refill_per_second`` seconds.

--- a/services/data_pipeline/src/data_pipeline/seeds/vlr.py
+++ b/services/data_pipeline/src/data_pipeline/seeds/vlr.py
@@ -267,10 +267,7 @@ def seed_from_vlr_csv(
     # ``.tuples()`` quirk in a particular SQLAlchemy minor version
     # changing semantics.
     match_canonical_by_vlr_id: dict[str, uuid.UUID] = {
-        row[0]: row[1]
-        for row in session.execute(
-            select(Match.vlr_match_id, Match.match_id)
-        ).all()
+        row[0]: row[1] for row in session.execute(select(Match.vlr_match_id, Match.match_id)).all()
     }
     pre_existing_match_ids: frozenset[str] = frozenset(match_canonical_by_vlr_id)
     existing_game_ids: set[str] = set(

--- a/services/data_pipeline/src/data_pipeline/seeds/vlr.py
+++ b/services/data_pipeline/src/data_pipeline/seeds/vlr.py
@@ -260,8 +260,12 @@ def seed_from_vlr_csv(
     # so a re-run that lands a new map under an already-seeded match
     # has its parent UUID in hand without an extra SELECT. Same for
     # the existing-game-id set, which only needs membership checks.
+    # ``.tuples()`` flattens SQLAlchemy 2.0 ``Row`` objects to plain
+    # ``tuple[str, UUID]`` so ``dict()`` accepts the iterable; without
+    # it mypy sees ``Sequence[Row[tuple[str, UUID]]]`` and rejects the
+    # call (tuple-like at runtime but not in the type system).
     match_canonical_by_vlr_id: dict[str, uuid.UUID] = dict(
-        session.execute(select(Match.vlr_match_id, Match.match_id)).all()
+        session.execute(select(Match.vlr_match_id, Match.match_id)).tuples().all()
     )
     pre_existing_match_ids: frozenset[str] = frozenset(match_canonical_by_vlr_id)
     existing_game_ids: set[str] = set(

--- a/services/data_pipeline/src/data_pipeline/seeds/vlr.py
+++ b/services/data_pipeline/src/data_pipeline/seeds/vlr.py
@@ -260,13 +260,18 @@ def seed_from_vlr_csv(
     # so a re-run that lands a new map under an already-seeded match
     # has its parent UUID in hand without an extra SELECT. Same for
     # the existing-game-id set, which only needs membership checks.
-    # ``.tuples()`` flattens SQLAlchemy 2.0 ``Row`` objects to plain
-    # ``tuple[str, UUID]`` so ``dict()`` accepts the iterable; without
-    # it mypy sees ``Sequence[Row[tuple[str, UUID]]]`` and rejects the
-    # call (tuple-like at runtime but not in the type system).
-    match_canonical_by_vlr_id: dict[str, uuid.UUID] = dict(
-        session.execute(select(Match.vlr_match_id, Match.match_id)).tuples().all()
-    )
+    # SQLAlchemy 2.0 ``Row`` objects are tuple-like at runtime but
+    # typed as ``Row[tuple[str, UUID]]``, which mypy refuses to feed
+    # to ``dict()``. Iterate explicitly so the runtime tuple-unpack
+    # is independent of the typed-result wrapper — no risk of a
+    # ``.tuples()`` quirk in a particular SQLAlchemy minor version
+    # changing semantics.
+    match_canonical_by_vlr_id: dict[str, uuid.UUID] = {
+        row[0]: row[1]
+        for row in session.execute(
+            select(Match.vlr_match_id, Match.match_id)
+        ).all()
+    }
     pre_existing_match_ids: frozenset[str] = frozenset(match_canonical_by_vlr_id)
     existing_game_ids: set[str] = set(
         session.execute(select(MapResult.vlr_game_id)).scalars().all()

--- a/services/data_pipeline/tests/fixtures/riot/match.json
+++ b/services/data_pipeline/tests/fixtures/riot/match.json
@@ -23,7 +23,7 @@
     {
       "puuid": "PUUID-PLAYER-02",
       "gameName": "Bravo",
-      "tagLine": "NA1",
+      "tagLine": "NA2",
       "teamId": "Blue",
       "characterId": "viper-id",
       "stats": {"score": 280, "kills": 18, "deaths": 16, "assists": 5}
@@ -31,7 +31,7 @@
     {
       "puuid": "PUUID-PLAYER-03",
       "gameName": "Charlie",
-      "tagLine": "NA1",
+      "tagLine": "NA3",
       "teamId": "Blue",
       "characterId": "killjoy-id",
       "stats": {"score": 240, "kills": 15, "deaths": 17, "assists": 6}
@@ -39,7 +39,7 @@
     {
       "puuid": "PUUID-PLAYER-04",
       "gameName": "Delta",
-      "tagLine": "NA1",
+      "tagLine": "NA4",
       "teamId": "Blue",
       "characterId": "omen-id",
       "stats": {"score": 210, "kills": 13, "deaths": 18, "assists": 7}
@@ -47,7 +47,7 @@
     {
       "puuid": "PUUID-PLAYER-05",
       "gameName": "Echo",
-      "tagLine": "NA1",
+      "tagLine": "NA5",
       "teamId": "Blue",
       "characterId": "sova-id",
       "stats": {"score": 200, "kills": 12, "deaths": 19, "assists": 8}
@@ -55,7 +55,7 @@
     {
       "puuid": "PUUID-PLAYER-06",
       "gameName": "Foxtrot",
-      "tagLine": "EU1",
+      "tagLine": "EU6",
       "teamId": "Red",
       "characterId": "raze-id",
       "stats": {"score": 310, "kills": 21, "deaths": 13, "assists": 3}
@@ -63,7 +63,7 @@
     {
       "puuid": "PUUID-PLAYER-07",
       "gameName": "Golf",
-      "tagLine": "EU1",
+      "tagLine": "EU7",
       "teamId": "Red",
       "characterId": "brimstone-id",
       "stats": {"score": 290, "kills": 19, "deaths": 14, "assists": 5}
@@ -71,7 +71,7 @@
     {
       "puuid": "PUUID-PLAYER-08",
       "gameName": "Hotel",
-      "tagLine": "EU1",
+      "tagLine": "EU8",
       "teamId": "Red",
       "characterId": "cypher-id",
       "stats": {"score": 250, "kills": 16, "deaths": 16, "assists": 4}
@@ -79,7 +79,7 @@
     {
       "puuid": "PUUID-PLAYER-09",
       "gameName": "India",
-      "tagLine": "EU1",
+      "tagLine": "EU9",
       "teamId": "Red",
       "characterId": "phoenix-id",
       "stats": {"score": 220, "kills": 14, "deaths": 17, "assists": 5}
@@ -87,7 +87,7 @@
     {
       "puuid": "PUUID-PLAYER-10",
       "gameName": "Juliet",
-      "tagLine": "EU1",
+      "tagLine": "EU0",
       "teamId": "Red",
       "characterId": "skye-id",
       "stats": {"score": 205, "kills": 13, "deaths": 18, "assists": 6}

--- a/services/data_pipeline/tests/test_riot_connector.py
+++ b/services/data_pipeline/tests/test_riot_connector.py
@@ -78,7 +78,14 @@ def _ok(json_body: dict[str, Any]) -> dict[str, Any]:
 
 
 def _ok_match() -> dict[str, Any]:
-    return _ok({"match": _load_fixture("match.json")})
+    # Fixture body must match the shape ``RiotConnector._fetch_match``
+    # returns, which is the parsed JSON body verbatim. The
+    # ``fetch`` loop then wraps that in ``{"match_id": ..., "match": ...}``
+    # before yielding, and ``validate`` reads ``raw_payload["match"]``
+    # to find ``matchInfo`` / ``players`` / ``roundResults``. An extra
+    # ``{"match": ...}`` wrapper here would shift the expected keys
+    # one level deeper and trip ``SCHEMA_DRIFT``.
+    return _ok(_load_fixture("match.json"))
 
 
 def _matchlist_response() -> dict[str, Any]:

--- a/services/ecosystem/pyproject.toml
+++ b/services/ecosystem/pyproject.toml
@@ -9,6 +9,11 @@ description = "Tycoon / management simulation service."
 requires-python = ">=3.12,<3.13"
 dependencies = [
     "esports-sim-shared",
+    # Graph exporter (BUF-53, Systems-spec System 08) emits feature
+    # matrices as numpy arrays. torch / torch_geometric stay optional —
+    # the exporter is numpy-only at the boundary; HeteroData.to_pyg()
+    # imports them lazily for trainer code that actually needs them.
+    "numpy>=1.26",
 ]
 
 [tool.uv.sources]

--- a/services/ecosystem/src/ecosystem/graph/__init__.py
+++ b/services/ecosystem/src/ecosystem/graph/__init__.py
@@ -25,7 +25,7 @@ Public API::
 """
 
 from ecosystem.graph.builder import build_snapshot
-from ecosystem.graph.export import export_era
+from ecosystem.graph.export import GraphExportStateError, export_era
 from ecosystem.graph.schema import (
     EDGE_TYPES,
     NODE_TYPES,
@@ -62,6 +62,7 @@ __all__ = [
     "ValidationReport",
     "build_snapshot",
     "edge_spec",
+    "GraphExportStateError",
     "export_era",
     "node_spec",
     "validate_snapshot",

--- a/services/ecosystem/src/ecosystem/graph/__init__.py
+++ b/services/ecosystem/src/ecosystem/graph/__init__.py
@@ -1,0 +1,68 @@
+"""Heterogeneous graph schema + export pipeline (BUF-53, Systems-spec System 08).
+
+The full graph the GNN trains on is a four-node, four-edge ``HeteroData``:
+
+* Nodes: ``player``, ``team``, ``patch``, ``agent``.
+* Edges: ``(player, plays_for, team)``, ``(team, relates_to, team)``,
+  ``(team, sponsored_by, team)``, ``(patch, affects, agent)``.
+
+A snapshot is built per patch era. The builder pulls rows from a
+:class:`~ecosystem.graph.source.GraphDataSource`, the normalisers in
+:mod:`ecosystem.graph.normalize` rescale every column to the unit
+interval (acceptance: "no raw un-scaled columns"), the validator in
+:mod:`ecosystem.graph.validate` runs the System-09 structural checks,
+and :mod:`ecosystem.graph.export` registers the run in the BUF-69
+registry and writes ``snapshot.npz`` plus ``manifest.json`` under
+``runs/{run_id}/``.
+
+Public API::
+
+    from ecosystem.graph import GraphSnapshot, build_snapshot, export_era
+    from ecosystem.graph.source import InMemoryDataSource
+
+    snapshot = build_snapshot(source, era_slug="e2024_01")
+    snapshot.to_pyg()  # lazy torch_geometric.HeteroData adapter
+"""
+
+from ecosystem.graph.builder import build_snapshot
+from ecosystem.graph.export import export_era
+from ecosystem.graph.schema import (
+    EDGE_TYPES,
+    NODE_TYPES,
+    EdgeSpec,
+    FeatureColumn,
+    FeatureGroup,
+    NodeSpec,
+    SchemaError,
+    edge_spec,
+    node_spec,
+)
+from ecosystem.graph.snapshot import EdgeBlock, GraphSnapshot, NodeBlock
+from ecosystem.graph.source import GraphDataSource, InMemoryDataSource
+from ecosystem.graph.validate import (
+    StructuralValidationError,
+    ValidationReport,
+    validate_snapshot,
+)
+
+__all__ = [
+    "EDGE_TYPES",
+    "EdgeBlock",
+    "EdgeSpec",
+    "FeatureColumn",
+    "FeatureGroup",
+    "GraphDataSource",
+    "GraphSnapshot",
+    "InMemoryDataSource",
+    "NODE_TYPES",
+    "NodeBlock",
+    "NodeSpec",
+    "SchemaError",
+    "StructuralValidationError",
+    "ValidationReport",
+    "build_snapshot",
+    "edge_spec",
+    "export_era",
+    "node_spec",
+    "validate_snapshot",
+]

--- a/services/ecosystem/src/ecosystem/graph/builder.py
+++ b/services/ecosystem/src/ecosystem/graph/builder.py
@@ -70,9 +70,7 @@ def build_snapshot(
         node_block, node_fit = _build_node_block(node_schema, node_rows)
         snapshot.node_blocks[node_type] = node_block
         ids_by_type[node_type] = {nid: idx for idx, nid in enumerate(node_block.ids)}
-        normalizer_params[node_type] = {
-            col: fit.to_jsonable() for col, fit in node_fit.items()
-        }
+        normalizer_params[node_type] = {col: fit.to_jsonable() for col, fit in node_fit.items()}
 
     # Edge blocks --------------------------------------------------------
     edge_normalizer_params: dict[str, dict[str, dict[str, Any]]] = {}
@@ -109,10 +107,7 @@ def _build_node_block(
     # First pass: drop any rows where a ``drop_node`` column is missing.
     drop_required = [col.name for col in columns if col.fill_policy == "drop_node"]
     if drop_required:
-        rows = [
-            r for r in rows
-            if all(_is_present(r.features.get(name)) for name in drop_required)
-        ]
+        rows = [r for r in rows if all(_is_present(r.features.get(name)) for name in drop_required)]
 
     n = len(rows)
     if n == 0:
@@ -175,9 +170,7 @@ def _attr_sort_key(attrs: dict[str, Any]) -> tuple[tuple[str, str], ...]:
     return tuple(sorted((k, str(attrs[k])) for k in attrs))
 
 
-def _apply_fill_policy(
-    normed: np.ndarray, raw: np.ndarray, col: FeatureColumn
-) -> np.ndarray:
+def _apply_fill_policy(normed: np.ndarray, raw: np.ndarray, col: FeatureColumn) -> np.ndarray:
     """Replace NaN cells (originally missing values) per the column's policy.
 
     ``raw`` is the pre-normalisation column; we use it to identify
@@ -303,9 +296,7 @@ def _build_edge_block(
     fit_by_col: dict[str, FitParams] = {}
     if spec.edge_attr_columns:
         if not kept_rows:
-            edge_attr = np.zeros(
-                (0, len(spec.edge_attr_columns)), dtype=np.float32
-            )
+            edge_attr = np.zeros((0, len(spec.edge_attr_columns)), dtype=np.float32)
         else:
             cols: list[np.ndarray] = []
             for col in spec.edge_attr_columns:

--- a/services/ecosystem/src/ecosystem/graph/builder.py
+++ b/services/ecosystem/src/ecosystem/graph/builder.py
@@ -157,17 +157,34 @@ def _build_node_block(
     return block, fit_by_col
 
 
-def _attr_sort_key(attrs: dict[str, Any]) -> tuple[tuple[str, str], ...]:
+def _attr_sort_key(
+    attrs: dict[str, Any], schema_columns: tuple[FeatureColumn, ...]
+) -> tuple[tuple[str, str], ...]:
     """Stable tertiary sort key for edges with identical endpoints.
 
-    Sorting attribute items by key first canonicalises the dict
-    iteration order; rendering values through ``str`` keeps the key
-    comparable even when values are mixed types (float / NaN /
-    datetime). We don't need the original value back — just a
-    deterministic ordering that two equivalent source implementations
-    will agree on.
+    Restricted to the schema-declared ``edge_attr_columns`` so volatile
+    non-schema keys (debug timestamps, per-source metadata) on the
+    source row can't perturb the sort order of duplicate-endpoint
+    edges. Without that restriction two equivalent sources — same
+    modeled features, different bookkeeping fields — produce different
+    snapshot fingerprints and the registry's idempotency contract
+    breaks. (See Codex review on PR #24.)
+
+    Missing keys and explicit ``None`` values are folded to the same
+    canonical token so a source that *omits* a column and one that
+    sets it to ``None`` agree on order. They already agree on the
+    final ``edge_attr`` row (both run through ``_extract_raw`` →
+    ``NaN`` → ``_apply_fill_policy``), so the sort key has to match.
     """
-    return tuple(sorted((k, str(attrs[k])) for k in attrs))
+    _MISSING = "\x00MISSING\x00"
+    items: list[tuple[str, str]] = []
+    for col in schema_columns:
+        value = attrs.get(col.name)
+        items.append((col.name, _MISSING if value is None else str(value)))
+    # ``schema_columns`` already comes in declaration order, so we
+    # don't need to sort — but sort defensively in case the schema
+    # ever uses a non-tuple iterable.
+    return tuple(sorted(items))
 
 
 def _apply_fill_policy(normed: np.ndarray, raw: np.ndarray, col: FeatureColumn) -> np.ndarray:
@@ -276,12 +293,13 @@ def _build_edge_block(
     # byte-identical snapshots — preserving the registry's
     # idempotency contract.
     if kept_rows:
+        attr_columns = spec.edge_attr_columns
         order = sorted(
             range(len(kept_rows)),
             key=lambda i: (
                 src_idx[i],
                 dst_idx[i],
-                _attr_sort_key(kept_rows[i].attributes),
+                _attr_sort_key(kept_rows[i].attributes, attr_columns),
             ),
         )
         src_idx = [src_idx[i] for i in order]

--- a/services/ecosystem/src/ecosystem/graph/builder.py
+++ b/services/ecosystem/src/ecosystem/graph/builder.py
@@ -1,0 +1,290 @@
+"""Build a :class:`GraphSnapshot` for one era from a :class:`GraphDataSource`.
+
+The builder is the only place that talks to both the schema and the
+data source. It:
+
+1. Pulls every node row of every declared node type from the source.
+2. For each declared :class:`FeatureColumn`, extracts the raw values,
+   applies the column's fill policy to the missing entries, runs the
+   declared normaliser, and stacks the result into the node-type's
+   ``x`` matrix.
+3. Pulls every edge row of every declared edge type, indexes the
+   ``src_id`` / ``dst_id`` pairs against the node id tables, drops
+   edges whose endpoints didn't survive a ``drop_node`` policy, and
+   normalises any edge attributes the schema declares.
+4. Wraps the result in a :class:`GraphSnapshot` with normaliser
+   parameters and per-era metadata stamped into ``metadata``.
+
+The builder is pure: same source + same era → byte-identical
+snapshot. Determinism matters because the registry's data
+fingerprint is folded into the run id; a non-deterministic builder
+would mint a fresh run id on every re-run and defeat idempotency.
+"""
+
+from __future__ import annotations
+
+import math
+from typing import Any
+
+import numpy as np
+
+from ecosystem.graph.normalize import FitParams, normalize_column
+from ecosystem.graph.schema import (
+    EDGE_TYPES,
+    NODE_TYPES,
+    EdgeSpec,
+    FeatureColumn,
+    NodeSpec,
+)
+from ecosystem.graph.snapshot import EdgeBlock, GraphSnapshot, NodeBlock
+from ecosystem.graph.source import EdgeRow, GraphDataSource, NodeRow
+
+
+class BuildError(RuntimeError):
+    """Raised when the builder can't satisfy the schema for the era."""
+
+
+def build_snapshot(
+    source: GraphDataSource,
+    *,
+    era_slug: str,
+) -> GraphSnapshot:
+    """Build the full :class:`GraphSnapshot` for ``era_slug``."""
+    snapshot = GraphSnapshot(era_slug=era_slug)
+    # patch_meta is consumed both as a node-feature source for the
+    # synthetic ``patch`` node and as snapshot-wide metadata.
+    patch_meta = source.patch_meta(era_slug)
+
+    normalizer_params: dict[str, dict[str, dict[str, Any]]] = {}
+
+    # Node blocks --------------------------------------------------------
+    # ``ids_by_type`` is the post-build id table per node type, used
+    # downstream for edge endpoint resolution.
+    ids_by_type: dict[str, dict[str, int]] = {}
+    for node_type, node_schema in NODE_TYPES.items():
+        node_rows = list(source.iter_nodes(node_type, era_slug=era_slug))
+        # Patch is the only synthetic node type — if the source didn't
+        # emit a row for it, materialise one from the patch metadata.
+        if node_type == "patch" and not node_rows:
+            node_rows = [_patch_row_from_meta(era_slug, patch_meta)]
+        node_block, node_fit = _build_node_block(node_schema, node_rows)
+        snapshot.node_blocks[node_type] = node_block
+        ids_by_type[node_type] = {nid: idx for idx, nid in enumerate(node_block.ids)}
+        normalizer_params[node_type] = {
+            col: fit.to_jsonable() for col, fit in node_fit.items()
+        }
+
+    # Edge blocks --------------------------------------------------------
+    edge_normalizer_params: dict[str, dict[str, dict[str, Any]]] = {}
+    for key, edge_schema in EDGE_TYPES.items():
+        edge_rows = list(source.iter_edges(key, era_slug=era_slug))
+        edge_block, edge_fit = _build_edge_block(edge_schema, edge_rows, ids_by_type)
+        snapshot.edge_blocks[key] = edge_block
+        edge_normalizer_params["__".join(key)] = {
+            col: fit.to_jsonable() for col, fit in edge_fit.items()
+        }
+
+    # Stamp deterministic metadata. The build timestamp deliberately
+    # is *not* recorded — wall-clock would make the snapshot non-
+    # deterministic, breaking the registry's content-hash idempotency.
+    snapshot.metadata = {
+        "era_slug": era_slug,
+        "patch_meta": patch_meta,
+        "node_normalizer_params": normalizer_params,
+        "edge_normalizer_params": edge_normalizer_params,
+    }
+    return snapshot
+
+
+# ---- node-block construction ----------------------------------------------
+
+
+def _build_node_block(
+    spec: NodeSpec,
+    rows: list[NodeRow],
+) -> tuple[NodeBlock, dict[str, FitParams]]:
+    """Return the populated NodeBlock and per-column fit params."""
+    columns = spec.all_columns()
+
+    # First pass: drop any rows where a ``drop_node`` column is missing.
+    drop_required = [col.name for col in columns if col.fill_policy == "drop_node"]
+    if drop_required:
+        rows = [
+            r for r in rows
+            if all(_is_present(r.features.get(name)) for name in drop_required)
+        ]
+
+    n = len(rows)
+    if n == 0:
+        # Empty era is legal (a region with no matches in the window);
+        # keep an empty (0, F) matrix so downstream shape handling
+        # stays uniform.
+        x = np.zeros((0, spec.feature_dim()), dtype=np.float32)
+        return (
+            NodeBlock(
+                node_type=spec.name,
+                ids=[],
+                x=x,
+                column_names=spec.column_names(),
+            ),
+            {},
+        )
+
+    # Stable id ordering. Sorting by id makes the snapshot deterministic
+    # regardless of the source's iteration order — a different source
+    # implementation can't perturb edge_index integers downstream.
+    rows.sort(key=lambda r: r.id)
+
+    cols: list[np.ndarray] = []
+    fit_by_col: dict[str, FitParams] = {}
+    for col in columns:
+        raw = np.array(
+            [_extract_raw(r.features, col) for r in rows],
+            dtype=np.float64,
+        )
+        normed, fit = normalize_column(raw, normalizer_name=col.normalizer)
+        cols.append(normed)
+        fit_by_col[col.name] = fit
+
+    x = np.stack(cols, axis=1).astype(np.float32, copy=False)
+    block = NodeBlock(
+        node_type=spec.name,
+        ids=[r.id for r in rows],
+        x=x,
+        column_names=spec.column_names(),
+    )
+    return block, fit_by_col
+
+
+def _extract_raw(features: dict[str, Any], col: FeatureColumn) -> float:
+    """Pull a raw scalar for ``col`` from a row's features dict.
+
+    Missing / None / NaN values are *not* substituted here — they are
+    preserved as NaN so the normaliser's fit phase can ignore them.
+    The post-normalisation NaN-fill below applies the column's
+    fill_policy on the normalised side, where 0 / mean have a
+    well-defined meaning.
+    """
+    val = features.get(col.name)
+    if val is None:
+        return float("nan")
+    try:
+        f = float(val)
+    except (TypeError, ValueError):
+        return float("nan")
+    if math.isnan(f) or math.isinf(f):
+        return float("nan")
+    return f
+
+
+def _is_present(value: Any) -> bool:
+    if value is None:
+        return False
+    try:
+        f = float(value)
+    except (TypeError, ValueError):
+        return True  # non-numeric but present (e.g. a label)
+    return not math.isnan(f)
+
+
+# ---- edge-block construction ----------------------------------------------
+
+
+def _build_edge_block(
+    spec: EdgeSpec,
+    rows: list[EdgeRow],
+    ids_by_type: dict[str, dict[str, int]],
+) -> tuple[EdgeBlock, dict[str, FitParams]]:
+    src_lookup = ids_by_type.get(spec.src, {})
+    dst_lookup = ids_by_type.get(spec.dst, {})
+
+    # Resolve endpoint ids to node-local indices; drop edges whose
+    # endpoints didn't survive the node build (e.g. dropped by
+    # drop_node policy, or simply absent from the era).
+    src_idx: list[int] = []
+    dst_idx: list[int] = []
+    kept_rows: list[EdgeRow] = []
+    for row in rows:
+        s = src_lookup.get(row.src_id)
+        d = dst_lookup.get(row.dst_id)
+        if s is None or d is None:
+            continue
+        src_idx.append(s)
+        dst_idx.append(d)
+        kept_rows.append(row)
+
+    # Determinism: sort by (src, dst) so a reorder in the source can't
+    # shuffle the snapshot's edge_index columns.
+    if kept_rows:
+        order = sorted(range(len(kept_rows)), key=lambda i: (src_idx[i], dst_idx[i]))
+        src_idx = [src_idx[i] for i in order]
+        dst_idx = [dst_idx[i] for i in order]
+        kept_rows = [kept_rows[i] for i in order]
+
+    edge_index = np.array([src_idx, dst_idx], dtype=np.int64)
+    if edge_index.size == 0:
+        edge_index = np.zeros((2, 0), dtype=np.int64)
+
+    edge_attr: np.ndarray | None = None
+    fit_by_col: dict[str, FitParams] = {}
+    if spec.edge_attr_columns:
+        if not kept_rows:
+            edge_attr = np.zeros(
+                (0, len(spec.edge_attr_columns)), dtype=np.float32
+            )
+        else:
+            cols: list[np.ndarray] = []
+            for col in spec.edge_attr_columns:
+                raw = np.array(
+                    [_extract_raw(r.attributes, col) for r in kept_rows],
+                    dtype=np.float64,
+                )
+                normed, fit = normalize_column(raw, normalizer_name=col.normalizer)
+                cols.append(normed)
+                fit_by_col[col.name] = fit
+            edge_attr = np.stack(cols, axis=1).astype(np.float32, copy=False)
+
+    block = EdgeBlock(
+        src=spec.src,
+        relation=spec.relation,
+        dst=spec.dst,
+        edge_index=edge_index,
+        edge_attr=edge_attr,
+        edge_attr_columns=tuple(c.name for c in spec.edge_attr_columns),
+    )
+    return block, fit_by_col
+
+
+# ---- patch synthetic node --------------------------------------------------
+
+
+def _patch_row_from_meta(era_slug: str, patch_meta: dict[str, Any]) -> NodeRow:
+    """Build a single patch node from the source's era metadata.
+
+    The data source is *allowed* to emit its own patch row (e.g. via a
+    SqlDataSource that joins with patch_era and the in-era match
+    aggregates), but for fixture-driven runs and for fresh eras we
+    derive a minimal row from whatever the source's
+    :meth:`patch_meta` returns.
+    """
+    season_year = patch_meta.get("season_year")
+    return NodeRow(
+        id=era_slug,
+        features={
+            "agg_match_acs": patch_meta.get("agg_match_acs", float("nan")),
+            "agg_match_kast": patch_meta.get("agg_match_kast", float("nan")),
+            "duration_days": patch_meta.get("duration_days", float("nan")),
+            "matches_played": patch_meta.get("matches_played", float("nan")),
+            "agents_added": patch_meta.get("agents_added", 0.0),
+            "maps_added": patch_meta.get("maps_added", 0.0),
+            "meta_magnitude": patch_meta.get("meta_magnitude", 0.0),
+            "is_major_shift": 1.0 if patch_meta.get("is_major_shift") else 0.0,
+            "era_ordinal": patch_meta.get("era_ordinal", 0.0),
+            "season_year_2024": 1.0 if season_year == 2024 else 0.0,
+            "season_year_2025": 1.0 if season_year == 2025 else 0.0,
+            "season_year_2026": 1.0 if season_year == 2026 else 0.0,
+        },
+    )
+
+
+__all__ = ["BuildError", "build_snapshot"]

--- a/services/ecosystem/src/ecosystem/graph/builder.py
+++ b/services/ecosystem/src/ecosystem/graph/builder.py
@@ -142,7 +142,13 @@ def _build_node_block(
             [_extract_raw(r.features, col) for r in rows],
             dtype=np.float64,
         )
+        # ``normalize_column`` ignores NaN inputs during fit but leaves
+        # them in the output for the missing rows — that's the point at
+        # which the column's declared ``fill_policy`` has to step in.
+        # Without this fill the snapshot would carry NaN cells and
+        # tip the validator's ``non_finite_features`` check.
         normed, fit = normalize_column(raw, normalizer_name=col.normalizer)
+        normed = _apply_fill_policy(normed, raw, col)
         cols.append(normed)
         fit_by_col[col.name] = fit
 
@@ -154,6 +160,48 @@ def _build_node_block(
         column_names=spec.column_names(),
     )
     return block, fit_by_col
+
+
+def _apply_fill_policy(
+    normed: np.ndarray, raw: np.ndarray, col: FeatureColumn
+) -> np.ndarray:
+    """Replace NaN cells (originally missing values) per the column's policy.
+
+    ``raw`` is the pre-normalisation column; we use it to identify
+    which rows were missing rather than re-checking ``normed`` —
+    the normalisers themselves can't *introduce* NaN, so the two
+    masks are equivalent, but reading from ``raw`` keeps the
+    intent visible to readers.
+
+    ``drop_node`` rows have already been filtered upstream, so
+    that policy never reaches this function. We still defensively
+    no-op on it rather than asserting, so a future refactor can't
+    crash here.
+    """
+    missing = np.isnan(raw)
+    if not missing.any():
+        return normed
+    if col.fill_policy == "zero":
+        normed = normed.copy()
+        normed[missing] = 0.0
+        return normed
+    if col.fill_policy == "mean":
+        # Post-normalisation mean is well-defined for every kind: it's
+        # the mean of the surviving (non-NaN) cells in ``normed`` itself.
+        # If every cell is missing, fall back to 0.5 — the "neutral"
+        # post-normalisation centre — rather than propagating NaN.
+        normed = normed.copy()
+        finite = normed[~missing]
+        fill_value = float(finite.mean()) if finite.size else 0.5
+        normed[missing] = fill_value
+        return normed
+    # ``drop_node`` reaches here only if the upstream filter let a
+    # row through anyway (e.g. a passthrough column with the policy
+    # nominally set). Treat as zero rather than failing — the
+    # validator catches anything genuinely broken.
+    normed = normed.copy()
+    normed[missing] = 0.0
+    return normed
 
 
 def _extract_raw(features: dict[str, Any], col: FeatureColumn) -> float:
@@ -240,6 +288,11 @@ def _build_edge_block(
                     dtype=np.float64,
                 )
                 normed, fit = normalize_column(raw, normalizer_name=col.normalizer)
+                # Same fill story as the node-block path — without
+                # this, an edge row missing one attribute would
+                # leave a NaN in ``edge_attr`` and trip
+                # ``non_finite_edge_attr``.
+                normed = _apply_fill_policy(normed, raw, col)
                 cols.append(normed)
                 fit_by_col[col.name] = fit
             edge_attr = np.stack(cols, axis=1).astype(np.float32, copy=False)

--- a/services/ecosystem/src/ecosystem/graph/builder.py
+++ b/services/ecosystem/src/ecosystem/graph/builder.py
@@ -162,6 +162,19 @@ def _build_node_block(
     return block, fit_by_col
 
 
+def _attr_sort_key(attrs: dict[str, Any]) -> tuple[tuple[str, str], ...]:
+    """Stable tertiary sort key for edges with identical endpoints.
+
+    Sorting attribute items by key first canonicalises the dict
+    iteration order; rendering values through ``str`` keeps the key
+    comparable even when values are mixed types (float / NaN /
+    datetime). We don't need the original value back — just a
+    deterministic ordering that two equivalent source implementations
+    will agree on.
+    """
+    return tuple(sorted((k, str(attrs[k])) for k in attrs))
+
+
 def _apply_fill_policy(
     normed: np.ndarray, raw: np.ndarray, col: FeatureColumn
 ) -> np.ndarray:
@@ -262,9 +275,22 @@ def _build_edge_block(
         kept_rows.append(row)
 
     # Determinism: sort by (src, dst) so a reorder in the source can't
-    # shuffle the snapshot's edge_index columns.
+    # shuffle the snapshot's edge_index columns. Two rows with the
+    # same endpoints are legal (a time-bounded relation re-asserted at
+    # different windows; an upstream double-write) and we break the
+    # tie on a canonicalised attribute fingerprint so identical
+    # source contents from two implementations still produce
+    # byte-identical snapshots — preserving the registry's
+    # idempotency contract.
     if kept_rows:
-        order = sorted(range(len(kept_rows)), key=lambda i: (src_idx[i], dst_idx[i]))
+        order = sorted(
+            range(len(kept_rows)),
+            key=lambda i: (
+                src_idx[i],
+                dst_idx[i],
+                _attr_sort_key(kept_rows[i].attributes),
+            ),
+        )
         src_idx = [src_idx[i] for i in order]
         dst_idx = [dst_idx[i] for i in order]
         kept_rows = [kept_rows[i] for i in order]

--- a/services/ecosystem/src/ecosystem/graph/export.py
+++ b/services/ecosystem/src/ecosystem/graph/export.py
@@ -39,6 +39,19 @@ _log = logging.getLogger(__name__)
 GRAPH_SNAPSHOT_KIND = "graph-snapshot"
 
 
+class GraphExportStateError(RuntimeError):
+    """Raised when the registry and on-disk artifacts disagree.
+
+    The orchestrator's exit contract is binary: a terminal registry
+    row matches a complete on-disk artifact set. If a re-run finds
+    a terminal row whose artifacts vanished, neither rebuilding (the
+    registry would silently keep the old status because
+    ``Registry.finalize`` no-ops on terminal rows) nor blindly
+    returning the cached status (there is no cache) is correct.
+    Surface it as an operator-actionable error instead.
+    """
+
+
 @dataclass(frozen=True, slots=True)
 class ExportResult:
     """Compact summary of one ``export_era`` invocation.
@@ -99,23 +112,32 @@ def export_era(
     record = registry.get(run_id)
 
     # Idempotent re-runs: the registry returned an existing run_id.
-    # If the on-disk artifacts are still there, skip the rebuild — the
-    # contract is "same input → same output", and writing the same
-    # bytes twice is wasted I/O. If they're missing (operator deleted
-    # them), rebuild them under the existing run_id.
+    # Both terminal statuses are valid resting states (per the
+    # function docstring's exit contract), so a hit on either
+    # COMPLETED *or* FAILED with intact artifacts short-circuits to
+    # the cached report. Treating only COMPLETED as a hit would
+    # rebuild after a prior FAILED, then call ``Registry.finalize``
+    # which is a no-op on terminal rows — leaving ``ExportResult.passed``
+    # potentially True while the registry says FAILED, contradicting
+    # the contract. (See Codex review on PR #24.)
     snapshot_path = record.run_dir / "snapshot.npz"
     manifest_path = record.run_dir / "manifest.json"
     validation_path = record.run_dir / "validation.json"
+    artifacts_present = (
+        snapshot_path.exists() and manifest_path.exists() and validation_path.exists()
+    )
     if (
-        record.status is RunStatus.COMPLETED
-        and snapshot_path.exists()
-        and manifest_path.exists()
-        and validation_path.exists()
+        record.status in (RunStatus.COMPLETED, RunStatus.FAILED)
+        and artifacts_present
     ):
         report = _load_report(validation_path, era_slug)
         _log.info(
             "graph-snapshot.idempotent_hit",
-            extra={"run_id": run_id, "era_slug": era_slug},
+            extra={
+                "run_id": run_id,
+                "era_slug": era_slug,
+                "status": record.status.value,
+            },
         )
         return ExportResult(
             run_id=run_id,
@@ -125,6 +147,21 @@ def export_era(
             validation_path=validation_path,
             report=report,
             snapshot=snapshot,
+        )
+
+    # Existing terminal row but artifacts gone (operator deleted
+    # them or never ran). ``Registry.finalize`` is a no-op on
+    # non-RUNNING rows so we cannot legitimately re-mint the status,
+    # which means rebuilding here would leave the registry and the
+    # ``ExportResult.passed`` flag in conflicting states. Refuse
+    # rather than silently produce that contradiction.
+    if record.status in (RunStatus.COMPLETED, RunStatus.FAILED):
+        raise GraphExportStateError(
+            f"run_id={run_id!r} for era {era_slug!r} is already terminal "
+            f"({record.status.value}) but artifacts are missing under "
+            f"{record.run_dir}. Restore the artifacts or delete the row "
+            f"before re-exporting; the registry refuses to relabel a "
+            f"terminal run."
         )
 
     # Validate before writing so a fail-on-validation run still has
@@ -251,6 +288,7 @@ def _load_report(path: Path, era_slug: str) -> ValidationReport:
 __all__ = [
     "ExportResult",
     "GRAPH_SNAPSHOT_KIND",
+    "GraphExportStateError",
     "export_era",
     "export_eras",
 ]

--- a/services/ecosystem/src/ecosystem/graph/export.py
+++ b/services/ecosystem/src/ecosystem/graph/export.py
@@ -126,10 +126,7 @@ def export_era(
     artifacts_present = (
         snapshot_path.exists() and manifest_path.exists() and validation_path.exists()
     )
-    if (
-        record.status in (RunStatus.COMPLETED, RunStatus.FAILED)
-        and artifacts_present
-    ):
+    if record.status in (RunStatus.COMPLETED, RunStatus.FAILED) and artifacts_present:
         report = _load_report(validation_path, era_slug)
         _log.info(
             "graph-snapshot.idempotent_hit",
@@ -216,9 +213,7 @@ def export_eras(
     registry = registry or Registry()
     results: list[ExportResult] = []
     for slug in era_slugs:
-        result = export_era(
-            source, era_slug=slug, config_path=config_path, registry=registry
-        )
+        result = export_era(source, era_slug=slug, config_path=config_path, registry=registry)
         results.append(result)
         if fail_fast and not result.passed:
             raise StructuralValidationError(

--- a/services/ecosystem/src/ecosystem/graph/export.py
+++ b/services/ecosystem/src/ecosystem/graph/export.py
@@ -1,0 +1,256 @@
+"""Run-the-export orchestrator.
+
+Glues :func:`build_snapshot` → :func:`validate_snapshot` → BUF-69
+:class:`Registry` together. The exit contract is binary: a passing
+validation produces a ``completed`` registry row and ``snapshot.npz``
++ ``manifest.json`` + ``validation.json`` under the run directory; a
+failing validation produces a ``failed`` row plus the same artifacts
+(so an operator can read ``validation.json`` to see why).
+
+The function returns the :class:`~esports_sim.registry.RunRecord` so
+the caller can read paths off it without re-querying the registry.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import json
+import logging
+from dataclasses import dataclass
+from pathlib import Path
+
+from esports_sim.registry import Registry, RunStatus
+
+from ecosystem.graph.builder import build_snapshot
+from ecosystem.graph.schema import SCHEMA_VERSION
+from ecosystem.graph.snapshot import GraphSnapshot
+from ecosystem.graph.source import GraphDataSource
+from ecosystem.graph.validate import (
+    StructuralValidationError,
+    ValidationReport,
+    validate_snapshot,
+)
+
+_log = logging.getLogger(__name__)
+
+# The registry's ``kind`` field is part of the run id and a CLI
+# filter; keep it aligned with the System-08 vocabulary so future
+# digest tools can find graph runs without a substring search.
+GRAPH_SNAPSHOT_KIND = "graph-snapshot"
+
+
+@dataclass(frozen=True, slots=True)
+class ExportResult:
+    """Compact summary of one ``export_era`` invocation.
+
+    Returned to CLI / batch callers so they can log or aggregate
+    without re-reading the registry. Carries the full
+    :class:`ValidationReport` for ad-hoc inspection.
+    """
+
+    run_id: str
+    run_dir: Path
+    snapshot_path: Path
+    manifest_path: Path
+    validation_path: Path
+    report: ValidationReport
+    snapshot: GraphSnapshot
+
+    @property
+    def passed(self) -> bool:
+        return self.report.passed
+
+
+def export_era(
+    source: GraphDataSource,
+    *,
+    era_slug: str,
+    config_path: Path | str,
+    registry: Registry | None = None,
+) -> ExportResult:
+    """Build, validate, register, and persist one era's snapshot.
+
+    ``config_path`` is the YAML/JSON config that drove this build; the
+    registry hashes its bytes for idempotency. Re-running with the
+    same config + same source produces the same run_id (no-op).
+
+    Pass ``registry`` to share a Registry instance across multiple
+    eras (typical for a batch run); otherwise the function constructs
+    a default one wired through the standard env vars.
+    """
+    config_path = Path(config_path)
+    registry = registry or Registry()
+
+    # Building the snapshot first means the data fingerprint reflects
+    # the actual graph contents, not just the config — two runs of the
+    # same config against different upstream snapshots get different
+    # run ids, which is the right semantics for the registry's
+    # idempotency contract.
+    snapshot = build_snapshot(source, era_slug=era_slug)
+    fingerprint = _fingerprint_snapshot(snapshot)
+
+    notes = f"era={era_slug} schema={SCHEMA_VERSION}"
+    run_id = registry.register(
+        kind=GRAPH_SNAPSHOT_KIND,
+        config_path=config_path,
+        data_fingerprint=fingerprint,
+        notes=notes,
+    )
+    record = registry.get(run_id)
+
+    # Idempotent re-runs: the registry returned an existing run_id.
+    # If the on-disk artifacts are still there, skip the rebuild — the
+    # contract is "same input → same output", and writing the same
+    # bytes twice is wasted I/O. If they're missing (operator deleted
+    # them), rebuild them under the existing run_id.
+    snapshot_path = record.run_dir / "snapshot.npz"
+    manifest_path = record.run_dir / "manifest.json"
+    validation_path = record.run_dir / "validation.json"
+    if (
+        record.status is RunStatus.COMPLETED
+        and snapshot_path.exists()
+        and manifest_path.exists()
+        and validation_path.exists()
+    ):
+        report = _load_report(validation_path, era_slug)
+        _log.info(
+            "graph-snapshot.idempotent_hit",
+            extra={"run_id": run_id, "era_slug": era_slug},
+        )
+        return ExportResult(
+            run_id=run_id,
+            run_dir=record.run_dir,
+            snapshot_path=snapshot_path,
+            manifest_path=manifest_path,
+            validation_path=validation_path,
+            report=report,
+            snapshot=snapshot,
+        )
+
+    # Validate before writing so a fail-on-validation run still has
+    # the npz / manifest on disk for inspection (writing happens
+    # below regardless of pass/fail), but we know the verdict before
+    # finalising.
+    report = validate_snapshot(snapshot)
+
+    # Write artifacts. The npz + manifest go through GraphSnapshot's
+    # writer for round-trip parity with snapshot.read; validation.json
+    # is independent.
+    snapshot.write(record.run_dir)
+    validation_path.write_text(
+        json.dumps(report.to_jsonable(), indent=2, sort_keys=True),
+        encoding="utf-8",
+    )
+
+    final_status = RunStatus.COMPLETED if report.passed else RunStatus.FAILED
+    finalize_notes = (
+        f"validation={'pass' if report.passed else 'fail'} "
+        f"errors={len(report.errors)} warnings={len(report.warnings)}"
+    )
+    registry.finalize(run_id, status=final_status, notes=finalize_notes)
+
+    return ExportResult(
+        run_id=run_id,
+        run_dir=record.run_dir,
+        snapshot_path=snapshot_path,
+        manifest_path=manifest_path,
+        validation_path=validation_path,
+        report=report,
+        snapshot=snapshot,
+    )
+
+
+def export_eras(
+    source: GraphDataSource,
+    *,
+    era_slugs: list[str],
+    config_path: Path | str,
+    registry: Registry | None = None,
+    fail_fast: bool = False,
+) -> list[ExportResult]:
+    """Sequential batch wrapper around :func:`export_era`.
+
+    The acceptance scenario explicitly mentions "Full graph export for
+    3 eras passes all structural validation" — this is the helper
+    that does that. ``fail_fast`` controls whether a failed validation
+    raises immediately (operator pipelines) or continues to the next
+    era (CI batch jobs collecting a full report).
+    """
+    registry = registry or Registry()
+    results: list[ExportResult] = []
+    for slug in era_slugs:
+        result = export_era(
+            source, era_slug=slug, config_path=config_path, registry=registry
+        )
+        results.append(result)
+        if fail_fast and not result.passed:
+            raise StructuralValidationError(
+                f"era {slug!r} failed structural validation; aborting batch "
+                f"(see {result.validation_path})"
+            )
+    return results
+
+
+# ---- helpers ---------------------------------------------------------------
+
+
+def _fingerprint_snapshot(snapshot: GraphSnapshot) -> str:
+    """Stable SHA-256 over the snapshot's tensors + structural metadata.
+
+    This is what the registry uses to decide idempotency. We *do not*
+    include normaliser fit parameters in the fingerprint: they are a
+    pure function of the tensors, so folding them in would be
+    redundant. We *do* include the schema version so a schema bump
+    forces a re-register even if the underlying ids are unchanged.
+    """
+    h = hashlib.sha256()
+    h.update(SCHEMA_VERSION.encode("utf-8"))
+    h.update(snapshot.snapshot_format_version.encode("utf-8"))
+    h.update(snapshot.era_slug.encode("utf-8"))
+    for nt in sorted(snapshot.node_blocks):
+        node_block = snapshot.node_blocks[nt]
+        h.update(f"node:{nt}".encode())
+        h.update(b"\x00".join(i.encode("utf-8") for i in node_block.ids))
+        h.update(node_block.x.tobytes())
+    for k in sorted(snapshot.edge_blocks):
+        edge_block = snapshot.edge_blocks[k]
+        h.update(("edge:" + "__".join(k)).encode("utf-8"))
+        h.update(edge_block.edge_index.tobytes())
+        if edge_block.edge_attr is not None:
+            h.update(edge_block.edge_attr.tobytes())
+    return h.hexdigest()
+
+
+def _load_report(path: Path, era_slug: str) -> ValidationReport:
+    """Re-hydrate a ``validation.json`` for the idempotent-hit path.
+
+    Only the fields :class:`ExportResult` actually exposes are
+    repopulated — the export path returns the original snapshot
+    object, so a callsite that wants the full issue list can read it
+    off the file directly.
+    """
+    raw = json.loads(path.read_text(encoding="utf-8"))
+    from ecosystem.graph.validate import ValidationIssue  # noqa: PLC0415 (local)
+
+    issues = [
+        ValidationIssue(
+            code=i["code"],
+            severity=i["severity"],
+            location=i["location"],
+            message=i["message"],
+        )
+        for i in raw.get("issues", [])
+    ]
+    return ValidationReport(
+        era_slug=raw.get("era_slug", era_slug),
+        schema_version=raw.get("schema_version", SCHEMA_VERSION),
+        issues=issues,
+    )
+
+
+__all__ = [
+    "ExportResult",
+    "GRAPH_SNAPSHOT_KIND",
+    "export_era",
+    "export_eras",
+]

--- a/services/ecosystem/src/ecosystem/graph/export.py
+++ b/services/ecosystem/src/ecosystem/graph/export.py
@@ -23,7 +23,7 @@ from esports_sim.registry import Registry, RunStatus
 
 from ecosystem.graph.builder import build_snapshot
 from ecosystem.graph.schema import SCHEMA_VERSION
-from ecosystem.graph.snapshot import GraphSnapshot
+from ecosystem.graph.snapshot import GraphSnapshot, jsonable_default
 from ecosystem.graph.source import GraphDataSource
 from ecosystem.graph.validate import (
     StructuralValidationError,
@@ -239,6 +239,13 @@ def _fingerprint_snapshot(snapshot: GraphSnapshot) -> str:
     pure function of the tensors, so folding them in would be
     redundant. We *do* include the schema version so a schema bump
     forces a re-register even if the underlying ids are unchanged.
+
+    The snapshot's ``metadata`` block is folded in too: the manifest
+    persists it verbatim, so two builds with the same tensors but
+    different metadata (e.g. shifted ``patch_meta.starts_at``) would
+    otherwise share a fingerprint and the orchestrator's idempotent
+    short-circuit would reuse stale artifacts. (See Codex review on
+    PR #24.)
     """
     h = hashlib.sha256()
     h.update(SCHEMA_VERSION.encode("utf-8"))
@@ -255,6 +262,16 @@ def _fingerprint_snapshot(snapshot: GraphSnapshot) -> str:
         h.update(edge_block.edge_index.tobytes())
         if edge_block.edge_attr is not None:
             h.update(edge_block.edge_attr.tobytes())
+    # Reuse the manifest's JSON encoder so the fingerprint sees the
+    # same bytes the persisted manifest would. ``sort_keys=True`` is
+    # what makes the digest order-independent across dict iterations.
+    metadata_bytes = json.dumps(
+        snapshot.metadata,
+        sort_keys=True,
+        default=jsonable_default,
+    ).encode("utf-8")
+    h.update(b"metadata:")
+    h.update(metadata_bytes)
     return h.hexdigest()
 
 

--- a/services/ecosystem/src/ecosystem/graph/normalize.py
+++ b/services/ecosystem/src/ecosystem/graph/normalize.py
@@ -1,0 +1,227 @@
+"""Per-column normalisers for the graph builder.
+
+Acceptance: "Feature matrices are fully normalized (no raw un-scaled
+columns)." Every column declared in :mod:`ecosystem.graph.schema`
+names a normaliser; the builder looks the name up here and applies it.
+A column with normaliser ``"passthrough"`` is *not* a raw escape
+hatch — it asserts the value is already in the unit interval (typical
+for one-hot / boolean indicators) and clips defensively.
+
+Normalisers are stateful per (node_type, column): they fit on the
+era's data, then transform. Fit parameters land on the snapshot's
+``metadata`` block so a held-out evaluation row can be transformed
+later without re-running the pipeline.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+
+
+class NormalizerError(ValueError):
+    """Raised when a normaliser is asked to do something impossible."""
+
+
+# Tolerance for "is this value in [0, 1]?" — passthrough columns get
+# clipped to the unit interval if they're within this slack, so a
+# float-comparison rounding error doesn't fail validation.
+_UNIT_SLACK = 1e-6
+
+
+@dataclass(slots=True)
+class FitParams:
+    """The per-column scalar parameters a normaliser learned during fit.
+
+    Stored on the snapshot manifest. ``kind`` is the normaliser name
+    so a future loader can re-instantiate without guessing.
+    """
+
+    kind: str
+    params: dict[str, float] = field(default_factory=dict)
+
+    def to_jsonable(self) -> dict[str, Any]:
+        return {"kind": self.kind, "params": dict(self.params)}
+
+
+class _Normalizer:
+    """Internal base class. Each subclass implements ``fit`` + ``transform``.
+
+    Stateless API for the builder: a fresh instance per (node_type,
+    column) on every build. The fit / transform separation is what
+    makes era-relative normalisation deterministic — fit only sees the
+    era's column, transform only sees the era's column.
+    """
+
+    name: str
+
+    def fit(self, values: np.ndarray) -> FitParams:  # pragma: no cover - abstract
+        raise NotImplementedError
+
+    def transform(  # pragma: no cover - abstract
+        self, values: np.ndarray, params: FitParams
+    ) -> np.ndarray:
+        raise NotImplementedError
+
+
+class _MinMax(_Normalizer):
+    """Linear rescale to ``[0, 1]`` against the era's min/max.
+
+    Degenerate column (all-equal values, or empty input) falls back to
+    a uniform 0.5 — preserves the "no raw column" invariant without
+    introducing NaNs from a zero-range divide.
+    """
+
+    name = "minmax"
+
+    def fit(self, values: np.ndarray) -> FitParams:
+        finite = values[np.isfinite(values)]
+        if finite.size == 0:
+            return FitParams(self.name, {"min": 0.0, "max": 1.0, "degenerate": 1.0})
+        lo = float(finite.min())
+        hi = float(finite.max())
+        degenerate = 1.0 if hi <= lo else 0.0
+        return FitParams(self.name, {"min": lo, "max": hi, "degenerate": degenerate})
+
+    def transform(self, values: np.ndarray, params: FitParams) -> np.ndarray:
+        if params.params.get("degenerate", 0.0) >= 1.0:
+            return np.full_like(values, 0.5, dtype=np.float64)
+        lo = params.params["min"]
+        hi = params.params["max"]
+        out = (values - lo) / (hi - lo)
+        return np.clip(out, 0.0, 1.0)
+
+
+class _ZScore(_Normalizer):
+    """Standardise to mean 0, std 1, then squash through a logistic.
+
+    The logistic squash keeps the output bounded in ``(0, 1)`` so the
+    "no raw" invariant holds; the underlying z-score lives in the
+    fit params for callers who need to invert.
+    """
+
+    name = "zscore"
+
+    def fit(self, values: np.ndarray) -> FitParams:
+        finite = values[np.isfinite(values)]
+        if finite.size == 0:
+            return FitParams(self.name, {"mean": 0.0, "std": 1.0, "degenerate": 1.0})
+        mean = float(finite.mean())
+        std = float(finite.std())
+        # ``ddof=0`` (population std) — we're describing the era's
+        # population, not estimating a sample.
+        if std < 1e-9:
+            return FitParams(self.name, {"mean": mean, "std": 1.0, "degenerate": 1.0})
+        return FitParams(self.name, {"mean": mean, "std": std, "degenerate": 0.0})
+
+    def transform(self, values: np.ndarray, params: FitParams) -> np.ndarray:
+        if params.params.get("degenerate", 0.0) >= 1.0:
+            return np.full_like(values, 0.5, dtype=np.float64)
+        z = (values - params.params["mean"]) / params.params["std"]
+        # Stable logistic — clip the input so large |z| doesn't
+        # under/overflow exp() in fp64.
+        z = np.clip(z, -50.0, 50.0)
+        return 1.0 / (1.0 + np.exp(-z))
+
+
+class _Log1pMinMax(_Normalizer):
+    """``log1p`` then min-max. Use for long-tailed positive counts.
+
+    Negative inputs are clamped to 0 before log1p — long-tailed counts
+    are non-negative by construction, so a negative is a data bug we
+    quietly correct rather than NaN-propagate.
+    """
+
+    name = "log1p_minmax"
+
+    def fit(self, values: np.ndarray) -> FitParams:
+        finite = values[np.isfinite(values)]
+        clamped = np.clip(finite, 0.0, None)
+        if clamped.size == 0:
+            return FitParams(self.name, {"min": 0.0, "max": 1.0, "degenerate": 1.0})
+        logged = np.log1p(clamped)
+        lo = float(logged.min())
+        hi = float(logged.max())
+        return FitParams(
+            self.name,
+            {"min": lo, "max": hi, "degenerate": 1.0 if hi <= lo else 0.0},
+        )
+
+    def transform(self, values: np.ndarray, params: FitParams) -> np.ndarray:
+        if params.params.get("degenerate", 0.0) >= 1.0:
+            return np.full_like(values, 0.5, dtype=np.float64)
+        clamped = np.clip(values, 0.0, None)
+        logged = np.log1p(clamped)
+        out = (logged - params.params["min"]) / (params.params["max"] - params.params["min"])
+        return np.asarray(np.clip(out, 0.0, 1.0))
+
+
+class _Passthrough(_Normalizer):
+    """Assert + clip to ``[0, 1]``. For one-hots and pre-scaled inputs.
+
+    Slightly out-of-range inputs (within :data:`_UNIT_SLACK`) are
+    silently clipped; anything farther out raises so a schema bug
+    doesn't sneak through.
+    """
+
+    name = "passthrough"
+
+    def fit(self, values: np.ndarray) -> FitParams:
+        finite = values[np.isfinite(values)]
+        if finite.size and (
+            (finite < -_UNIT_SLACK).any() or (finite > 1.0 + _UNIT_SLACK).any()
+        ):
+            raise NormalizerError(
+                f"passthrough column got values outside [0, 1]: "
+                f"min={float(finite.min())}, max={float(finite.max())}. "
+                f"Either fix the source or pick a real normaliser."
+            )
+        return FitParams(self.name, {})
+
+    def transform(self, values: np.ndarray, params: FitParams) -> np.ndarray:
+        return np.asarray(np.clip(values, 0.0, 1.0))
+
+
+_NORMALIZERS: dict[str, _Normalizer] = {
+    n.name: n
+    for n in (_MinMax(), _ZScore(), _Log1pMinMax(), _Passthrough())
+}
+
+
+def get_normalizer(name: str) -> _Normalizer:
+    try:
+        return _NORMALIZERS[name]
+    except KeyError as e:
+        raise NormalizerError(
+            f"unknown normaliser {name!r}; known: {sorted(_NORMALIZERS)}"
+        ) from e
+
+
+def normalize_column(
+    values: np.ndarray,
+    *,
+    normalizer_name: str,
+) -> tuple[np.ndarray, FitParams]:
+    """Fit then transform a single column. Returns (out, fit_params).
+
+    The fit params are returned alongside the values so the builder
+    can stuff them in the snapshot's metadata; round-tripping a
+    held-out row through the same parameters is the only safe way to
+    score a player who didn't appear in the training era.
+    """
+    norm = get_normalizer(normalizer_name)
+    fit = norm.fit(values.astype(np.float64, copy=False))
+    out = norm.transform(values.astype(np.float64, copy=False), fit)
+    # Force fp32 on the way out — matches GraphSnapshot's storage
+    # dtype, so the builder doesn't have to re-cast.
+    return out.astype(np.float32, copy=False), fit
+
+
+__all__ = [
+    "FitParams",
+    "NormalizerError",
+    "get_normalizer",
+    "normalize_column",
+]

--- a/services/ecosystem/src/ecosystem/graph/normalize.py
+++ b/services/ecosystem/src/ecosystem/graph/normalize.py
@@ -170,9 +170,7 @@ class _Passthrough(_Normalizer):
 
     def fit(self, values: np.ndarray) -> FitParams:
         finite = values[np.isfinite(values)]
-        if finite.size and (
-            (finite < -_UNIT_SLACK).any() or (finite > 1.0 + _UNIT_SLACK).any()
-        ):
+        if finite.size and ((finite < -_UNIT_SLACK).any() or (finite > 1.0 + _UNIT_SLACK).any()):
             raise NormalizerError(
                 f"passthrough column got values outside [0, 1]: "
                 f"min={float(finite.min())}, max={float(finite.max())}. "
@@ -185,8 +183,7 @@ class _Passthrough(_Normalizer):
 
 
 _NORMALIZERS: dict[str, _Normalizer] = {
-    n.name: n
-    for n in (_MinMax(), _ZScore(), _Log1pMinMax(), _Passthrough())
+    n.name: n for n in (_MinMax(), _ZScore(), _Log1pMinMax(), _Passthrough())
 }
 
 
@@ -194,9 +191,7 @@ def get_normalizer(name: str) -> _Normalizer:
     try:
         return _NORMALIZERS[name]
     except KeyError as e:
-        raise NormalizerError(
-            f"unknown normaliser {name!r}; known: {sorted(_NORMALIZERS)}"
-        ) from e
+        raise NormalizerError(f"unknown normaliser {name!r}; known: {sorted(_NORMALIZERS)}") from e
 
 
 def normalize_column(

--- a/services/ecosystem/src/ecosystem/graph/schema.py
+++ b/services/ecosystem/src/ecosystem/graph/schema.py
@@ -1,0 +1,418 @@
+"""HeteroData schema declarations (Systems-spec System 08).
+
+The schema is the contract between the data pipeline and every consumer
+of the exported graph (the GNN trainer, the validator, the snapshot
+diffing tools). Changing it is a versioned event: bump
+:data:`SCHEMA_VERSION` and add a migration note so an older snapshot
+doesn't get loaded into a newer trainer with silently-shifted columns.
+
+Feature columns are grouped into four named blocks per node type:
+
+* ``acs_norm`` — primary headline rate stats (ACS, KAST, ADR, ...)
+  rescaled into ``[0, 1]`` against the era's distribution.
+* ``derived`` — features computed from raw stats by the
+  ``config/derivation.yaml`` stage (first-blood rate, agent-specific
+  metrics, economy efficiency).
+* ``inferred`` — model-emitted estimates not present in the source
+  data (synergy embedding magnitude, role-fit score, latent skill).
+* ``context`` — slow-moving structural attributes (region one-hot,
+  tier rank, age in days, era ordinal).
+
+Each :class:`FeatureColumn` carries its dtype and a fill policy used
+when the source row is missing the column. The builder concatenates
+the four groups in declaration order; the manifest carried with each
+snapshot records which column ended up at which index so a downstream
+trainer never has to guess by position.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Literal
+
+# Bump this when the column list, edge schema, or feature block ordering
+# changes. The validator refuses to load a snapshot whose manifest
+# version doesn't match the runtime; that's the early-warning that two
+# pipeline runs produced incompatible artifacts.
+SCHEMA_VERSION = "1.0.0"
+
+
+class SchemaError(ValueError):
+    """Raised when a schema lookup hits an unknown name."""
+
+
+FeatureGroupName = Literal["acs_norm", "derived", "inferred", "context"]
+FILL_POLICIES = frozenset({"zero", "mean", "drop_node"})
+
+
+@dataclass(frozen=True, slots=True)
+class FeatureColumn:
+    """One scalar feature column on a node-type's feature matrix.
+
+    ``normalizer`` is the name of a transform registered in
+    :mod:`ecosystem.graph.normalize`; the builder looks it up rather
+    than embedding a callable here so the schema stays a pure data
+    description.
+
+    ``fill_policy`` decides what the builder does when the source row
+    is missing the underlying value:
+
+    * ``"zero"`` — emit ``0.0`` (post-normalisation neutral). Most
+      stat columns use this since 0 is a safe baseline.
+    * ``"mean"`` — emit the era-mean from the normaliser. Use for
+      columns where 0 is a meaningful low (e.g. ratings).
+    * ``"drop_node"`` — refuse to emit the node at all. Use for
+      identity-critical columns (e.g. ``team`` membership) where the
+      node would corrupt downstream queries if its row were zero.
+    """
+
+    name: str
+    group: FeatureGroupName
+    normalizer: str
+    fill_policy: str = "zero"
+    description: str = ""
+
+    def __post_init__(self) -> None:
+        if self.fill_policy not in FILL_POLICIES:
+            raise SchemaError(
+                f"FeatureColumn {self.name!r}: fill_policy={self.fill_policy!r} "
+                f"not in {sorted(FILL_POLICIES)}"
+            )
+
+
+@dataclass(frozen=True, slots=True)
+class FeatureGroup:
+    """A named block of feature columns within a node-type's feature matrix."""
+
+    name: FeatureGroupName
+    columns: tuple[FeatureColumn, ...]
+
+
+@dataclass(frozen=True, slots=True)
+class NodeSpec:
+    """Schema for one heterogeneous node type."""
+
+    name: str
+    groups: tuple[FeatureGroup, ...]
+
+    def all_columns(self) -> tuple[FeatureColumn, ...]:
+        """Flatten all groups in declaration order."""
+        return tuple(col for grp in self.groups for col in grp.columns)
+
+    def feature_dim(self) -> int:
+        """Total width of the ``x`` matrix for this node type."""
+        return sum(len(g.columns) for g in self.groups)
+
+    def column_names(self) -> tuple[str, ...]:
+        """Flat list of column names — consumed by the manifest writer."""
+        return tuple(col.name for col in self.all_columns())
+
+
+@dataclass(frozen=True, slots=True)
+class EdgeSpec:
+    """One heterogeneous edge type.
+
+    The PyG-conventional canonical key is ``(src, relation, dst)``.
+    ``edge_attr_columns`` is the (optional) list of scalar attributes
+    carried per edge — the builder stacks these into ``edge_attr`` on
+    the snapshot the same way it builds node features.
+    ``time_bounded`` means each edge carries ``valid_from`` /
+    ``valid_to`` columns that the era filter respects.
+    """
+
+    src: str
+    relation: str
+    dst: str
+    edge_attr_columns: tuple[FeatureColumn, ...] = field(default_factory=tuple)
+    time_bounded: bool = False
+
+    @property
+    def key(self) -> tuple[str, str, str]:
+        """PyG-style canonical triple, also used as the dict key on snapshots."""
+        return (self.src, self.relation, self.dst)
+
+
+# ---- node specs ------------------------------------------------------------
+#
+# The exact column inventory is derived from
+# Systems-spec System 08 §node_features and from the headline stats VLR
+# already exposes in MapResult.team{1,2}_stats. Adding a column here is
+# a schema-version bump (see SCHEMA_VERSION above).
+
+_PLAYER = NodeSpec(
+    name="player",
+    groups=(
+        FeatureGroup(
+            name="acs_norm",
+            columns=(
+                FeatureColumn("acs", "acs_norm", "minmax", description="combat score / round"),
+                FeatureColumn(
+                    "kast",
+                    "acs_norm",
+                    "minmax",
+                    description="kill/assist/survive/trade %",
+                ),
+                FeatureColumn("adr", "acs_norm", "minmax", description="damage / round"),
+                FeatureColumn("hs_pct", "acs_norm", "minmax", description="headshot %"),
+                FeatureColumn("rating", "acs_norm", "minmax", description="VLR composite rating"),
+            ),
+        ),
+        FeatureGroup(
+            name="derived",
+            columns=(
+                FeatureColumn("fb_rate", "derived", "minmax", description="first-blood rate"),
+                FeatureColumn("fd_rate", "derived", "minmax", description="first-death rate"),
+                FeatureColumn("clutch_rate", "derived", "minmax"),
+                FeatureColumn("multikill_rate", "derived", "minmax"),
+            ),
+        ),
+        FeatureGroup(
+            name="inferred",
+            columns=(
+                FeatureColumn(
+                    "latent_skill",
+                    "inferred",
+                    "zscore",
+                    description="bayesian skill estimate",
+                ),
+                FeatureColumn("role_fit", "inferred", "minmax"),
+                FeatureColumn("synergy_mag", "inferred", "minmax"),
+            ),
+        ),
+        FeatureGroup(
+            name="context",
+            columns=(
+                FeatureColumn("age_days", "context", "log1p_minmax"),
+                FeatureColumn("region_americas", "context", "passthrough"),
+                FeatureColumn("region_emea", "context", "passthrough"),
+                FeatureColumn("region_pacific", "context", "passthrough"),
+                FeatureColumn("region_china", "context", "passthrough"),
+                FeatureColumn("tier_rank", "context", "minmax"),
+            ),
+        ),
+    ),
+)
+
+
+_TEAM = NodeSpec(
+    name="team",
+    groups=(
+        FeatureGroup(
+            name="acs_norm",
+            columns=(
+                FeatureColumn("avg_acs", "acs_norm", "minmax"),
+                FeatureColumn("avg_kast", "acs_norm", "minmax"),
+                FeatureColumn("win_rate", "acs_norm", "minmax"),
+                FeatureColumn("map_win_rate", "acs_norm", "minmax"),
+            ),
+        ),
+        FeatureGroup(
+            name="derived",
+            columns=(
+                FeatureColumn(
+                    "attack_rwr",
+                    "derived",
+                    "minmax",
+                    description="attack-side round win rate",
+                ),
+                FeatureColumn("defense_rwr", "derived", "minmax"),
+                FeatureColumn("eco_efficiency", "derived", "minmax"),
+                FeatureColumn("comeback_rate", "derived", "minmax"),
+            ),
+        ),
+        FeatureGroup(
+            name="inferred",
+            columns=(
+                FeatureColumn("strength_rating", "inferred", "zscore"),
+                FeatureColumn("style_aggression", "inferred", "minmax"),
+                FeatureColumn("style_utility", "inferred", "minmax"),
+            ),
+        ),
+        FeatureGroup(
+            name="context",
+            columns=(
+                FeatureColumn("region_americas", "context", "passthrough"),
+                FeatureColumn("region_emea", "context", "passthrough"),
+                FeatureColumn("region_pacific", "context", "passthrough"),
+                FeatureColumn("region_china", "context", "passthrough"),
+                FeatureColumn("tier_rank", "context", "minmax"),
+                FeatureColumn("roster_age_days", "context", "log1p_minmax"),
+            ),
+        ),
+    ),
+)
+
+
+_PATCH = NodeSpec(
+    name="patch",
+    groups=(
+        FeatureGroup(
+            name="acs_norm",
+            # Patch nodes don't have ACS-style stats; the slot is kept
+            # for symmetry with the other node types so a single
+            # contiguous matrix layout works in the trainer. Two
+            # placeholder summary columns are computed by the builder.
+            columns=(
+                FeatureColumn("agg_match_acs", "acs_norm", "minmax"),
+                FeatureColumn("agg_match_kast", "acs_norm", "minmax"),
+            ),
+        ),
+        FeatureGroup(
+            name="derived",
+            columns=(
+                FeatureColumn("duration_days", "derived", "log1p_minmax"),
+                FeatureColumn("matches_played", "derived", "log1p_minmax"),
+                FeatureColumn("agents_added", "derived", "minmax"),
+                FeatureColumn("maps_added", "derived", "minmax"),
+            ),
+        ),
+        FeatureGroup(
+            name="inferred",
+            columns=(
+                FeatureColumn("meta_magnitude", "inferred", "passthrough"),
+                FeatureColumn("is_major_shift", "inferred", "passthrough"),
+            ),
+        ),
+        FeatureGroup(
+            name="context",
+            columns=(
+                FeatureColumn("era_ordinal", "context", "minmax"),
+                FeatureColumn("season_year_2024", "context", "passthrough"),
+                FeatureColumn("season_year_2025", "context", "passthrough"),
+                FeatureColumn("season_year_2026", "context", "passthrough"),
+            ),
+        ),
+    ),
+)
+
+
+_AGENT = NodeSpec(
+    name="agent",
+    groups=(
+        FeatureGroup(
+            name="acs_norm",
+            # Agent ACS_norm = era-relative pick performance.
+            columns=(
+                FeatureColumn("avg_acs_when_picked", "acs_norm", "minmax"),
+                FeatureColumn("avg_rating_when_picked", "acs_norm", "minmax"),
+            ),
+        ),
+        FeatureGroup(
+            name="derived",
+            columns=(
+                FeatureColumn("pick_rate", "derived", "minmax"),
+                FeatureColumn("win_rate_when_picked", "derived", "minmax"),
+                FeatureColumn("ban_rate", "derived", "minmax"),
+            ),
+        ),
+        FeatureGroup(
+            name="inferred",
+            columns=(
+                FeatureColumn("strength_score", "inferred", "minmax"),
+                FeatureColumn("synergy_index", "inferred", "minmax"),
+            ),
+        ),
+        FeatureGroup(
+            name="context",
+            columns=(
+                FeatureColumn("role_duelist", "context", "passthrough"),
+                FeatureColumn("role_controller", "context", "passthrough"),
+                FeatureColumn("role_initiator", "context", "passthrough"),
+                FeatureColumn("role_sentinel", "context", "passthrough"),
+                FeatureColumn("age_days", "context", "log1p_minmax"),
+            ),
+        ),
+    ),
+)
+
+
+NODE_TYPES: dict[str, NodeSpec] = {
+    "player": _PLAYER,
+    "team": _TEAM,
+    "patch": _PATCH,
+    "agent": _AGENT,
+}
+
+
+# ---- edge specs ------------------------------------------------------------
+
+_PLAYS_FOR = EdgeSpec(
+    src="player",
+    relation="plays_for",
+    dst="team",
+    edge_attr_columns=(
+        FeatureColumn("tenure_days", "context", "log1p_minmax"),
+        FeatureColumn("role_slot", "context", "minmax"),
+    ),
+    time_bounded=True,
+)
+
+_RELATES_TO = EdgeSpec(
+    src="team",
+    relation="relates_to",
+    dst="team",
+    edge_attr_columns=(
+        FeatureColumn("rivalry_strength", "inferred", "minmax"),
+        FeatureColumn("head_to_head_count", "context", "log1p_minmax"),
+    ),
+)
+
+_SPONSORED_BY = EdgeSpec(
+    src="team",
+    relation="sponsored_by",
+    dst="team",
+    edge_attr_columns=(
+        FeatureColumn("annual_value_usd", "context", "log1p_minmax"),
+        FeatureColumn("tenure_days", "context", "log1p_minmax"),
+    ),
+    time_bounded=True,
+)
+
+_AFFECTS = EdgeSpec(
+    src="patch",
+    relation="affects",
+    dst="agent",
+    edge_attr_columns=(
+        FeatureColumn("change_magnitude", "inferred", "minmax"),
+        FeatureColumn("buff_direction", "inferred", "passthrough"),
+    ),
+)
+
+
+EDGE_TYPES: dict[tuple[str, str, str], EdgeSpec] = {
+    spec.key: spec for spec in (_PLAYS_FOR, _RELATES_TO, _SPONSORED_BY, _AFFECTS)
+}
+
+
+def node_spec(name: str) -> NodeSpec:
+    try:
+        return NODE_TYPES[name]
+    except KeyError as e:
+        raise SchemaError(
+            f"unknown node type {name!r}; known: {sorted(NODE_TYPES)}"
+        ) from e
+
+
+def edge_spec(key: tuple[str, str, str]) -> EdgeSpec:
+    try:
+        return EDGE_TYPES[key]
+    except KeyError as e:
+        raise SchemaError(
+            f"unknown edge type {key!r}; known: {sorted(EDGE_TYPES)}"
+        ) from e
+
+
+__all__ = [
+    "EDGE_TYPES",
+    "EdgeSpec",
+    "FILL_POLICIES",
+    "FeatureColumn",
+    "FeatureGroup",
+    "FeatureGroupName",
+    "NODE_TYPES",
+    "NodeSpec",
+    "SCHEMA_VERSION",
+    "SchemaError",
+    "edge_spec",
+    "node_spec",
+]

--- a/services/ecosystem/src/ecosystem/graph/schema.py
+++ b/services/ecosystem/src/ecosystem/graph/schema.py
@@ -388,18 +388,14 @@ def node_spec(name: str) -> NodeSpec:
     try:
         return NODE_TYPES[name]
     except KeyError as e:
-        raise SchemaError(
-            f"unknown node type {name!r}; known: {sorted(NODE_TYPES)}"
-        ) from e
+        raise SchemaError(f"unknown node type {name!r}; known: {sorted(NODE_TYPES)}") from e
 
 
 def edge_spec(key: tuple[str, str, str]) -> EdgeSpec:
     try:
         return EDGE_TYPES[key]
     except KeyError as e:
-        raise SchemaError(
-            f"unknown edge type {key!r}; known: {sorted(EDGE_TYPES)}"
-        ) from e
+        raise SchemaError(f"unknown edge type {key!r}; known: {sorted(EDGE_TYPES)}") from e
 
 
 __all__ = [

--- a/services/ecosystem/src/ecosystem/graph/snapshot.py
+++ b/services/ecosystem/src/ecosystem/graph/snapshot.py
@@ -234,7 +234,7 @@ class GraphSnapshot:
                 self._build_manifest(),
                 indent=2,
                 sort_keys=True,
-                default=_jsonable_default,
+                default=jsonable_default,
             ),
             encoding="utf-8",
         )
@@ -360,7 +360,7 @@ class GraphSnapshot:
 # ---- helpers ---------------------------------------------------------------
 
 
-def _jsonable_default(obj: Any) -> Any:
+def jsonable_default(obj: Any) -> Any:
     """Coerce non-native types (datetime, numpy scalars, ...) for ``json.dumps``.
 
     The snapshot's metadata block carries whatever the data source
@@ -373,6 +373,11 @@ def _jsonable_default(obj: Any) -> Any:
     manifest is a human-readable record, not a typed contract — losing
     a millisecond of precision on a stored timestamp is a fair price
     for not failing the export.
+
+    Public so :mod:`ecosystem.graph.export` can reuse it when folding
+    metadata into the run fingerprint — the registry's idempotency
+    contract requires that the bytes the fingerprint sees match the
+    bytes the manifest persists.
     """
     # ``datetime`` and ``date`` carry ``.isoformat()``; numpy datetimes
     # do not, but ``str(np.datetime64(...))`` returns ISO-like text.
@@ -432,4 +437,5 @@ __all__ = [
     "NodeBlock",
     "SNAPSHOT_FORMAT_VERSION",
     "assert_schema_known",
+    "jsonable_default",
 ]

--- a/services/ecosystem/src/ecosystem/graph/snapshot.py
+++ b/services/ecosystem/src/ecosystem/graph/snapshot.py
@@ -1,0 +1,389 @@
+"""GraphSnapshot — the in-memory, framework-agnostic HeteroData payload.
+
+The snapshot is what the builder produces and what the validator and
+the registry write to disk. It is intentionally numpy-only so that:
+
+* Tests don't need ``torch`` / ``torch_geometric`` on the import path
+  (CI image stays small).
+* The serialised ``snapshot.npz`` is a stable, language-portable
+  artifact — a downstream Rust trainer or a Jupyter notebook can load
+  it without the PyG runtime.
+
+A trainer that does want a real :class:`torch_geometric.data.HeteroData`
+calls :meth:`GraphSnapshot.to_pyg`, which lazily imports torch /
+torch_geometric. ``to_pyg`` is the one place the library boundary
+lives; everything upstream is numpy.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import TYPE_CHECKING, Any
+
+import numpy as np
+
+from ecosystem.graph.schema import EDGE_TYPES, NODE_TYPES, SCHEMA_VERSION
+
+if TYPE_CHECKING:  # pragma: no cover - import-only
+    import torch_geometric.data as pyg_data
+
+
+# Versioning is on the snapshot, not on the schema constants alone, so
+# a future format-only change (e.g. switching from npz to safetensors)
+# can bump the snapshot version while leaving the schema untouched.
+SNAPSHOT_FORMAT_VERSION = "1.0.0"
+
+# Default float precision for feature matrices. fp32 is the trainer's
+# native dtype; emitting fp64 here would double the snapshot size on
+# disk for no model-side benefit.
+_FLOAT_DTYPE = np.float32
+
+# Edge indices are int64 to match torch_geometric.HeteroData's contract
+# (torch.long). int32 would save bytes but force a cast on every load.
+_INDEX_DTYPE = np.int64
+
+
+@dataclass(slots=True)
+class NodeBlock:
+    """One heterogeneous node type's data on a snapshot.
+
+    ``ids`` holds the canonical entity ids (UUID hex strings or any
+    stable string). ``x`` is the dense feature matrix; row ``i``
+    describes node ``ids[i]``. ``column_names`` is the manifest the
+    schema declared for this node type at build time — recorded on the
+    snapshot so a later trainer never has to look up the schema by
+    column index.
+    """
+
+    node_type: str
+    ids: list[str]
+    x: np.ndarray
+    column_names: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        n = len(self.ids)
+        if self.x.shape[0] != n:
+            raise ValueError(
+                f"NodeBlock[{self.node_type}]: x.shape[0]={self.x.shape[0]} "
+                f"but len(ids)={n}"
+            )
+        if self.x.shape[1] != len(self.column_names):
+            raise ValueError(
+                f"NodeBlock[{self.node_type}]: x.shape[1]={self.x.shape[1]} "
+                f"but len(column_names)={len(self.column_names)}"
+            )
+        if self.x.dtype != _FLOAT_DTYPE:
+            # Tolerate fp64 from numpy.array(...) inferences by casting
+            # on the way in. A stronger error here would break naive
+            # callers without buying anything.
+            self.x = self.x.astype(_FLOAT_DTYPE, copy=False)
+
+    @property
+    def num_nodes(self) -> int:
+        return len(self.ids)
+
+    @property
+    def feature_dim(self) -> int:
+        return int(self.x.shape[1])
+
+
+@dataclass(slots=True)
+class EdgeBlock:
+    """One heterogeneous edge type's data on a snapshot.
+
+    ``edge_index`` is shape ``(2, E)`` with row 0 = source node-local
+    index, row 1 = destination node-local index. ``edge_attr`` is shape
+    ``(E, K)`` or ``None`` when the schema declares no attributes.
+    """
+
+    src: str
+    relation: str
+    dst: str
+    edge_index: np.ndarray
+    edge_attr: np.ndarray | None
+    edge_attr_columns: tuple[str, ...]
+
+    def __post_init__(self) -> None:
+        if self.edge_index.ndim != 2 or self.edge_index.shape[0] != 2:
+            raise ValueError(
+                f"EdgeBlock[{self.key}]: edge_index must be shape (2, E), "
+                f"got {self.edge_index.shape}"
+            )
+        if self.edge_index.dtype != _INDEX_DTYPE:
+            self.edge_index = self.edge_index.astype(_INDEX_DTYPE, copy=False)
+        if self.edge_attr is not None:
+            e = self.edge_index.shape[1]
+            if self.edge_attr.shape[0] != e:
+                raise ValueError(
+                    f"EdgeBlock[{self.key}]: edge_attr.shape[0]={self.edge_attr.shape[0]} "
+                    f"!= edge_index.shape[1]={e}"
+                )
+            if self.edge_attr.shape[1] != len(self.edge_attr_columns):
+                raise ValueError(
+                    f"EdgeBlock[{self.key}]: edge_attr.shape[1]={self.edge_attr.shape[1]} "
+                    f"!= len(edge_attr_columns)={len(self.edge_attr_columns)}"
+                )
+            if self.edge_attr.dtype != _FLOAT_DTYPE:
+                self.edge_attr = self.edge_attr.astype(_FLOAT_DTYPE, copy=False)
+
+    @property
+    def key(self) -> tuple[str, str, str]:
+        return (self.src, self.relation, self.dst)
+
+    @property
+    def num_edges(self) -> int:
+        return int(self.edge_index.shape[1])
+
+
+@dataclass(slots=True)
+class GraphSnapshot:
+    """A built, validation-ready heterogeneous graph for one era.
+
+    The snapshot is opaque to the validator and the writer — they go
+    through :meth:`nodes`/:meth:`edges` rather than the underlying
+    dicts. That makes adding a new node type a one-line dict
+    addition, not a multi-touch refactor.
+    """
+
+    era_slug: str
+    schema_version: str = SCHEMA_VERSION
+    snapshot_format_version: str = SNAPSHOT_FORMAT_VERSION
+    node_blocks: dict[str, NodeBlock] = field(default_factory=dict)
+    edge_blocks: dict[tuple[str, str, str], EdgeBlock] = field(default_factory=dict)
+    # Free-form metadata: era window, build timestamp, normaliser
+    # parameters keyed by (node_type, column). Persisted verbatim into
+    # ``manifest.json`` so a later trainer can re-apply normalisation
+    # to a held-out evaluation row without re-running the pipeline.
+    metadata: dict[str, Any] = field(default_factory=dict)
+
+    # ---- accessors -------------------------------------------------------
+
+    def nodes(self, node_type: str) -> NodeBlock:
+        if node_type not in self.node_blocks:
+            raise KeyError(f"snapshot has no node block for {node_type!r}")
+        return self.node_blocks[node_type]
+
+    def edges(self, key: tuple[str, str, str]) -> EdgeBlock:
+        if key not in self.edge_blocks:
+            raise KeyError(f"snapshot has no edge block for {key!r}")
+        return self.edge_blocks[key]
+
+    def node_types(self) -> tuple[str, ...]:
+        return tuple(self.node_blocks)
+
+    def edge_types(self) -> tuple[tuple[str, str, str], ...]:
+        return tuple(self.edge_blocks)
+
+    # ---- summaries -------------------------------------------------------
+
+    def summary(self) -> dict[str, Any]:
+        """Compact dict for log lines and the run manifest."""
+        return {
+            "era_slug": self.era_slug,
+            "schema_version": self.schema_version,
+            "snapshot_format_version": self.snapshot_format_version,
+            "node_counts": {
+                nt: blk.num_nodes for nt, blk in self.node_blocks.items()
+            },
+            "node_feature_dims": {
+                nt: blk.feature_dim for nt, blk in self.node_blocks.items()
+            },
+            "edge_counts": {
+                _edge_key_str(k): blk.num_edges
+                for k, blk in self.edge_blocks.items()
+            },
+        }
+
+    # ---- IO --------------------------------------------------------------
+
+    def write(self, run_dir: Path) -> dict[str, Path]:
+        """Write ``snapshot.npz`` + ``manifest.json`` under ``run_dir``.
+
+        Returns a dict of {role: path} for the caller's convenience —
+        the registry stamps these into the run record's notes.
+        """
+        run_dir.mkdir(parents=True, exist_ok=True)
+        npz_path = run_dir / "snapshot.npz"
+        manifest_path = run_dir / "manifest.json"
+
+        arrays = self._to_npz_dict()
+        # ``np.savez`` is platform-portable and decompresses lazily;
+        # gzip-compressing the matrices would shave ~30% off disk but
+        # add a load-time cost we don't need under the 2-minutes-per-
+        # era acceptance budget. The numpy stub for ``savez`` types
+        # ``**kwds`` as ``bool`` (likely a stale stub picking up
+        # ``allow_pickle``); the runtime accepts ``str -> ndarray``
+        # cleanly, which is the documented use.
+        np.savez(npz_path, **arrays)  # type: ignore[arg-type]
+        manifest_path.write_text(
+            json.dumps(self._build_manifest(), indent=2, sort_keys=True),
+            encoding="utf-8",
+        )
+        return {"snapshot": npz_path, "manifest": manifest_path}
+
+    @classmethod
+    def read(cls, run_dir: Path) -> GraphSnapshot:
+        """Round-trip counterpart to :meth:`write`."""
+        manifest = json.loads((run_dir / "manifest.json").read_text(encoding="utf-8"))
+        with np.load(run_dir / "snapshot.npz", allow_pickle=False) as npz:
+            arrays = {k: npz[k].copy() for k in npz.files}
+        return cls._from_arrays_and_manifest(arrays, manifest)
+
+    # ---- internals -------------------------------------------------------
+
+    def _to_npz_dict(self) -> dict[str, np.ndarray]:
+        """Pack all blocks into a flat dict of (str → ndarray) for ``savez``.
+
+        Keys are namespaced so a bug that picked the wrong dtype in
+        one block can't silently overwrite another. ``ids`` are stored
+        as fixed-width unicode arrays — they're identifiers, not
+        floats, and roundtrip cleanly through npz.
+        """
+        out: dict[str, np.ndarray] = {}
+        for nt, node_blk in self.node_blocks.items():
+            out[f"node:{nt}:x"] = node_blk.x
+            out[f"node:{nt}:ids"] = np.asarray(node_blk.ids, dtype=np.str_)
+        for k, edge_blk in self.edge_blocks.items():
+            tag = _edge_key_str(k)
+            out[f"edge:{tag}:edge_index"] = edge_blk.edge_index
+            if edge_blk.edge_attr is not None:
+                out[f"edge:{tag}:edge_attr"] = edge_blk.edge_attr
+        return out
+
+    def _build_manifest(self) -> dict[str, Any]:
+        return {
+            "era_slug": self.era_slug,
+            "schema_version": self.schema_version,
+            "snapshot_format_version": self.snapshot_format_version,
+            "summary": self.summary(),
+            "node_columns": {
+                nt: list(blk.column_names) for nt, blk in self.node_blocks.items()
+            },
+            "edge_attr_columns": {
+                _edge_key_str(k): list(blk.edge_attr_columns)
+                for k, blk in self.edge_blocks.items()
+            },
+            "metadata": self.metadata,
+        }
+
+    @classmethod
+    def _from_arrays_and_manifest(
+        cls,
+        arrays: dict[str, np.ndarray],
+        manifest: dict[str, Any],
+    ) -> GraphSnapshot:
+        node_blocks: dict[str, NodeBlock] = {}
+        edge_blocks: dict[tuple[str, str, str], EdgeBlock] = {}
+
+        node_columns = manifest.get("node_columns", {})
+        for nt, cols in node_columns.items():
+            x = arrays[f"node:{nt}:x"]
+            ids = arrays[f"node:{nt}:ids"].tolist()
+            node_blocks[nt] = NodeBlock(
+                node_type=nt,
+                ids=[str(i) for i in ids],
+                x=x,
+                column_names=tuple(cols),
+            )
+
+        edge_attr_columns = manifest.get("edge_attr_columns", {})
+        for tag, cols in edge_attr_columns.items():
+            key = _edge_key_from_str(tag)
+            edge_index = arrays[f"edge:{tag}:edge_index"]
+            edge_attr = arrays.get(f"edge:{tag}:edge_attr")
+            edge_blocks[key] = EdgeBlock(
+                src=key[0],
+                relation=key[1],
+                dst=key[2],
+                edge_index=edge_index,
+                edge_attr=edge_attr,
+                edge_attr_columns=tuple(cols),
+            )
+
+        return cls(
+            era_slug=manifest["era_slug"],
+            schema_version=manifest["schema_version"],
+            snapshot_format_version=manifest["snapshot_format_version"],
+            node_blocks=node_blocks,
+            edge_blocks=edge_blocks,
+            metadata=manifest.get("metadata", {}),
+        )
+
+    # ---- adapters --------------------------------------------------------
+
+    def to_pyg(self) -> pyg_data.HeteroData:
+        """Return a :class:`torch_geometric.data.HeteroData` view.
+
+        Lazy import: ``torch_geometric`` is *only* required when a
+        consumer calls this method. Unit tests and the export pipeline
+        itself stay numpy-only.
+        """
+        # Local import keeps torch_geometric out of the cold-import
+        # path; the trainer that needs this already pays the import
+        # cost on its own boot.
+        import torch  # noqa: PLC0415  (lazy by design)
+        from torch_geometric.data import HeteroData  # noqa: PLC0415
+
+        data = HeteroData()
+        for nt, node_blk in self.node_blocks.items():
+            data[nt].x = torch.from_numpy(node_blk.x)
+            data[nt].num_nodes = node_blk.num_nodes
+            # PyG accepts arbitrary attributes; keep ids around for
+            # debugging-level joins.
+            data[nt].ids = list(node_blk.ids)
+        for k, edge_blk in self.edge_blocks.items():
+            data[k].edge_index = torch.from_numpy(edge_blk.edge_index)
+            if edge_blk.edge_attr is not None:
+                data[k].edge_attr = torch.from_numpy(edge_blk.edge_attr)
+        return data
+
+
+# ---- helpers ---------------------------------------------------------------
+
+
+def _edge_key_str(key: tuple[str, str, str]) -> str:
+    """Stable tag used in npz file keys.
+
+    The ``__`` separator avoids collision with ``_`` in node/edge type
+    names ("plays_for", "patch_era") and roundtrips cleanly through
+    :func:`_edge_key_from_str`.
+    """
+    return "__".join(key)
+
+
+def _edge_key_from_str(tag: str) -> tuple[str, str, str]:
+    parts = tag.split("__")
+    if len(parts) != 3:
+        raise ValueError(f"edge tag {tag!r} did not split into 3 parts on '__'")
+    return parts[0], parts[1], parts[2]
+
+
+# ``_assert_schema_known`` is a tiny self-test the validator can call
+# to detect manifests built against an obviously-broken schema (e.g. a
+# downstream rename that the runtime didn't pick up). It lives here
+# because the snapshot owns the schema contract.
+def assert_schema_known(snapshot: GraphSnapshot) -> None:
+    """Raise ValueError if a node/edge type isn't in the runtime schema."""
+    for nt in snapshot.node_blocks:
+        if nt not in NODE_TYPES:
+            raise ValueError(
+                f"snapshot carries unknown node type {nt!r}; runtime knows "
+                f"{sorted(NODE_TYPES)}"
+            )
+    for k in snapshot.edge_blocks:
+        if k not in EDGE_TYPES:
+            raise ValueError(
+                f"snapshot carries unknown edge type {k!r}; runtime knows "
+                f"{sorted(EDGE_TYPES)}"
+            )
+
+
+__all__ = [
+    "EdgeBlock",
+    "GraphSnapshot",
+    "NodeBlock",
+    "SNAPSHOT_FORMAT_VERSION",
+    "assert_schema_known",
+]

--- a/services/ecosystem/src/ecosystem/graph/snapshot.py
+++ b/services/ecosystem/src/ecosystem/graph/snapshot.py
@@ -66,8 +66,7 @@ class NodeBlock:
         n = len(self.ids)
         if self.x.shape[0] != n:
             raise ValueError(
-                f"NodeBlock[{self.node_type}]: x.shape[0]={self.x.shape[0]} "
-                f"but len(ids)={n}"
+                f"NodeBlock[{self.node_type}]: x.shape[0]={self.x.shape[0]} " f"but len(ids)={n}"
             )
         if self.x.shape[1] != len(self.column_names):
             raise ValueError(
@@ -196,16 +195,9 @@ class GraphSnapshot:
             "era_slug": self.era_slug,
             "schema_version": self.schema_version,
             "snapshot_format_version": self.snapshot_format_version,
-            "node_counts": {
-                nt: blk.num_nodes for nt, blk in self.node_blocks.items()
-            },
-            "node_feature_dims": {
-                nt: blk.feature_dim for nt, blk in self.node_blocks.items()
-            },
-            "edge_counts": {
-                _edge_key_str(k): blk.num_edges
-                for k, blk in self.edge_blocks.items()
-            },
+            "node_counts": {nt: blk.num_nodes for nt, blk in self.node_blocks.items()},
+            "node_feature_dims": {nt: blk.feature_dim for nt, blk in self.node_blocks.items()},
+            "edge_counts": {_edge_key_str(k): blk.num_edges for k, blk in self.edge_blocks.items()},
         }
 
     # ---- IO --------------------------------------------------------------
@@ -275,12 +267,9 @@ class GraphSnapshot:
             "schema_version": self.schema_version,
             "snapshot_format_version": self.snapshot_format_version,
             "summary": self.summary(),
-            "node_columns": {
-                nt: list(blk.column_names) for nt, blk in self.node_blocks.items()
-            },
+            "node_columns": {nt: list(blk.column_names) for nt, blk in self.node_blocks.items()},
             "edge_attr_columns": {
-                _edge_key_str(k): list(blk.edge_attr_columns)
-                for k, blk in self.edge_blocks.items()
+                _edge_key_str(k): list(blk.edge_attr_columns) for k, blk in self.edge_blocks.items()
             },
             "metadata": self.metadata,
         }
@@ -420,14 +409,12 @@ def assert_schema_known(snapshot: GraphSnapshot) -> None:
     for nt in snapshot.node_blocks:
         if nt not in NODE_TYPES:
             raise ValueError(
-                f"snapshot carries unknown node type {nt!r}; runtime knows "
-                f"{sorted(NODE_TYPES)}"
+                f"snapshot carries unknown node type {nt!r}; runtime knows " f"{sorted(NODE_TYPES)}"
             )
     for k in snapshot.edge_blocks:
         if k not in EDGE_TYPES:
             raise ValueError(
-                f"snapshot carries unknown edge type {k!r}; runtime knows "
-                f"{sorted(EDGE_TYPES)}"
+                f"snapshot carries unknown edge type {k!r}; runtime knows " f"{sorted(EDGE_TYPES)}"
             )
 
 

--- a/services/ecosystem/src/ecosystem/graph/snapshot.py
+++ b/services/ecosystem/src/ecosystem/graph/snapshot.py
@@ -218,7 +218,12 @@ class GraphSnapshot:
         # cleanly, which is the documented use.
         np.savez(npz_path, **arrays)  # type: ignore[arg-type]
         manifest_path.write_text(
-            json.dumps(self._build_manifest(), indent=2, sort_keys=True),
+            json.dumps(
+                self._build_manifest(),
+                indent=2,
+                sort_keys=True,
+                default=_jsonable_default,
+            ),
             encoding="utf-8",
         )
         return {"snapshot": npz_path, "manifest": manifest_path}
@@ -341,6 +346,35 @@ class GraphSnapshot:
 
 
 # ---- helpers ---------------------------------------------------------------
+
+
+def _jsonable_default(obj: Any) -> Any:
+    """Coerce non-native types (datetime, numpy scalars, ...) for ``json.dumps``.
+
+    The snapshot's metadata block carries whatever the data source
+    handed back from ``patch_meta`` — typically era window timestamps
+    as ``datetime`` instances. Without this default, ``json.dumps``
+    raises ``TypeError`` when the manifest is written.
+
+    The handler is deliberately permissive: anything ISO-stringifiable
+    is converted, anything else falls through to ``str()``. The
+    manifest is a human-readable record, not a typed contract — losing
+    a millisecond of precision on a stored timestamp is a fair price
+    for not failing the export.
+    """
+    # ``datetime`` and ``date`` carry ``.isoformat()``; numpy datetimes
+    # do not, but ``str(np.datetime64(...))`` returns ISO-like text.
+    iso = getattr(obj, "isoformat", None)
+    if callable(iso):
+        return iso()
+    # numpy scalars implement ``.item()`` to fall back to a Python type.
+    item = getattr(obj, "item", None)
+    if callable(item):
+        try:
+            return item()
+        except (TypeError, ValueError):
+            pass
+    return str(obj)
 
 
 def _edge_key_str(key: tuple[str, str, str]) -> str:

--- a/services/ecosystem/src/ecosystem/graph/snapshot.py
+++ b/services/ecosystem/src/ecosystem/graph/snapshot.py
@@ -111,6 +111,18 @@ class EdgeBlock:
                 f"EdgeBlock[{self.key}]: edge_index must be shape (2, E), "
                 f"got {self.edge_index.shape}"
             )
+        # Refuse a non-integer edge_index instead of silently casting.
+        # Truncating ``0.9`` to ``0`` would still pass the bounds check
+        # downstream and the trainer would see a different graph than
+        # the producer wrote — exactly the corruption mode the
+        # validator exists to catch.
+        if not np.issubdtype(self.edge_index.dtype, np.integer):
+            raise ValueError(
+                f"EdgeBlock[{self.key}]: edge_index dtype must be an integer "
+                f"kind; got {self.edge_index.dtype}. The builder always emits "
+                f"int64; a float dtype here means an upstream producer wrote "
+                f"the wrong array."
+            )
         if self.edge_index.dtype != _INDEX_DTYPE:
             self.edge_index = self.edge_index.astype(_INDEX_DTYPE, copy=False)
         if self.edge_attr is not None:

--- a/services/ecosystem/src/ecosystem/graph/source.py
+++ b/services/ecosystem/src/ecosystem/graph/source.py
@@ -1,0 +1,127 @@
+"""Pluggable data sources for the graph builder.
+
+Decoupling the builder from any concrete database (BUF-6 SQLAlchemy,
+DuckDB, parquet, fixture dicts) buys two things:
+
+* Tests can construct deterministic graphs from fixtures without a
+  Postgres in CI.
+* A future migration to a different feature store (parquet on s3, a
+  feast online store, ...) is one new ``GraphDataSource`` class — the
+  builder doesn't notice.
+
+Source rows are dicts of ``column_name -> value``. Missing columns are
+filled by the builder according to each :class:`FeatureColumn`'s
+``fill_policy``; sources don't have to know the schema. Edge rows
+carry ``src_id`` / ``dst_id`` keyed against the same string ids the
+node iterator yields, plus the optional attribute columns the edge
+spec declares.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass, field
+from typing import Any, Protocol
+
+
+@dataclass(frozen=True, slots=True)
+class NodeRow:
+    """One node's raw inputs.
+
+    ``id`` is the canonical entity id (UUID hex, slug, anything stable
+    for the era). ``features`` is the loose dict of column values; any
+    column the schema lists but the dict misses gets the column's
+    declared fill policy applied.
+    """
+
+    id: str
+    features: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass(frozen=True, slots=True)
+class EdgeRow:
+    """One edge's raw inputs."""
+
+    src_id: str
+    dst_id: str
+    attributes: dict[str, Any] = field(default_factory=dict)
+
+
+class GraphDataSource(Protocol):
+    """Read-side interface the builder consumes.
+
+    Implementations are responsible for filtering to the requested era
+    *before* yielding rows — the builder treats the iterators as
+    authoritative for the era.
+    """
+
+    def iter_nodes(self, node_type: str, *, era_slug: str) -> Iterable[NodeRow]:
+        """Yield every node of ``node_type`` active in ``era_slug``."""
+        ...
+
+    def iter_edges(
+        self, key: tuple[str, str, str], *, era_slug: str
+    ) -> Iterable[EdgeRow]:
+        """Yield every edge of canonical type ``key`` active in ``era_slug``."""
+        ...
+
+    def patch_meta(self, era_slug: str) -> dict[str, Any]:
+        """Return era-window metadata: start/end timestamps, magnitude flags.
+
+        Used by the builder to populate the synthetic patch-node row
+        and to stamp the snapshot's metadata block.
+        """
+        ...
+
+
+# ---- in-memory reference implementation -----------------------------------
+
+
+@dataclass
+class InMemoryDataSource:
+    """Fixture-friendly :class:`GraphDataSource` for tests.
+
+    Rows are stored in nested dicts keyed by era slug. The constructor
+    is permissive — missing eras yield empty iterators rather than
+    raising, since "this era has no edges of this kind" is a legal
+    state during the early backfill.
+    """
+
+    # era_slug -> node_type -> list[NodeRow]
+    nodes: dict[str, dict[str, list[NodeRow]]] = field(default_factory=dict)
+    # era_slug -> edge_key -> list[EdgeRow]
+    edges: dict[str, dict[tuple[str, str, str], list[EdgeRow]]] = field(default_factory=dict)
+    # era_slug -> meta dict
+    patches: dict[str, dict[str, Any]] = field(default_factory=dict)
+
+    def iter_nodes(self, node_type: str, *, era_slug: str) -> Iterable[NodeRow]:
+        return iter(self.nodes.get(era_slug, {}).get(node_type, ()))
+
+    def iter_edges(
+        self, key: tuple[str, str, str], *, era_slug: str
+    ) -> Iterable[EdgeRow]:
+        return iter(self.edges.get(era_slug, {}).get(key, ()))
+
+    def patch_meta(self, era_slug: str) -> dict[str, Any]:
+        return dict(self.patches.get(era_slug, {}))
+
+    # ---- builder helpers ------------------------------------------------
+
+    def add_node(self, era_slug: str, node_type: str, row: NodeRow) -> None:
+        self.nodes.setdefault(era_slug, {}).setdefault(node_type, []).append(row)
+
+    def add_edge(
+        self, era_slug: str, key: tuple[str, str, str], row: EdgeRow
+    ) -> None:
+        self.edges.setdefault(era_slug, {}).setdefault(key, []).append(row)
+
+    def set_patch(self, era_slug: str, meta: dict[str, Any]) -> None:
+        self.patches[era_slug] = dict(meta)
+
+
+__all__ = [
+    "EdgeRow",
+    "GraphDataSource",
+    "InMemoryDataSource",
+    "NodeRow",
+]

--- a/services/ecosystem/src/ecosystem/graph/source.py
+++ b/services/ecosystem/src/ecosystem/graph/source.py
@@ -59,9 +59,7 @@ class GraphDataSource(Protocol):
         """Yield every node of ``node_type`` active in ``era_slug``."""
         ...
 
-    def iter_edges(
-        self, key: tuple[str, str, str], *, era_slug: str
-    ) -> Iterable[EdgeRow]:
+    def iter_edges(self, key: tuple[str, str, str], *, era_slug: str) -> Iterable[EdgeRow]:
         """Yield every edge of canonical type ``key`` active in ``era_slug``."""
         ...
 
@@ -97,9 +95,7 @@ class InMemoryDataSource:
     def iter_nodes(self, node_type: str, *, era_slug: str) -> Iterable[NodeRow]:
         return iter(self.nodes.get(era_slug, {}).get(node_type, ()))
 
-    def iter_edges(
-        self, key: tuple[str, str, str], *, era_slug: str
-    ) -> Iterable[EdgeRow]:
+    def iter_edges(self, key: tuple[str, str, str], *, era_slug: str) -> Iterable[EdgeRow]:
         return iter(self.edges.get(era_slug, {}).get(key, ()))
 
     def patch_meta(self, era_slug: str) -> dict[str, Any]:
@@ -110,9 +106,7 @@ class InMemoryDataSource:
     def add_node(self, era_slug: str, node_type: str, row: NodeRow) -> None:
         self.nodes.setdefault(era_slug, {}).setdefault(node_type, []).append(row)
 
-    def add_edge(
-        self, era_slug: str, key: tuple[str, str, str], row: EdgeRow
-    ) -> None:
+    def add_edge(self, era_slug: str, key: tuple[str, str, str], row: EdgeRow) -> None:
         self.edges.setdefault(era_slug, {}).setdefault(key, []).append(row)
 
     def set_patch(self, era_slug: str, meta: dict[str, Any]) -> None:

--- a/services/ecosystem/src/ecosystem/graph/validate.py
+++ b/services/ecosystem/src/ecosystem/graph/validate.py
@@ -326,6 +326,23 @@ def _check_edge_blocks(
                 )
             )
 
+        # Column-name parity. A snapshot with the right *width* but
+        # swapped or renamed attribute columns would otherwise pass
+        # validation and the trainer would consume the wrong feature
+        # at every position — silent semantic corruption is exactly
+        # what System 09 should catch.
+        expected_attr_cols = tuple(c.name for c in spec.edge_attr_columns)
+        if block.edge_attr_columns != expected_attr_cols:
+            report.issues.append(
+                ValidationIssue(
+                    "edge_attr_column_mismatch",
+                    "error",
+                    loc,
+                    f"edge_attr_columns={block.edge_attr_columns!r} != "
+                    f"expected={expected_attr_cols!r}",
+                )
+            )
+
         # Edge-attribute health: same NaN / range checks as nodes.
         if block.edge_attr is not None and block.num_edges:
             if not np.all(np.isfinite(block.edge_attr)):

--- a/services/ecosystem/src/ecosystem/graph/validate.py
+++ b/services/ecosystem/src/ecosystem/graph/validate.py
@@ -309,6 +309,23 @@ def _check_edge_blocks(
                     )
                 )
 
+        # If the schema declares attribute columns for this edge, the
+        # block must carry an ``edge_attr`` matrix — a corrupted
+        # ``snapshot.npz`` (or a producer that forgot to write the
+        # array) would otherwise sail through and the trainer would
+        # silently lose every attribute on relations like
+        # ``plays_for`` / ``affects``.
+        if spec.edge_attr_columns and block.edge_attr is None:
+            report.issues.append(
+                ValidationIssue(
+                    "missing_edge_attr",
+                    "error",
+                    loc,
+                    f"schema declares {len(spec.edge_attr_columns)} edge_attr "
+                    f"column(s) but block carries no edge_attr matrix",
+                )
+            )
+
         # Edge-attribute health: same NaN / range checks as nodes.
         if block.edge_attr is not None and block.num_edges:
             if not np.all(np.isfinite(block.edge_attr)):

--- a/services/ecosystem/src/ecosystem/graph/validate.py
+++ b/services/ecosystem/src/ecosystem/graph/validate.py
@@ -98,13 +98,10 @@ class ValidationReport:
     def assert_passed(self) -> None:
         if self.passed:
             return
-        joined = "; ".join(
-            f"[{i.code} @ {i.location}] {i.message}" for i in self.errors[:5]
-        )
+        joined = "; ".join(f"[{i.code} @ {i.location}] {i.message}" for i in self.errors[:5])
         more = f" (+{len(self.errors) - 5} more)" if len(self.errors) > 5 else ""
         raise StructuralValidationError(
-            f"snapshot for era {self.era_slug!r} failed structural validation: "
-            f"{joined}{more}"
+            f"snapshot for era {self.era_slug!r} failed structural validation: " f"{joined}{more}"
         )
 
 
@@ -123,9 +120,7 @@ def validate_snapshot(snapshot: GraphSnapshot) -> ValidationReport:
 # ---- individual check groups ----------------------------------------------
 
 
-def _check_schema_version(
-    snapshot: GraphSnapshot, report: ValidationReport
-) -> None:
+def _check_schema_version(snapshot: GraphSnapshot, report: ValidationReport) -> None:
     if snapshot.schema_version != SCHEMA_VERSION:
         report.issues.append(
             ValidationIssue(
@@ -140,9 +135,7 @@ def _check_schema_version(
         )
 
 
-def _check_node_blocks(
-    snapshot: GraphSnapshot, report: ValidationReport
-) -> None:
+def _check_node_blocks(snapshot: GraphSnapshot, report: ValidationReport) -> None:
     # Cover every declared node type — missing is an error, not a warn,
     # since the trainer's fixed-shape ingestion would index off the end.
     for node_type, spec in NODE_TYPES.items():
@@ -167,8 +160,7 @@ def _check_node_blocks(
                     "column_mismatch",
                     "error",
                     loc,
-                    f"column_names={block.column_names!r} != "
-                    f"expected={expected_cols!r}",
+                    f"column_names={block.column_names!r} != " f"expected={expected_cols!r}",
                 )
             )
 
@@ -247,9 +239,7 @@ def _check_node_blocks(
             )
 
 
-def _check_edge_blocks(
-    snapshot: GraphSnapshot, report: ValidationReport
-) -> None:
+def _check_edge_blocks(snapshot: GraphSnapshot, report: ValidationReport) -> None:
     for key, spec in EDGE_TYPES.items():
         loc = f"edge:{'__'.join(key)}"
         block = snapshot.edge_blocks.get(key)

--- a/services/ecosystem/src/ecosystem/graph/validate.py
+++ b/services/ecosystem/src/ecosystem/graph/validate.py
@@ -1,0 +1,354 @@
+"""Structural validation of a :class:`GraphSnapshot` (Systems-spec System 09).
+
+The validator is the gate between ``build_snapshot`` and
+``Registry.finalize``: a snapshot that fails any check is a
+``failed`` run, not a ``completed`` one. Acceptance:
+
+> Full graph export for 3 eras passes all structural validation.
+
+Checks fall into three buckets:
+
+1. **Schema consistency** — the snapshot only references node/edge
+   types the runtime knows; column counts / dtypes match the schema.
+2. **Numerical health** — no NaN/Inf values; feature matrices are in
+   the unit interval (the "no raw un-scaled columns" acceptance);
+   ids are non-empty unique strings.
+3. **Edge integrity** — every edge endpoint refers to a valid index;
+   no orphan edges; no self-loops on relations that forbid them
+   (currently none, but the hook is here).
+
+The validator returns a :class:`ValidationReport` rather than raising
+on the first failure — operators want the full picture, not the first
+broken row. The export orchestrator inspects ``report.passed`` and
+either finalises the registry row as ``completed`` or ``failed``.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any
+
+import numpy as np
+
+from ecosystem.graph.schema import (
+    EDGE_TYPES,
+    NODE_TYPES,
+    SCHEMA_VERSION,
+)
+from ecosystem.graph.snapshot import GraphSnapshot
+
+# Tolerance for unit-interval checks. The normalisers explicitly clip
+# their output, so anything outside this window indicates a bypassed
+# normaliser, not a rounding artefact.
+_UNIT_SLACK = 1e-5
+
+
+class StructuralValidationError(RuntimeError):
+    """Raised when :func:`assert_valid` is called on a failed report."""
+
+
+@dataclass(slots=True)
+class ValidationIssue:
+    """One thing the validator found wrong with the snapshot."""
+
+    code: str
+    severity: str  # "error" | "warn"
+    location: str  # human-readable: "node:player", "edge:patch__affects__agent", ...
+    message: str
+
+    def to_jsonable(self) -> dict[str, Any]:
+        return {
+            "code": self.code,
+            "severity": self.severity,
+            "location": self.location,
+            "message": self.message,
+        }
+
+
+@dataclass(slots=True)
+class ValidationReport:
+    """The full output of :func:`validate_snapshot`."""
+
+    era_slug: str
+    schema_version: str
+    issues: list[ValidationIssue] = field(default_factory=list)
+
+    @property
+    def errors(self) -> list[ValidationIssue]:
+        return [i for i in self.issues if i.severity == "error"]
+
+    @property
+    def warnings(self) -> list[ValidationIssue]:
+        return [i for i in self.issues if i.severity == "warn"]
+
+    @property
+    def passed(self) -> bool:
+        return not self.errors
+
+    def to_jsonable(self) -> dict[str, Any]:
+        return {
+            "era_slug": self.era_slug,
+            "schema_version": self.schema_version,
+            "passed": self.passed,
+            "error_count": len(self.errors),
+            "warning_count": len(self.warnings),
+            "issues": [i.to_jsonable() for i in self.issues],
+        }
+
+    def assert_passed(self) -> None:
+        if self.passed:
+            return
+        joined = "; ".join(
+            f"[{i.code} @ {i.location}] {i.message}" for i in self.errors[:5]
+        )
+        more = f" (+{len(self.errors) - 5} more)" if len(self.errors) > 5 else ""
+        raise StructuralValidationError(
+            f"snapshot for era {self.era_slug!r} failed structural validation: "
+            f"{joined}{more}"
+        )
+
+
+def validate_snapshot(snapshot: GraphSnapshot) -> ValidationReport:
+    """Run every structural check; return the full report."""
+    report = ValidationReport(
+        era_slug=snapshot.era_slug,
+        schema_version=snapshot.schema_version,
+    )
+    _check_schema_version(snapshot, report)
+    _check_node_blocks(snapshot, report)
+    _check_edge_blocks(snapshot, report)
+    return report
+
+
+# ---- individual check groups ----------------------------------------------
+
+
+def _check_schema_version(
+    snapshot: GraphSnapshot, report: ValidationReport
+) -> None:
+    if snapshot.schema_version != SCHEMA_VERSION:
+        report.issues.append(
+            ValidationIssue(
+                code="schema_version_mismatch",
+                severity="error",
+                location="snapshot",
+                message=(
+                    f"snapshot schema_version={snapshot.schema_version!r} "
+                    f"!= runtime SCHEMA_VERSION={SCHEMA_VERSION!r}"
+                ),
+            )
+        )
+
+
+def _check_node_blocks(
+    snapshot: GraphSnapshot, report: ValidationReport
+) -> None:
+    # Cover every declared node type — missing is an error, not a warn,
+    # since the trainer's fixed-shape ingestion would index off the end.
+    for node_type, spec in NODE_TYPES.items():
+        loc = f"node:{node_type}"
+        block = snapshot.node_blocks.get(node_type)
+        if block is None:
+            report.issues.append(
+                ValidationIssue(
+                    "missing_node_block",
+                    "error",
+                    loc,
+                    "snapshot has no block for this declared node type",
+                )
+            )
+            continue
+
+        # Column-count parity with the schema.
+        expected_cols = spec.column_names()
+        if block.column_names != expected_cols:
+            report.issues.append(
+                ValidationIssue(
+                    "column_mismatch",
+                    "error",
+                    loc,
+                    f"column_names={block.column_names!r} != "
+                    f"expected={expected_cols!r}",
+                )
+            )
+
+        # Shape sanity — NodeBlock.__post_init__ catches construction-
+        # time mismatches; this catches a snapshot that was loaded
+        # from disk with an inconsistent npz/manifest pair.
+        if block.x.shape != (block.num_nodes, len(expected_cols)):
+            report.issues.append(
+                ValidationIssue(
+                    "shape_mismatch",
+                    "error",
+                    loc,
+                    f"x.shape={block.x.shape} but expected "
+                    f"({block.num_nodes}, {len(expected_cols)})",
+                )
+            )
+
+        # Numerical health: NaN / Inf would silently propagate through
+        # the GNN's matmul and corrupt the loss; catch them here.
+        if block.num_nodes > 0:
+            if not np.all(np.isfinite(block.x)):
+                bad = int(np.sum(~np.isfinite(block.x)))
+                report.issues.append(
+                    ValidationIssue(
+                        "non_finite_features",
+                        "error",
+                        loc,
+                        f"{bad} non-finite values in x",
+                    )
+                )
+            # "Fully normalised" — the acceptance requires every column
+            # in [0, 1]. Let _UNIT_SLACK absorb fp32-precision drift
+            # from the normaliser's internal fp64 arithmetic.
+            lo = float(block.x.min())
+            hi = float(block.x.max())
+            if lo < -_UNIT_SLACK or hi > 1.0 + _UNIT_SLACK:
+                report.issues.append(
+                    ValidationIssue(
+                        "feature_range_violation",
+                        "error",
+                        loc,
+                        f"x range=[{lo:.6f}, {hi:.6f}] outside [0, 1]",
+                    )
+                )
+
+        # ID hygiene.
+        if len(set(block.ids)) != len(block.ids):
+            report.issues.append(
+                ValidationIssue(
+                    "duplicate_node_ids",
+                    "error",
+                    loc,
+                    f"{len(block.ids) - len(set(block.ids))} duplicates",
+                )
+            )
+        if any((not isinstance(i, str)) or not i for i in block.ids):
+            report.issues.append(
+                ValidationIssue(
+                    "empty_node_ids",
+                    "error",
+                    loc,
+                    "found empty / non-string node id",
+                )
+            )
+
+    # Reverse direction: snapshot carrying an unknown node type.
+    for nt in snapshot.node_blocks:
+        if nt not in NODE_TYPES:
+            report.issues.append(
+                ValidationIssue(
+                    "unknown_node_type",
+                    "error",
+                    f"node:{nt}",
+                    f"snapshot block {nt!r} not in runtime schema {sorted(NODE_TYPES)}",
+                )
+            )
+
+
+def _check_edge_blocks(
+    snapshot: GraphSnapshot, report: ValidationReport
+) -> None:
+    for key, spec in EDGE_TYPES.items():
+        loc = f"edge:{'__'.join(key)}"
+        block = snapshot.edge_blocks.get(key)
+        if block is None:
+            report.issues.append(
+                ValidationIssue(
+                    "missing_edge_block",
+                    "error",
+                    loc,
+                    "snapshot has no block for this declared edge type",
+                )
+            )
+            continue
+
+        if block.edge_index.shape[0] != 2:
+            report.issues.append(
+                ValidationIssue(
+                    "edge_index_shape",
+                    "error",
+                    loc,
+                    f"edge_index must be (2, E); got {block.edge_index.shape}",
+                )
+            )
+            continue  # subsequent checks would raise on the bad shape
+
+        # Endpoint integrity. The builder filters orphans, but a hand-
+        # constructed snapshot or a loaded npz could still violate.
+        src_block = snapshot.node_blocks.get(spec.src)
+        dst_block = snapshot.node_blocks.get(spec.dst)
+        if src_block is None or dst_block is None:
+            # The missing-block error is already reported above; skip
+            # endpoint checks since we can't compute bounds.
+            continue
+        if block.num_edges:
+            src_max = int(block.edge_index[0].max(initial=-1))
+            dst_max = int(block.edge_index[1].max(initial=-1))
+            src_min = int(block.edge_index[0].min(initial=0))
+            dst_min = int(block.edge_index[1].min(initial=0))
+            if src_min < 0 or src_max >= src_block.num_nodes:
+                report.issues.append(
+                    ValidationIssue(
+                        "src_index_out_of_bounds",
+                        "error",
+                        loc,
+                        f"src indices in [{src_min}, {src_max}] but "
+                        f"{spec.src} has {src_block.num_nodes} nodes",
+                    )
+                )
+            if dst_min < 0 or dst_max >= dst_block.num_nodes:
+                report.issues.append(
+                    ValidationIssue(
+                        "dst_index_out_of_bounds",
+                        "error",
+                        loc,
+                        f"dst indices in [{dst_min}, {dst_max}] but "
+                        f"{spec.dst} has {dst_block.num_nodes} nodes",
+                    )
+                )
+
+        # Edge-attribute health: same NaN / range checks as nodes.
+        if block.edge_attr is not None and block.num_edges:
+            if not np.all(np.isfinite(block.edge_attr)):
+                bad = int(np.sum(~np.isfinite(block.edge_attr)))
+                report.issues.append(
+                    ValidationIssue(
+                        "non_finite_edge_attr",
+                        "error",
+                        loc,
+                        f"{bad} non-finite values in edge_attr",
+                    )
+                )
+            lo = float(block.edge_attr.min())
+            hi = float(block.edge_attr.max())
+            if lo < -_UNIT_SLACK or hi > 1.0 + _UNIT_SLACK:
+                report.issues.append(
+                    ValidationIssue(
+                        "edge_attr_range_violation",
+                        "error",
+                        loc,
+                        f"edge_attr range=[{lo:.6f}, {hi:.6f}] outside [0, 1]",
+                    )
+                )
+
+    # Snapshot edge type the runtime doesn't know.
+    for k in snapshot.edge_blocks:
+        if k not in EDGE_TYPES:
+            report.issues.append(
+                ValidationIssue(
+                    "unknown_edge_type",
+                    "error",
+                    f"edge:{'__'.join(k)}",
+                    f"snapshot block {k!r} not in runtime schema {sorted(EDGE_TYPES)}",
+                )
+            )
+
+
+__all__ = [
+    "StructuralValidationError",
+    "ValidationIssue",
+    "ValidationReport",
+    "validate_snapshot",
+]

--- a/services/ecosystem/tests/conftest.py
+++ b/services/ecosystem/tests/conftest.py
@@ -1,0 +1,19 @@
+"""Pytest fixtures for the ecosystem service tests.
+
+The graph-export tests are pure (no Postgres dependency), so this
+conftest is much smaller than the data_pipeline / packages-shared
+twins. It only handles the sibling-import path so
+``from graph_fixtures import ...`` keeps working under
+``--import-mode=importlib``.
+"""
+
+from __future__ import annotations
+
+import sys
+from pathlib import Path
+
+# Sibling-import path: pytest's ``--import-mode=importlib`` (set at the
+# workspace root) skips the sys.path manipulation that ``prepend`` mode
+# would otherwise do. Adding the test directory here keeps
+# ``from graph_fixtures import ...`` working in the per-test files.
+sys.path.insert(0, str(Path(__file__).resolve().parent))

--- a/services/ecosystem/tests/graph_fixtures.py
+++ b/services/ecosystem/tests/graph_fixtures.py
@@ -1,0 +1,259 @@
+"""Fixture builders for the graph-export tests (BUF-53).
+
+Produces a deterministic three-era :class:`InMemoryDataSource` with:
+
+* 12 players, 4 teams, 3 patches, 6 agents per era.
+* A full set of ``plays_for`` / ``relates_to`` / ``sponsored_by`` /
+  ``affects`` edges.
+
+The data is synthetic but *realistic* in distribution: ACS values
+roughly mirror VLR norms, region one-hots are mutually exclusive, and
+era-over-era player counts shift slightly so the normalisers see
+different fits per era.
+
+Kept under ``tests/`` (not ``src/``) — these helpers exist solely to
+exercise the production builder; pollution in the production package
+would mislead callers about which fixture loaders are blessed.
+"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+from ecosystem.graph.source import EdgeRow, InMemoryDataSource, NodeRow
+
+# Era slugs match the ones in config/patch_eras.yaml so a future
+# integration test can reuse the same fixture loader pointed at the
+# real seeder.
+ERA_SLUGS = ("e2024_01", "e2024_02", "e2024_03")
+
+_REGIONS = ("americas", "emea", "pacific", "china")
+_AGENT_ROLES = ("duelist", "controller", "initiator", "sentinel")
+
+
+@dataclass(frozen=True, slots=True)
+class _EraConfig:
+    slug: str
+    season_year: int
+    ordinal: float
+    duration_days: float
+    matches_played: float
+    agents_added: float
+    maps_added: float
+    meta_magnitude: float
+    is_major_shift: bool
+
+
+_ERAS = (
+    _EraConfig("e2024_01", 2024, 0.0, 96.0, 1200.0, 1.0, 0.0, 0.4, False),
+    _EraConfig("e2024_02", 2024, 1.0, 112.0, 1500.0, 1.0, 0.0, 0.7, True),
+    _EraConfig("e2024_03", 2024, 2.0, 154.0, 1750.0, 1.0, 0.0, 0.3, False),
+)
+
+
+def build_three_era_source() -> InMemoryDataSource:
+    """Return a fully-populated three-era :class:`InMemoryDataSource`."""
+    src = InMemoryDataSource()
+    for era_idx, era in enumerate(_ERAS):
+        _seed_era(src, era_idx, era)
+    return src
+
+
+# ---- per-era seeding ------------------------------------------------------
+
+
+def _seed_era(src: InMemoryDataSource, era_idx: int, era: _EraConfig) -> None:
+    src.set_patch(
+        era.slug,
+        {
+            "season_year": era.season_year,
+            "era_ordinal": era.ordinal,
+            "duration_days": era.duration_days,
+            "matches_played": era.matches_played,
+            "agents_added": era.agents_added,
+            "maps_added": era.maps_added,
+            "meta_magnitude": era.meta_magnitude,
+            "is_major_shift": era.is_major_shift,
+            "agg_match_acs": 220.0 + 4.0 * era_idx,
+            "agg_match_kast": 0.71 + 0.01 * era_idx,
+        },
+    )
+
+    # ---- players --------------------------------------------------------
+    n_players = 12
+    for p in range(n_players):
+        region = _REGIONS[p % len(_REGIONS)]
+        # Vary stats per era so the per-era normaliser fit differs;
+        # the shape is "meaningful but constrained" — ACS in [180, 280],
+        # KAST in [0.55, 0.85], etc.
+        acs = 180.0 + (p * 7.0) + (era_idx * 5.0)
+        kast = 0.55 + 0.01 * p + 0.01 * era_idx
+        adr = 120.0 + 2.5 * p + era_idx
+        hs_pct = 0.18 + 0.01 * (p % 5)
+        rating = 0.85 + 0.02 * p + 0.01 * era_idx
+        fb_rate = 0.10 + 0.01 * (p % 6)
+        fd_rate = 0.10 + 0.005 * (p % 7)
+        clutch_rate = 0.10 + 0.01 * (p % 5)
+        multikill_rate = 0.05 + 0.005 * (p % 4)
+        latent_skill = float(p) - 5.5  # negative + positive z
+        role_fit = 0.4 + 0.04 * (p % 6)
+        synergy_mag = 0.3 + 0.05 * (p % 5)
+        age_days = 200.0 + p * 30.0
+        tier_rank = 0.2 + 0.05 * (p % 6)
+
+        src.add_node(
+            era.slug,
+            "player",
+            NodeRow(
+                id=f"player-{p:02d}",
+                features={
+                    "acs": acs,
+                    "kast": kast,
+                    "adr": adr,
+                    "hs_pct": hs_pct,
+                    "rating": rating,
+                    "fb_rate": fb_rate,
+                    "fd_rate": fd_rate,
+                    "clutch_rate": clutch_rate,
+                    "multikill_rate": multikill_rate,
+                    "latent_skill": latent_skill,
+                    "role_fit": role_fit,
+                    "synergy_mag": synergy_mag,
+                    "age_days": age_days,
+                    "region_americas": 1.0 if region == "americas" else 0.0,
+                    "region_emea": 1.0 if region == "emea" else 0.0,
+                    "region_pacific": 1.0 if region == "pacific" else 0.0,
+                    "region_china": 1.0 if region == "china" else 0.0,
+                    "tier_rank": tier_rank,
+                },
+            ),
+        )
+
+    # ---- teams ----------------------------------------------------------
+    n_teams = 4
+    for t in range(n_teams):
+        region = _REGIONS[t % len(_REGIONS)]
+        src.add_node(
+            era.slug,
+            "team",
+            NodeRow(
+                id=f"team-{t:02d}",
+                features={
+                    "avg_acs": 210.0 + 4.0 * t + era_idx,
+                    "avg_kast": 0.68 + 0.01 * t + 0.005 * era_idx,
+                    "win_rate": 0.40 + 0.05 * t,
+                    "map_win_rate": 0.45 + 0.04 * t,
+                    "attack_rwr": 0.42 + 0.03 * t,
+                    "defense_rwr": 0.50 + 0.02 * t,
+                    "eco_efficiency": 0.30 + 0.05 * t,
+                    "comeback_rate": 0.10 + 0.02 * t,
+                    "strength_rating": float(t) - 1.5,
+                    "style_aggression": 0.40 + 0.05 * t,
+                    "style_utility": 0.50 + 0.04 * t,
+                    "region_americas": 1.0 if region == "americas" else 0.0,
+                    "region_emea": 1.0 if region == "emea" else 0.0,
+                    "region_pacific": 1.0 if region == "pacific" else 0.0,
+                    "region_china": 1.0 if region == "china" else 0.0,
+                    "tier_rank": 0.3 + 0.1 * t,
+                    "roster_age_days": 365.0 + 90.0 * t,
+                },
+            ),
+        )
+
+    # ---- agents ---------------------------------------------------------
+    n_agents = 6
+    for a in range(n_agents):
+        role = _AGENT_ROLES[a % len(_AGENT_ROLES)]
+        src.add_node(
+            era.slug,
+            "agent",
+            NodeRow(
+                id=f"agent-{a:02d}",
+                features={
+                    "avg_acs_when_picked": 200.0 + 6.0 * a + era_idx,
+                    "avg_rating_when_picked": 0.95 + 0.02 * a,
+                    "pick_rate": 0.05 + 0.04 * a,
+                    "win_rate_when_picked": 0.40 + 0.04 * a,
+                    "ban_rate": 0.01 + 0.005 * a,
+                    "strength_score": 0.40 + 0.05 * a,
+                    "synergy_index": 0.30 + 0.06 * a,
+                    "role_duelist": 1.0 if role == "duelist" else 0.0,
+                    "role_controller": 1.0 if role == "controller" else 0.0,
+                    "role_initiator": 1.0 if role == "initiator" else 0.0,
+                    "role_sentinel": 1.0 if role == "sentinel" else 0.0,
+                    "age_days": 100.0 + 200.0 * a,
+                },
+            ),
+        )
+
+    # ---- plays_for ------------------------------------------------------
+    # Spread 12 players across 4 teams, 3 per team. Some players move
+    # team across eras to exercise edge filtering.
+    for p in range(n_players):
+        team_idx = (p + era_idx) % n_teams
+        src.add_edge(
+            era.slug,
+            ("player", "plays_for", "team"),
+            EdgeRow(
+                src_id=f"player-{p:02d}",
+                dst_id=f"team-{team_idx:02d}",
+                attributes={
+                    "tenure_days": 30.0 + 10.0 * p,
+                    "role_slot": 0.2 * (p % 5),
+                },
+            ),
+        )
+
+    # ---- relates_to (team↔team) ----------------------------------------
+    # A small ring: 0→1, 1→2, 2→3, 3→0.
+    for t in range(n_teams):
+        src.add_edge(
+            era.slug,
+            ("team", "relates_to", "team"),
+            EdgeRow(
+                src_id=f"team-{t:02d}",
+                dst_id=f"team-{(t + 1) % n_teams:02d}",
+                attributes={
+                    "rivalry_strength": 0.3 + 0.1 * t,
+                    "head_to_head_count": 5.0 + t * 2.0,
+                },
+            ),
+        )
+
+    # ---- sponsored_by (team→team) --------------------------------------
+    # Each org sponsors the next-but-one; a thin pattern that still
+    # produces non-empty edge_attr matrices.
+    for t in range(n_teams - 1):
+        src.add_edge(
+            era.slug,
+            ("team", "sponsored_by", "team"),
+            EdgeRow(
+                src_id=f"team-{t:02d}",
+                dst_id=f"team-{(t + 2) % n_teams:02d}",
+                attributes={
+                    "annual_value_usd": 100_000.0 * (t + 1),
+                    "tenure_days": 200.0 + 50.0 * t,
+                },
+            ),
+        )
+
+    # ---- affects (patch→agent) -----------------------------------------
+    # The patch node touches every agent — a real era usually tweaks
+    # ~half of them but the validator only checks structural soundness,
+    # so the dense fixture is fine here.
+    for a in range(n_agents):
+        src.add_edge(
+            era.slug,
+            ("patch", "affects", "agent"),
+            EdgeRow(
+                src_id=era.slug,
+                dst_id=f"agent-{a:02d}",
+                attributes={
+                    "change_magnitude": 0.05 + 0.1 * a,
+                    "buff_direction": 1.0 if a % 2 == 0 else 0.0,
+                },
+            ),
+        )
+
+
+__all__ = ["ERA_SLUGS", "build_three_era_source"]

--- a/services/ecosystem/tests/test_graph_builder.py
+++ b/services/ecosystem/tests/test_graph_builder.py
@@ -189,3 +189,99 @@ def test_empty_era_produces_zero_row_blocks() -> None:
         assert snap.edges(k).num_edges == 0
     # Validator still passes — empty is structurally valid.
     assert validate_snapshot(snap).passed
+
+
+# ---- fill_policy on missing values ---------------------------------------
+
+
+def _player_features_full(seed: float) -> dict[str, float]:
+    """Helper: a full player feature dict so we can blank one column at a time."""
+    return {
+        "acs": 200.0 + seed,
+        "kast": 0.65,
+        "adr": 130.0,
+        "hs_pct": 0.22,
+        "rating": 1.0,
+        "fb_rate": 0.10,
+        "fd_rate": 0.10,
+        "clutch_rate": 0.10,
+        "multikill_rate": 0.05,
+        "latent_skill": 0.0,
+        "role_fit": 0.5,
+        "synergy_mag": 0.5,
+        "age_days": 365.0,
+        "region_americas": 1.0,
+        "region_emea": 0.0,
+        "region_pacific": 0.0,
+        "region_china": 0.0,
+        "tier_rank": 0.5,
+    }
+
+
+def test_missing_feature_does_not_propagate_nan() -> None:
+    """Codex P1 (PR #24): omitted source columns must be back-filled.
+
+    Without ``_apply_fill_policy``, a NaN raw value would survive the
+    normaliser's arithmetic and trip the validator's
+    ``non_finite_features`` check on the first real source row that
+    happens to be missing a column.
+    """
+    src = InMemoryDataSource()
+    src.set_patch("e_t", {"era_ordinal": 0.0})
+    feats_complete = _player_features_full(seed=0.0)
+    feats_missing = _player_features_full(seed=10.0)
+    del feats_missing["acs"]  # simulate an upstream gap
+    src.add_node("e_t", "player", NodeRow(id="p-0", features=feats_complete))
+    src.add_node("e_t", "player", NodeRow(id="p-1", features=feats_missing))
+
+    snap = build_snapshot(src, era_slug="e_t")
+    player = snap.nodes("player")
+    # No NaN cells anywhere.
+    assert np.all(np.isfinite(player.x))
+    # The missing ``acs`` cell got back-filled to 0.0 (the column's
+    # declared fill_policy="zero" default).
+    acs_idx = list(player.column_names).index("acs")
+    p1_idx = player.ids.index("p-1")
+    assert player.x[p1_idx, acs_idx] == 0.0
+    # And the snapshot still validates.
+    assert validate_snapshot(snap).passed
+
+
+def test_missing_edge_attribute_does_not_propagate_nan() -> None:
+    """Edge attributes go through the same fill path; protect that too."""
+    src = InMemoryDataSource()
+    src.set_patch("e_t", {"era_ordinal": 0.0})
+    src.add_node("e_t", "player", NodeRow(id="p-0", features=_player_features_full(0.0)))
+    # One team with full feature dict so the team block validates.
+    team_features = {
+        "avg_acs": 210.0,
+        "avg_kast": 0.68,
+        "win_rate": 0.5,
+        "map_win_rate": 0.5,
+        "attack_rwr": 0.5,
+        "defense_rwr": 0.5,
+        "eco_efficiency": 0.5,
+        "comeback_rate": 0.1,
+        "strength_rating": 0.0,
+        "style_aggression": 0.5,
+        "style_utility": 0.5,
+        "region_americas": 1.0,
+        "region_emea": 0.0,
+        "region_pacific": 0.0,
+        "region_china": 0.0,
+        "tier_rank": 0.5,
+        "roster_age_days": 365.0,
+    }
+    src.add_node("e_t", "team", NodeRow(id="t-0", features=team_features))
+    # Edge with one attribute deliberately omitted.
+    src.add_edge(
+        "e_t",
+        ("player", "plays_for", "team"),
+        EdgeRow(src_id="p-0", dst_id="t-0", attributes={"role_slot": 0.4}),
+    )
+
+    snap = build_snapshot(src, era_slug="e_t")
+    plays_for = snap.edges(("player", "plays_for", "team"))
+    assert plays_for.edge_attr is not None
+    assert np.all(np.isfinite(plays_for.edge_attr))
+    assert validate_snapshot(snap).passed

--- a/services/ecosystem/tests/test_graph_builder.py
+++ b/services/ecosystem/tests/test_graph_builder.py
@@ -144,6 +144,24 @@ def test_validation_catches_dropped_edge_endpoints() -> None:
     assert plays_for.num_edges == 0
 
 
+def test_validator_flags_missing_edge_attr_when_schema_declares_columns() -> None:
+    """Codex P2 (PR #24): a typed-attribute edge with edge_attr=None must fail.
+
+    Without this check, a corrupted ``snapshot.npz`` (or a producer
+    that forgot to write the matrix) would pass validation, and the
+    trainer would silently lose every attribute on relations like
+    ``plays_for`` / ``affects``.
+    """
+    src = build_three_era_source()
+    snap = build_snapshot(src, era_slug="e2024_01")
+    # ``plays_for`` declares two edge_attr columns; blanking the matrix
+    # post-build models the corrupted-snapshot scenario.
+    snap.edges(("player", "plays_for", "team")).edge_attr = None
+    report = validate_snapshot(snap)
+    assert not report.passed
+    assert any(i.code == "missing_edge_attr" for i in report.errors)
+
+
 def test_validator_flags_out_of_range_node_features() -> None:
     """If we hand-mutate the snapshot post-build, the validator should catch it."""
     src = build_three_era_source()

--- a/services/ecosystem/tests/test_graph_builder.py
+++ b/services/ecosystem/tests/test_graph_builder.py
@@ -144,6 +144,43 @@ def test_validation_catches_dropped_edge_endpoints() -> None:
     assert plays_for.num_edges == 0
 
 
+def test_edge_block_rejects_non_integer_edge_index() -> None:
+    """Codex P2 (PR #24): a float edge_index must raise, not be coerced.
+
+    Truncating ``0.9`` to ``0`` would still pass the bounds check and
+    produce a "valid" snapshot with rewired edges — exactly the
+    silent corruption the validator exists to catch.
+    """
+    from ecosystem.graph.snapshot import EdgeBlock
+
+    bad_index = np.array([[0.0, 1.0], [1.0, 0.0]], dtype=np.float32)
+    with pytest.raises(ValueError, match="edge_index dtype"):
+        EdgeBlock(
+            src="player",
+            relation="plays_for",
+            dst="team",
+            edge_index=bad_index,
+            edge_attr=None,
+            edge_attr_columns=(),
+        )
+
+
+def test_validator_flags_edge_attr_column_mismatch() -> None:
+    """Codex P1 (PR #24): renamed/swapped edge_attr columns must fail.
+
+    Same width, same dtype, same numeric range — a silent semantic
+    swap that only column-name parity catches.
+    """
+    src = build_three_era_source()
+    snap = build_snapshot(src, era_slug="e2024_01")
+    block = snap.edges(("player", "plays_for", "team"))
+    # Swap the two declared column names.
+    block.edge_attr_columns = ("role_slot", "tenure_days")
+    report = validate_snapshot(snap)
+    assert not report.passed
+    assert any(i.code == "edge_attr_column_mismatch" for i in report.errors)
+
+
 def test_validator_flags_missing_edge_attr_when_schema_declares_columns() -> None:
     """Codex P2 (PR #24): a typed-attribute edge with edge_attr=None must fail.
 

--- a/services/ecosystem/tests/test_graph_builder.py
+++ b/services/ecosystem/tests/test_graph_builder.py
@@ -247,6 +247,64 @@ def test_missing_feature_does_not_propagate_nan() -> None:
     assert validate_snapshot(snap).passed
 
 
+def test_duplicate_edges_get_deterministic_order() -> None:
+    """Codex P2 (PR #24): duplicate-endpoint edges must sort deterministically.
+
+    Two ``InMemoryDataSource`` instances with the same edges in two
+    different insertion orders should produce identical snapshots —
+    otherwise the registry's content fingerprint changes on every
+    re-run and the idempotency contract breaks.
+    """
+    def _build_one(order: tuple[int, ...]) -> tuple[np.ndarray, np.ndarray]:
+        src = InMemoryDataSource()
+        src.set_patch("e_t", {"era_ordinal": 0.0})
+        src.add_node("e_t", "player", NodeRow(id="p-0", features=_player_features_full(0.0)))
+        # One team to anchor the dst endpoint.
+        src.add_node(
+            "e_t",
+            "team",
+            NodeRow(
+                id="t-0",
+                features={
+                    "avg_acs": 210.0,
+                    "avg_kast": 0.68,
+                    "win_rate": 0.5,
+                    "map_win_rate": 0.5,
+                    "attack_rwr": 0.5,
+                    "defense_rwr": 0.5,
+                    "eco_efficiency": 0.5,
+                    "comeback_rate": 0.1,
+                    "strength_rating": 0.0,
+                    "style_aggression": 0.5,
+                    "style_utility": 0.5,
+                    "region_americas": 1.0,
+                    "region_emea": 0.0,
+                    "region_pacific": 0.0,
+                    "region_china": 0.0,
+                    "tier_rank": 0.5,
+                    "roster_age_days": 365.0,
+                },
+            ),
+        )
+        # Three duplicate-endpoint edges with distinct attributes.
+        edges = [
+            EdgeRow(src_id="p-0", dst_id="t-0", attributes={"tenure_days": 30.0, "role_slot": 0.2}),
+            EdgeRow(src_id="p-0", dst_id="t-0", attributes={"tenure_days": 60.0, "role_slot": 0.4}),
+            EdgeRow(src_id="p-0", dst_id="t-0", attributes={"tenure_days": 90.0, "role_slot": 0.6}),
+        ]
+        for i in order:
+            src.add_edge("e_t", ("player", "plays_for", "team"), edges[i])
+        snap = build_snapshot(src, era_slug="e_t")
+        block = snap.edges(("player", "plays_for", "team"))
+        assert block.edge_attr is not None
+        return block.edge_index, block.edge_attr
+
+    a_index, a_attr = _build_one((0, 1, 2))
+    b_index, b_attr = _build_one((2, 0, 1))
+    np.testing.assert_array_equal(a_index, b_index)
+    np.testing.assert_array_equal(a_attr, b_attr)
+
+
 def test_missing_edge_attribute_does_not_propagate_nan() -> None:
     """Edge attributes go through the same fill path; protect that too."""
     src = InMemoryDataSource()

--- a/services/ecosystem/tests/test_graph_builder.py
+++ b/services/ecosystem/tests/test_graph_builder.py
@@ -1,0 +1,191 @@
+"""Builder + validator integration tests on synthetic eras (BUF-53).
+
+The fixture in ``graph_fixtures.py`` produces a deterministic
+three-era source; these tests exercise the builder against it and
+assert the structural invariants the System-09 validator pins.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from ecosystem.graph import (
+    EDGE_TYPES,
+    NODE_TYPES,
+    GraphSnapshot,
+    build_snapshot,
+    validate_snapshot,
+)
+from ecosystem.graph.snapshot import assert_schema_known
+from ecosystem.graph.source import EdgeRow, InMemoryDataSource, NodeRow
+from graph_fixtures import ERA_SLUGS, build_three_era_source
+
+# ---- shape & determinism --------------------------------------------------
+
+
+@pytest.fixture(scope="module")
+def source() -> InMemoryDataSource:
+    return build_three_era_source()
+
+
+@pytest.fixture(params=list(ERA_SLUGS))
+def snapshot(source: InMemoryDataSource, request: pytest.FixtureRequest) -> GraphSnapshot:
+    return build_snapshot(source, era_slug=request.param)
+
+
+def test_every_node_type_present(snapshot: GraphSnapshot) -> None:
+    assert set(snapshot.node_types()) == set(NODE_TYPES)
+
+
+def test_every_edge_type_present(snapshot: GraphSnapshot) -> None:
+    assert set(snapshot.edge_types()) == set(EDGE_TYPES)
+
+
+def test_node_feature_dims_match_schema(snapshot: GraphSnapshot) -> None:
+    for nt, spec in NODE_TYPES.items():
+        block = snapshot.nodes(nt)
+        assert block.feature_dim == spec.feature_dim()
+        assert block.column_names == spec.column_names()
+
+
+def test_builder_is_deterministic(source: InMemoryDataSource) -> None:
+    """Same source + same era → byte-identical x matrices."""
+    a = build_snapshot(source, era_slug="e2024_01")
+    b = build_snapshot(source, era_slug="e2024_01")
+    for nt in a.node_types():
+        np.testing.assert_array_equal(a.nodes(nt).x, b.nodes(nt).x)
+        assert a.nodes(nt).ids == b.nodes(nt).ids
+    for k in a.edge_types():
+        np.testing.assert_array_equal(
+            a.edges(k).edge_index, b.edges(k).edge_index
+        )
+
+
+def test_node_ids_are_sorted(snapshot: GraphSnapshot) -> None:
+    """Sorted ids → deterministic node-local indices regardless of source order."""
+    for nt in snapshot.node_types():
+        ids = snapshot.nodes(nt).ids
+        assert ids == sorted(ids)
+
+
+# ---- normalisation invariant ----------------------------------------------
+
+
+def test_no_raw_unscaled_columns(snapshot: GraphSnapshot) -> None:
+    """Acceptance: feature matrices are fully normalized."""
+    for nt in snapshot.node_types():
+        x = snapshot.nodes(nt).x
+        if x.size == 0:
+            continue
+        assert float(x.min()) >= -1e-5
+        assert float(x.max()) <= 1.0 + 1e-5
+
+
+def test_edge_attrs_are_unit_clamped(snapshot: GraphSnapshot) -> None:
+    for k in snapshot.edge_types():
+        block = snapshot.edges(k)
+        if block.edge_attr is None or block.edge_attr.size == 0:
+            continue
+        assert float(block.edge_attr.min()) >= -1e-5
+        assert float(block.edge_attr.max()) <= 1.0 + 1e-5
+
+
+# ---- structural validation (System 09) ------------------------------------
+
+
+def test_three_era_export_passes_validation(source: InMemoryDataSource) -> None:
+    """Issue acceptance: full graph export for 3 eras passes validation."""
+    for slug in ERA_SLUGS:
+        snap = build_snapshot(source, era_slug=slug)
+        report = validate_snapshot(snap)
+        assert report.passed, "; ".join(i.message for i in report.errors)
+
+
+def test_validation_catches_dropped_edge_endpoints() -> None:
+    """A dangling edge (endpoint not in node table) should be filtered, not raise."""
+    src = InMemoryDataSource()
+    src.set_patch("e2024_01", {"era_ordinal": 0.0})
+    # One team, no players, but an edge claiming a player exists.
+    src.add_node(
+        "e2024_01",
+        "team",
+        NodeRow(
+            id="t-0",
+            features={
+                "avg_acs": 200.0,
+                "avg_kast": 0.65,
+                "win_rate": 0.5,
+                "map_win_rate": 0.5,
+                "attack_rwr": 0.5,
+                "defense_rwr": 0.5,
+                "eco_efficiency": 0.5,
+                "comeback_rate": 0.1,
+                "strength_rating": 0.0,
+                "style_aggression": 0.5,
+                "style_utility": 0.5,
+                "region_americas": 1.0,
+                "region_emea": 0.0,
+                "region_pacific": 0.0,
+                "region_china": 0.0,
+                "tier_rank": 0.5,
+                "roster_age_days": 365.0,
+            },
+        ),
+    )
+    src.add_edge(
+        "e2024_01",
+        ("player", "plays_for", "team"),
+        EdgeRow(src_id="ghost-player", dst_id="t-0"),
+    )
+
+    snap = build_snapshot(src, era_slug="e2024_01")
+    # The orphan edge should be silently dropped — passing validation.
+    plays_for = snap.edges(("player", "plays_for", "team"))
+    assert plays_for.num_edges == 0
+
+
+def test_validator_flags_out_of_range_node_features() -> None:
+    """If we hand-mutate the snapshot post-build, the validator should catch it."""
+    src = build_three_era_source()
+    snap = build_snapshot(src, era_slug="e2024_01")
+    # Inject a bug.
+    snap.nodes("player").x[0, 0] = 5.0
+    report = validate_snapshot(snap)
+    assert not report.passed
+    assert any(i.code == "feature_range_violation" for i in report.errors)
+
+
+def test_assert_schema_known_passes_on_clean_snapshot() -> None:
+    snap = build_snapshot(build_three_era_source(), era_slug="e2024_01")
+    assert_schema_known(snap)  # does not raise
+
+
+# ---- per-era fit independence ---------------------------------------------
+
+
+def test_fits_differ_across_eras(source: InMemoryDataSource) -> None:
+    """The fixture varies stats per era, so per-era min/max should differ."""
+    a = build_snapshot(source, era_slug="e2024_01")
+    c = build_snapshot(source, era_slug="e2024_03")
+    fit_a = a.metadata["node_normalizer_params"]["player"]["acs"]["params"]
+    fit_c = c.metadata["node_normalizer_params"]["player"]["acs"]["params"]
+    assert fit_a != fit_c
+
+
+# ---- empty era handling ---------------------------------------------------
+
+
+def test_empty_era_produces_zero_row_blocks() -> None:
+    src = InMemoryDataSource()
+    src.set_patch("e_empty", {"era_ordinal": 0.0})
+    snap = build_snapshot(src, era_slug="e_empty")
+    # Patch is synthesised even when nothing else exists, so the
+    # patch block carries 1 node. Other blocks are empty.
+    assert snap.nodes("patch").num_nodes == 1
+    assert snap.nodes("player").num_nodes == 0
+    assert snap.nodes("team").num_nodes == 0
+    # All edges empty.
+    for k in snap.edge_types():
+        assert snap.edges(k).num_edges == 0
+    # Validator still passes — empty is structurally valid.
+    assert validate_snapshot(snap).passed

--- a/services/ecosystem/tests/test_graph_builder.py
+++ b/services/ecosystem/tests/test_graph_builder.py
@@ -7,6 +7,8 @@ assert the structural invariants the System-09 validator pins.
 
 from __future__ import annotations
 
+from typing import Any
+
 import numpy as np
 import pytest
 from ecosystem.graph import (
@@ -177,6 +179,79 @@ def test_validator_flags_edge_attr_column_mismatch() -> None:
     report = validate_snapshot(snap)
     assert not report.passed
     assert any(i.code == "edge_attr_column_mismatch" for i in report.errors)
+
+
+def test_duplicate_edge_sort_ignores_non_schema_attributes() -> None:
+    """Codex P2 (PR #24): non-schema keys must not perturb the sort key.
+
+    Two sources that emit the same modeled features but disagree on a
+    bookkeeping field (debug timestamps, per-source metadata) must
+    still produce identical snapshot fingerprints. The
+    duplicate-edge tie-breaker now restricts itself to
+    ``spec.edge_attr_columns``; any other key on the row's
+    ``attributes`` dict gets ignored.
+
+    Also pins the missing-vs-None equivalence: a source that omits
+    an attribute and one that sets it to ``None`` agree on order
+    (both already produce the same ``edge_attr`` row via
+    ``_extract_raw`` → NaN → ``_apply_fill_policy``).
+    """
+    base_attrs = {"tenure_days": 30.0, "role_slot": 0.2}
+
+    def _build(extra_per_row: list[dict[str, Any]]) -> tuple[np.ndarray, np.ndarray]:
+        src = InMemoryDataSource()
+        src.set_patch("e_t", {"era_ordinal": 0.0})
+        src.add_node("e_t", "player", NodeRow(id="p-0", features=_player_features_full(0.0)))
+        src.add_node(
+            "e_t",
+            "team",
+            NodeRow(
+                id="t-0",
+                features={
+                    "avg_acs": 210.0,
+                    "avg_kast": 0.68,
+                    "win_rate": 0.5,
+                    "map_win_rate": 0.5,
+                    "attack_rwr": 0.5,
+                    "defense_rwr": 0.5,
+                    "eco_efficiency": 0.5,
+                    "comeback_rate": 0.1,
+                    "strength_rating": 0.0,
+                    "style_aggression": 0.5,
+                    "style_utility": 0.5,
+                    "region_americas": 1.0,
+                    "region_emea": 0.0,
+                    "region_pacific": 0.0,
+                    "region_china": 0.0,
+                    "tier_rank": 0.5,
+                    "roster_age_days": 365.0,
+                },
+            ),
+        )
+        # Three duplicate-endpoint edges; the per-row ``extra`` dict
+        # holds non-schema keys that two sources might disagree on.
+        for extra in extra_per_row:
+            src.add_edge(
+                "e_t",
+                ("player", "plays_for", "team"),
+                EdgeRow(src_id="p-0", dst_id="t-0", attributes={**base_attrs, **extra}),
+            )
+        snap = build_snapshot(src, era_slug="e_t")
+        block = snap.edges(("player", "plays_for", "team"))
+        assert block.edge_attr is not None
+        return block.edge_index, block.edge_attr
+
+    # Source A includes a "fetched_at" timestamp; source B omits it.
+    a_index, a_attr = _build(
+        [
+            {"fetched_at": "2024-01-01T00:00:00Z"},
+            {"fetched_at": "2024-01-02T00:00:00Z"},
+            {"fetched_at": "2024-01-03T00:00:00Z"},
+        ]
+    )
+    b_index, b_attr = _build([{}, {}, {}])
+    np.testing.assert_array_equal(a_index, b_index)
+    np.testing.assert_array_equal(a_attr, b_attr)
 
 
 def test_validator_flags_missing_edge_attr_when_schema_declares_columns() -> None:

--- a/services/ecosystem/tests/test_graph_builder.py
+++ b/services/ecosystem/tests/test_graph_builder.py
@@ -56,9 +56,7 @@ def test_builder_is_deterministic(source: InMemoryDataSource) -> None:
         np.testing.assert_array_equal(a.nodes(nt).x, b.nodes(nt).x)
         assert a.nodes(nt).ids == b.nodes(nt).ids
     for k in a.edge_types():
-        np.testing.assert_array_equal(
-            a.edges(k).edge_index, b.edges(k).edge_index
-        )
+        np.testing.assert_array_equal(a.edges(k).edge_index, b.edges(k).edge_index)
 
 
 def test_node_ids_are_sorted(snapshot: GraphSnapshot) -> None:
@@ -310,6 +308,7 @@ def test_duplicate_edges_get_deterministic_order() -> None:
     otherwise the registry's content fingerprint changes on every
     re-run and the idempotency contract breaks.
     """
+
     def _build_one(order: tuple[int, ...]) -> tuple[np.ndarray, np.ndarray]:
         src = InMemoryDataSource()
         src.set_patch("e_t", {"era_ordinal": 0.0})

--- a/services/ecosystem/tests/test_graph_export.py
+++ b/services/ecosystem/tests/test_graph_export.py
@@ -192,6 +192,84 @@ def test_manifest_serializes_datetime_metadata(tmp_path: Path) -> None:
     assert "2024-01-09" in patch_meta["starts_at"]
 
 
+def test_failed_run_short_circuits_on_re_export(
+    registry: Registry, config_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Codex P1 (PR #24): re-exporting after a FAILED run must not relabel.
+
+    First export forces a validation failure → row finalises FAILED
+    with artifacts. Second export hits the same idempotency triple
+    so ``register`` returns the existing FAILED row. The orchestrator
+    must short-circuit to the cached report (passed=False) rather
+    than rebuild and silently report passed=True against a registry
+    row that ``Registry.finalize`` cannot transition out of FAILED.
+    """
+    src = build_three_era_source()
+
+    real_validate = validate_snapshot
+
+    def force_failing_report(snapshot: GraphSnapshot):
+        report = real_validate(snapshot)
+        from ecosystem.graph.validate import ValidationIssue
+
+        report.issues.append(
+            ValidationIssue("injected", "error", "test", "forced fail")
+        )
+        return report
+
+    monkeypatch.setattr(
+        "ecosystem.graph.export.validate_snapshot", force_failing_report
+    )
+    first = export_era(
+        src, era_slug="e2024_01", config_path=config_path, registry=registry
+    )
+    assert not first.passed
+    assert registry.get(first.run_id).status is RunStatus.FAILED
+
+    # Lift the injected failure for the second pass — were the
+    # orchestrator to rebuild instead of short-circuiting, the
+    # rebuild would now pass and contradict the FAILED row.
+    monkeypatch.setattr(
+        "ecosystem.graph.export.validate_snapshot", real_validate
+    )
+    second = export_era(
+        src, era_slug="e2024_01", config_path=config_path, registry=registry
+    )
+    assert second.run_id == first.run_id
+    assert not second.passed, (
+        "re-export should return the cached FAILED report, not relabel"
+    )
+    assert registry.get(second.run_id).status is RunStatus.FAILED
+
+
+def test_terminal_run_with_missing_artifacts_raises(
+    registry: Registry, config_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Codex P1 (PR #24): missing artifacts on a terminal row → operator action.
+
+    Rebuilding silently would leave the registry stuck on the
+    pre-existing terminal status (since ``Registry.finalize`` no-ops
+    on non-RUNNING rows), so the orchestrator surfaces the conflict
+    instead of producing contradictory state.
+    """
+    from ecosystem.graph.export import GraphExportStateError
+
+    src = build_three_era_source()
+    first = export_era(
+        src, era_slug="e2024_01", config_path=config_path, registry=registry
+    )
+    assert first.passed
+    # Operator manually deleted the artifacts but left the row.
+    first.snapshot_path.unlink()
+    first.manifest_path.unlink()
+    first.validation_path.unlink()
+
+    with pytest.raises(GraphExportStateError):
+        export_era(
+            src, era_slug="e2024_01", config_path=config_path, registry=registry
+        )
+
+
 def test_failed_validation_writes_failed_status(
     registry: Registry, config_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/services/ecosystem/tests/test_graph_export.py
+++ b/services/ecosystem/tests/test_graph_export.py
@@ -39,9 +39,7 @@ def registry(tmp_path: Path) -> Registry:
 @pytest.fixture
 def config_path(tmp_path: Path) -> Path:
     p = tmp_path / "graph_snapshot.yaml"
-    p.write_text(
-        "kind: graph-snapshot\nschema_version: 1.0.0\n", encoding="utf-8"
-    )
+    p.write_text("kind: graph-snapshot\nschema_version: 1.0.0\n", encoding="utf-8")
     return p
 
 
@@ -57,15 +55,11 @@ def test_snapshot_round_trips_through_npz(tmp_path: Path) -> None:
     loaded = GraphSnapshot.read(out_dir)
     assert loaded.era_slug == snap.era_slug
     for nt in snap.node_types():
-        np.testing.assert_array_equal(
-            loaded.nodes(nt).x, snap.nodes(nt).x
-        )
+        np.testing.assert_array_equal(loaded.nodes(nt).x, snap.nodes(nt).x)
         assert loaded.nodes(nt).ids == snap.nodes(nt).ids
         assert loaded.nodes(nt).column_names == snap.nodes(nt).column_names
     for k in snap.edge_types():
-        np.testing.assert_array_equal(
-            loaded.edges(k).edge_index, snap.edges(k).edge_index
-        )
+        np.testing.assert_array_equal(loaded.edges(k).edge_index, snap.edges(k).edge_index)
     assert_schema_known(loaded)
 
 
@@ -87,13 +81,9 @@ def test_manifest_records_per_node_columns(tmp_path: Path) -> None:
 # ---- export orchestrator ---------------------------------------------------
 
 
-def test_export_era_creates_registered_completed_run(
-    registry: Registry, config_path: Path
-) -> None:
+def test_export_era_creates_registered_completed_run(registry: Registry, config_path: Path) -> None:
     src = build_three_era_source()
-    result = export_era(
-        src, era_slug="e2024_01", config_path=config_path, registry=registry
-    )
+    result = export_era(src, era_slug="e2024_01", config_path=config_path, registry=registry)
 
     assert result.passed
     assert result.snapshot_path.exists()
@@ -104,9 +94,7 @@ def test_export_era_creates_registered_completed_run(
     assert record.kind == GRAPH_SNAPSHOT_KIND
 
 
-def test_export_eras_three_era_acceptance(
-    registry: Registry, config_path: Path
-) -> None:
+def test_export_eras_three_era_acceptance(registry: Registry, config_path: Path) -> None:
     """BUF-53 acceptance: full graph export for 3 eras passes structural validation."""
     src = build_three_era_source()
     results = export_eras(
@@ -122,9 +110,7 @@ def test_export_eras_three_era_acceptance(
     assert len({r.run_id for r in results}) == 3
 
 
-def test_export_eras_runs_in_under_two_minutes(
-    registry: Registry, config_path: Path
-) -> None:
+def test_export_eras_runs_in_under_two_minutes(registry: Registry, config_path: Path) -> None:
     """BUF-53 acceptance: export runs in under 2 minutes per era.
 
     The fixture is small enough that the per-era cost should be in
@@ -144,17 +130,11 @@ def test_export_eras_runs_in_under_two_minutes(
     assert duration < 30.0, f"3-era export took {duration:.2f}s, budget is 30s"
 
 
-def test_export_era_is_idempotent(
-    registry: Registry, config_path: Path
-) -> None:
+def test_export_era_is_idempotent(registry: Registry, config_path: Path) -> None:
     """Re-exporting the same era + same source returns the same run_id (no-op)."""
     src = build_three_era_source()
-    first = export_era(
-        src, era_slug="e2024_01", config_path=config_path, registry=registry
-    )
-    second = export_era(
-        src, era_slug="e2024_01", config_path=config_path, registry=registry
-    )
+    first = export_era(src, era_slug="e2024_01", config_path=config_path, registry=registry)
+    second = export_era(src, era_slug="e2024_01", config_path=config_path, registry=registry)
     assert first.run_id == second.run_id
     assert second.passed
 
@@ -192,9 +172,7 @@ def test_manifest_serializes_datetime_metadata(tmp_path: Path) -> None:
     assert "2024-01-09" in patch_meta["starts_at"]
 
 
-def test_metadata_change_changes_run_id(
-    registry: Registry, config_path: Path
-) -> None:
+def test_metadata_change_changes_run_id(registry: Registry, config_path: Path) -> None:
     """Codex P2 (PR #24): a metadata-only source change must mint a new run_id.
 
     The fingerprint previously hashed only tensors, so a source that
@@ -227,9 +205,9 @@ def test_metadata_change_changes_run_id(
         config_path=config_path,
         registry=registry,
     )
-    assert first.run_id != second.run_id, (
-        "metadata-only source change must produce a new fingerprint"
-    )
+    assert (
+        first.run_id != second.run_id
+    ), "metadata-only source change must produce a new fingerprint"
 
 
 def test_failed_run_short_circuits_on_re_export(
@@ -252,33 +230,21 @@ def test_failed_run_short_circuits_on_re_export(
         report = real_validate(snapshot)
         from ecosystem.graph.validate import ValidationIssue
 
-        report.issues.append(
-            ValidationIssue("injected", "error", "test", "forced fail")
-        )
+        report.issues.append(ValidationIssue("injected", "error", "test", "forced fail"))
         return report
 
-    monkeypatch.setattr(
-        "ecosystem.graph.export.validate_snapshot", force_failing_report
-    )
-    first = export_era(
-        src, era_slug="e2024_01", config_path=config_path, registry=registry
-    )
+    monkeypatch.setattr("ecosystem.graph.export.validate_snapshot", force_failing_report)
+    first = export_era(src, era_slug="e2024_01", config_path=config_path, registry=registry)
     assert not first.passed
     assert registry.get(first.run_id).status is RunStatus.FAILED
 
     # Lift the injected failure for the second pass — were the
     # orchestrator to rebuild instead of short-circuiting, the
     # rebuild would now pass and contradict the FAILED row.
-    monkeypatch.setattr(
-        "ecosystem.graph.export.validate_snapshot", real_validate
-    )
-    second = export_era(
-        src, era_slug="e2024_01", config_path=config_path, registry=registry
-    )
+    monkeypatch.setattr("ecosystem.graph.export.validate_snapshot", real_validate)
+    second = export_era(src, era_slug="e2024_01", config_path=config_path, registry=registry)
     assert second.run_id == first.run_id
-    assert not second.passed, (
-        "re-export should return the cached FAILED report, not relabel"
-    )
+    assert not second.passed, "re-export should return the cached FAILED report, not relabel"
     assert registry.get(second.run_id).status is RunStatus.FAILED
 
 
@@ -295,9 +261,7 @@ def test_terminal_run_with_missing_artifacts_raises(
     from ecosystem.graph.export import GraphExportStateError
 
     src = build_three_era_source()
-    first = export_era(
-        src, era_slug="e2024_01", config_path=config_path, registry=registry
-    )
+    first = export_era(src, era_slug="e2024_01", config_path=config_path, registry=registry)
     assert first.passed
     # Operator manually deleted the artifacts but left the row.
     first.snapshot_path.unlink()
@@ -305,9 +269,7 @@ def test_terminal_run_with_missing_artifacts_raises(
     first.validation_path.unlink()
 
     with pytest.raises(GraphExportStateError):
-        export_era(
-            src, era_slug="e2024_01", config_path=config_path, registry=registry
-        )
+        export_era(src, era_slug="e2024_01", config_path=config_path, registry=registry)
 
 
 def test_failed_validation_writes_failed_status(
@@ -333,12 +295,8 @@ def test_failed_validation_writes_failed_status(
         )
         return report
 
-    monkeypatch.setattr(
-        "ecosystem.graph.export.validate_snapshot", force_failing_report
-    )
-    result = export_era(
-        src, era_slug="e2024_01", config_path=config_path, registry=registry
-    )
+    monkeypatch.setattr("ecosystem.graph.export.validate_snapshot", force_failing_report)
+    result = export_era(src, era_slug="e2024_01", config_path=config_path, registry=registry)
     assert not result.passed
     assert result.snapshot_path.exists()
     assert result.validation_path.exists()

--- a/services/ecosystem/tests/test_graph_export.py
+++ b/services/ecosystem/tests/test_graph_export.py
@@ -192,6 +192,46 @@ def test_manifest_serializes_datetime_metadata(tmp_path: Path) -> None:
     assert "2024-01-09" in patch_meta["starts_at"]
 
 
+def test_metadata_change_changes_run_id(
+    registry: Registry, config_path: Path
+) -> None:
+    """Codex P2 (PR #24): a metadata-only source change must mint a new run_id.
+
+    The fingerprint previously hashed only tensors, so a source that
+    shifted ``patch_meta.starts_at`` (or any other manifest-only
+    field) would short-circuit to the prior run_id and the manifest
+    on disk would silently disagree with the source — broken
+    auditability.
+    """
+    from datetime import UTC, datetime
+
+    from ecosystem.graph.source import InMemoryDataSource
+
+    def _build_source(starts_at: datetime) -> InMemoryDataSource:
+        s = InMemoryDataSource()
+        s.set_patch(
+            "e_t",
+            {"era_ordinal": 0.0, "starts_at": starts_at},
+        )
+        return s
+
+    first = export_era(
+        _build_source(datetime(2024, 1, 9, tzinfo=UTC)),
+        era_slug="e_t",
+        config_path=config_path,
+        registry=registry,
+    )
+    second = export_era(
+        _build_source(datetime(2024, 1, 10, tzinfo=UTC)),
+        era_slug="e_t",
+        config_path=config_path,
+        registry=registry,
+    )
+    assert first.run_id != second.run_id, (
+        "metadata-only source change must produce a new fingerprint"
+    )
+
+
 def test_failed_run_short_circuits_on_re_export(
     registry: Registry, config_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/services/ecosystem/tests/test_graph_export.py
+++ b/services/ecosystem/tests/test_graph_export.py
@@ -159,6 +159,39 @@ def test_export_era_is_idempotent(
     assert second.passed
 
 
+def test_manifest_serializes_datetime_metadata(tmp_path: Path) -> None:
+    """Codex P1 (PR #24): datetime values from ``patch_meta`` must serialize.
+
+    The ``GraphDataSource.patch_meta`` contract documents that era
+    window timestamps may flow through; ``json.dumps`` would otherwise
+    raise ``TypeError`` on the manifest write.
+    """
+    from datetime import UTC, datetime
+
+    from ecosystem.graph.source import InMemoryDataSource
+
+    src = InMemoryDataSource()
+    src.set_patch(
+        "e_t",
+        {
+            "era_ordinal": 0.0,
+            "starts_at": datetime(2024, 1, 9, tzinfo=UTC),
+            "ends_at": datetime(2024, 4, 15, tzinfo=UTC),
+        },
+    )
+    snap = build_snapshot(src, era_slug="e_t")
+    out_dir = tmp_path / "snap"
+    snap.write(out_dir)
+
+    manifest = json.loads((out_dir / "manifest.json").read_text(encoding="utf-8"))
+    patch_meta = manifest["metadata"]["patch_meta"]
+    # Datetimes round-trip as ISO strings; the exact format is whatever
+    # ``datetime.isoformat()`` produces, so we just confirm it landed
+    # as a string rather than crashing the dump.
+    assert isinstance(patch_meta["starts_at"], str)
+    assert "2024-01-09" in patch_meta["starts_at"]
+
+
 def test_failed_validation_writes_failed_status(
     registry: Registry, config_path: Path, monkeypatch: pytest.MonkeyPatch
 ) -> None:

--- a/services/ecosystem/tests/test_graph_export.py
+++ b/services/ecosystem/tests/test_graph_export.py
@@ -1,0 +1,195 @@
+"""Snapshot IO + export-orchestrator tests (BUF-53).
+
+The acceptance scenario is "full graph export for 3 eras passes
+structural validation"; these tests run that flow end-to-end through
+the real BUF-69 :class:`Registry` and assert the on-disk artifacts
+are present, well-formed, and round-trip cleanly back into a
+:class:`GraphSnapshot`.
+"""
+
+from __future__ import annotations
+
+import json
+import time
+from pathlib import Path
+
+import numpy as np
+import pytest
+from ecosystem.graph import GraphSnapshot, build_snapshot, validate_snapshot
+from ecosystem.graph.export import (
+    GRAPH_SNAPSHOT_KIND,
+    export_era,
+    export_eras,
+)
+from ecosystem.graph.snapshot import assert_schema_known
+from esports_sim.registry import Registry, RunStatus
+from graph_fixtures import ERA_SLUGS, build_three_era_source
+
+# ---- fixtures --------------------------------------------------------------
+
+
+@pytest.fixture
+def registry(tmp_path: Path) -> Registry:
+    return Registry(
+        db_path=tmp_path / "state" / "registry.db",
+        runs_dir=tmp_path / "runs",
+    )
+
+
+@pytest.fixture
+def config_path(tmp_path: Path) -> Path:
+    p = tmp_path / "graph_snapshot.yaml"
+    p.write_text(
+        "kind: graph-snapshot\nschema_version: 1.0.0\n", encoding="utf-8"
+    )
+    return p
+
+
+# ---- snapshot round-trip ---------------------------------------------------
+
+
+def test_snapshot_round_trips_through_npz(tmp_path: Path) -> None:
+    src = build_three_era_source()
+    snap = build_snapshot(src, era_slug="e2024_01")
+    out_dir = tmp_path / "snap"
+    snap.write(out_dir)
+
+    loaded = GraphSnapshot.read(out_dir)
+    assert loaded.era_slug == snap.era_slug
+    for nt in snap.node_types():
+        np.testing.assert_array_equal(
+            loaded.nodes(nt).x, snap.nodes(nt).x
+        )
+        assert loaded.nodes(nt).ids == snap.nodes(nt).ids
+        assert loaded.nodes(nt).column_names == snap.nodes(nt).column_names
+    for k in snap.edge_types():
+        np.testing.assert_array_equal(
+            loaded.edges(k).edge_index, snap.edges(k).edge_index
+        )
+    assert_schema_known(loaded)
+
+
+def test_manifest_records_per_node_columns(tmp_path: Path) -> None:
+    src = build_three_era_source()
+    snap = build_snapshot(src, era_slug="e2024_01")
+    snap.write(tmp_path)
+    manifest = json.loads((tmp_path / "manifest.json").read_text(encoding="utf-8"))
+
+    assert "node_columns" in manifest
+    assert "player" in manifest["node_columns"]
+    # acs / kast / adr / hs_pct / rating headline + derived + inferred + context
+    assert "acs" in manifest["node_columns"]["player"]
+    # Edge columns surfaced too.
+    assert "edge_attr_columns" in manifest
+    assert "player__plays_for__team" in manifest["edge_attr_columns"]
+
+
+# ---- export orchestrator ---------------------------------------------------
+
+
+def test_export_era_creates_registered_completed_run(
+    registry: Registry, config_path: Path
+) -> None:
+    src = build_three_era_source()
+    result = export_era(
+        src, era_slug="e2024_01", config_path=config_path, registry=registry
+    )
+
+    assert result.passed
+    assert result.snapshot_path.exists()
+    assert result.manifest_path.exists()
+    assert result.validation_path.exists()
+    record = registry.get(result.run_id)
+    assert record.status is RunStatus.COMPLETED
+    assert record.kind == GRAPH_SNAPSHOT_KIND
+
+
+def test_export_eras_three_era_acceptance(
+    registry: Registry, config_path: Path
+) -> None:
+    """BUF-53 acceptance: full graph export for 3 eras passes structural validation."""
+    src = build_three_era_source()
+    results = export_eras(
+        src,
+        era_slugs=list(ERA_SLUGS),
+        config_path=config_path,
+        registry=registry,
+    )
+
+    assert len(results) == 3
+    assert all(r.passed for r in results)
+    # Three distinct run ids — different fingerprints per era.
+    assert len({r.run_id for r in results}) == 3
+
+
+def test_export_eras_runs_in_under_two_minutes(
+    registry: Registry, config_path: Path
+) -> None:
+    """BUF-53 acceptance: export runs in under 2 minutes per era.
+
+    The fixture is small enough that the per-era cost should be in
+    the 10s of milliseconds; this test asserts the budget for the
+    *whole batch* with two orders of magnitude of headroom so a
+    legitimate slowdown trips it before a real era ever does.
+    """
+    src = build_three_era_source()
+    start = time.monotonic()
+    export_eras(
+        src,
+        era_slugs=list(ERA_SLUGS),
+        config_path=config_path,
+        registry=registry,
+    )
+    duration = time.monotonic() - start
+    assert duration < 30.0, f"3-era export took {duration:.2f}s, budget is 30s"
+
+
+def test_export_era_is_idempotent(
+    registry: Registry, config_path: Path
+) -> None:
+    """Re-exporting the same era + same source returns the same run_id (no-op)."""
+    src = build_three_era_source()
+    first = export_era(
+        src, era_slug="e2024_01", config_path=config_path, registry=registry
+    )
+    second = export_era(
+        src, era_slug="e2024_01", config_path=config_path, registry=registry
+    )
+    assert first.run_id == second.run_id
+    assert second.passed
+
+
+def test_failed_validation_writes_failed_status(
+    registry: Registry, config_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A snapshot that fails validation still writes artifacts but finalises FAILED."""
+    src = build_three_era_source()
+
+    real_validate = validate_snapshot
+
+    def force_failing_report(snapshot: GraphSnapshot):
+        report = real_validate(snapshot)
+        # Inject a synthetic error so the orchestrator records FAILED.
+        from ecosystem.graph.validate import ValidationIssue
+
+        report.issues.append(
+            ValidationIssue(
+                code="injected",
+                severity="error",
+                location="test",
+                message="forced failure for orchestrator coverage",
+            )
+        )
+        return report
+
+    monkeypatch.setattr(
+        "ecosystem.graph.export.validate_snapshot", force_failing_report
+    )
+    result = export_era(
+        src, era_slug="e2024_01", config_path=config_path, registry=registry
+    )
+    assert not result.passed
+    assert result.snapshot_path.exists()
+    assert result.validation_path.exists()
+    record = registry.get(result.run_id)
+    assert record.status is RunStatus.FAILED

--- a/services/ecosystem/tests/test_graph_normalize.py
+++ b/services/ecosystem/tests/test_graph_normalize.py
@@ -111,9 +111,7 @@ def test_get_normalizer_unknown_raises() -> None:
 
 def test_nan_inputs_are_ignored_in_fit() -> None:
     """NaN values shouldn't shift the fit; downstream fill_policy handles missing."""
-    out, fit = normalize_column(
-        np.array([1.0, np.nan, 9.0]), normalizer_name="minmax"
-    )
+    out, fit = normalize_column(np.array([1.0, np.nan, 9.0]), normalizer_name="minmax")
     # The two finite values bound the fit. The NaN passes through
     # arithmetic untouched here — the *builder* applies fill_policy on
     # top of normalize_column's output (see test_graph_builder.py).

--- a/services/ecosystem/tests/test_graph_normalize.py
+++ b/services/ecosystem/tests/test_graph_normalize.py
@@ -1,0 +1,121 @@
+"""Per-normaliser unit tests (BUF-53).
+
+These are deliberately small and exhaustive — the builder asks only
+for ``normalize_column``, but a regression in any single normaliser
+would silently corrupt every era's snapshot.
+"""
+
+from __future__ import annotations
+
+import numpy as np
+import pytest
+from ecosystem.graph.normalize import (
+    NormalizerError,
+    get_normalizer,
+    normalize_column,
+)
+
+# ---- minmax ---------------------------------------------------------------
+
+
+def test_minmax_maps_endpoints_to_zero_and_one() -> None:
+    out, fit = normalize_column(np.array([1.0, 5.0, 9.0]), normalizer_name="minmax")
+    assert out.dtype == np.float32
+    assert pytest.approx(out.tolist()) == [0.0, 0.5, 1.0]
+    assert fit.params["min"] == 1.0
+    assert fit.params["max"] == 9.0
+
+
+def test_minmax_degenerate_returns_uniform_half() -> None:
+    """All-equal column is well-defined: middle of [0, 1]."""
+    out, fit = normalize_column(np.array([3.0, 3.0, 3.0]), normalizer_name="minmax")
+    assert pytest.approx(out.tolist()) == [0.5, 0.5, 0.5]
+    assert fit.params["degenerate"] == 1.0
+
+
+def test_minmax_clips_unseen_outliers() -> None:
+    """Transform-time values outside the fitted range are clipped, not extrapolated."""
+    norm = get_normalizer("minmax")
+    fit = norm.fit(np.array([0.0, 10.0]))
+    out = norm.transform(np.array([-5.0, 15.0]), fit)
+    assert out.tolist() == [0.0, 1.0]
+
+
+# ---- zscore ---------------------------------------------------------------
+
+
+def test_zscore_centers_to_half_via_logistic() -> None:
+    out, _ = normalize_column(np.array([0.0, 0.0, 0.0]), normalizer_name="zscore")
+    # Degenerate (zero std) — falls back to 0.5.
+    assert pytest.approx(out.tolist()) == [0.5, 0.5, 0.5]
+
+
+def test_zscore_squashes_to_unit_interval() -> None:
+    """Even extreme inputs squash through logistic to (0, 1)."""
+    out, _ = normalize_column(
+        np.array([-100.0, -1.0, 0.0, 1.0, 100.0]),
+        normalizer_name="zscore",
+    )
+    assert (out >= 0.0).all() and (out <= 1.0).all()
+    # Symmetric inputs should bracket 0.5.
+    assert out[0] < out[1] < out[2] < out[3] < out[4]
+
+
+# ---- log1p_minmax ---------------------------------------------------------
+
+
+def test_log1p_minmax_handles_long_tail() -> None:
+    # log1p flattens the tail so the mid-value isn't 0.5.
+    out, _ = normalize_column(
+        np.array([0.0, 1.0, 100.0, 10000.0]),
+        normalizer_name="log1p_minmax",
+    )
+    assert out[0] == pytest.approx(0.0)
+    assert out[-1] == pytest.approx(1.0)
+    # The "1.0" point should be much closer to 0 than to 1.
+    assert out[1] < 0.2
+
+
+def test_log1p_minmax_clamps_negatives_silently() -> None:
+    out, _ = normalize_column(
+        np.array([-5.0, 0.0, 10.0]),
+        normalizer_name="log1p_minmax",
+    )
+    # Negative becomes 0.0 (post-clamp == post-log1p baseline).
+    assert out[0] == pytest.approx(out[1])
+
+
+# ---- passthrough ----------------------------------------------------------
+
+
+def test_passthrough_accepts_unit_interval() -> None:
+    out, _ = normalize_column(np.array([0.0, 0.5, 1.0]), normalizer_name="passthrough")
+    assert pytest.approx(out.tolist()) == [0.0, 0.5, 1.0]
+
+
+def test_passthrough_rejects_out_of_range_values() -> None:
+    with pytest.raises(NormalizerError):
+        normalize_column(np.array([0.0, 0.5, 1.5]), normalizer_name="passthrough")
+
+
+# ---- registry --------------------------------------------------------------
+
+
+def test_get_normalizer_unknown_raises() -> None:
+    with pytest.raises(NormalizerError):
+        get_normalizer("not_a_real_normalizer")
+
+
+# ---- nan handling ---------------------------------------------------------
+
+
+def test_nan_inputs_are_ignored_in_fit() -> None:
+    """NaN values shouldn't shift the fit but still get a sensible transform."""
+    out, fit = normalize_column(
+        np.array([1.0, np.nan, 9.0]), normalizer_name="minmax"
+    )
+    # The two finite values bound the fit; the NaN row gets the
+    # post-clip output, which is NaN passed through arithmetic.
+    assert fit.params["min"] == 1.0
+    assert fit.params["max"] == 9.0
+    assert np.isnan(out[1])

--- a/services/ecosystem/tests/test_graph_normalize.py
+++ b/services/ecosystem/tests/test_graph_normalize.py
@@ -110,12 +110,13 @@ def test_get_normalizer_unknown_raises() -> None:
 
 
 def test_nan_inputs_are_ignored_in_fit() -> None:
-    """NaN values shouldn't shift the fit but still get a sensible transform."""
+    """NaN values shouldn't shift the fit; downstream fill_policy handles missing."""
     out, fit = normalize_column(
         np.array([1.0, np.nan, 9.0]), normalizer_name="minmax"
     )
-    # The two finite values bound the fit; the NaN row gets the
-    # post-clip output, which is NaN passed through arithmetic.
+    # The two finite values bound the fit. The NaN passes through
+    # arithmetic untouched here — the *builder* applies fill_policy on
+    # top of normalize_column's output (see test_graph_builder.py).
     assert fit.params["min"] == 1.0
     assert fit.params["max"] == 9.0
     assert np.isnan(out[1])

--- a/services/ecosystem/tests/test_graph_schema.py
+++ b/services/ecosystem/tests/test_graph_schema.py
@@ -1,0 +1,94 @@
+"""Schema-shape contract tests for the graph exporter (BUF-53).
+
+These pin the declared node + edge inventory so a one-line refactor in
+:mod:`ecosystem.graph.schema` doesn't quietly change what the trainer
+expects to load.
+"""
+
+from __future__ import annotations
+
+import pytest
+from ecosystem.graph.schema import (
+    EDGE_TYPES,
+    NODE_TYPES,
+    SchemaError,
+    edge_spec,
+    node_spec,
+)
+
+# ---- node-type inventory ---------------------------------------------------
+
+
+def test_node_types_match_systems_spec() -> None:
+    """Issue mandates feature matrices for player / team / patch (+ agent for affects edge)."""
+    assert set(NODE_TYPES) == {"player", "team", "patch", "agent"}
+
+
+@pytest.mark.parametrize("node_type", sorted(NODE_TYPES))
+def test_each_node_type_has_all_four_feature_groups(node_type: str) -> None:
+    """Acceptance: acs_norm, derived, inferred, context — every node type."""
+    spec = NODE_TYPES[node_type]
+    group_names = {g.name for g in spec.groups}
+    assert group_names == {"acs_norm", "derived", "inferred", "context"}
+
+
+def test_node_spec_lookup_round_trips() -> None:
+    spec = node_spec("player")
+    assert spec.name == "player"
+    assert spec.feature_dim() == sum(len(g.columns) for g in spec.groups)
+
+
+def test_node_spec_unknown_raises() -> None:
+    with pytest.raises(SchemaError):
+        node_spec("not_a_real_node_type")
+
+
+# ---- edge-type inventory ---------------------------------------------------
+
+
+def test_edge_types_match_issue_scope() -> None:
+    """Issue mandates: plays_for, relates_to, sponsored_by, affects (patch→agent)."""
+    assert set(EDGE_TYPES) == {
+        ("player", "plays_for", "team"),
+        ("team", "relates_to", "team"),
+        ("team", "sponsored_by", "team"),
+        ("patch", "affects", "agent"),
+    }
+
+
+def test_affects_edge_runs_patch_to_agent() -> None:
+    """The acceptance pin from the issue body."""
+    spec = edge_spec(("patch", "affects", "agent"))
+    assert spec.src == "patch"
+    assert spec.relation == "affects"
+    assert spec.dst == "agent"
+
+
+def test_plays_for_edge_is_time_bounded() -> None:
+    """Roster movement is the canonical time-bounded edge."""
+    assert edge_spec(("player", "plays_for", "team")).time_bounded is True
+
+
+def test_edge_spec_unknown_raises() -> None:
+    with pytest.raises(SchemaError):
+        edge_spec(("does", "not", "exist"))
+
+
+# ---- column-level invariants ----------------------------------------------
+
+
+def test_every_column_has_a_normalizer_name() -> None:
+    """Acceptance: no raw un-scaled columns. Every column declares one."""
+    for spec in NODE_TYPES.values():
+        for col in spec.all_columns():
+            assert col.normalizer
+    for spec in EDGE_TYPES.values():
+        for col in spec.edge_attr_columns:
+            assert col.normalizer
+
+
+def test_invalid_fill_policy_rejected() -> None:
+    from ecosystem.graph.schema import FeatureColumn
+
+    with pytest.raises(SchemaError):
+        FeatureColumn(name="x", group="acs_norm", normalizer="minmax", fill_policy="invalid")

--- a/uv.lock
+++ b/uv.lock
@@ -277,10 +277,14 @@ version = "0.0.1"
 source = { editable = "services/ecosystem" }
 dependencies = [
     { name = "esports-sim-shared" },
+    { name = "numpy" },
 ]
 
 [package.metadata]
-requires-dist = [{ name = "esports-sim-shared", editable = "packages/shared" }]
+requires-dist = [
+    { name = "esports-sim-shared", editable = "packages/shared" },
+    { name = "numpy", specifier = ">=1.26" },
+]
 
 [[package]]
 name = "esports-sim-shared"

--- a/uv.lock
+++ b/uv.lock
@@ -30,6 +30,7 @@ dev = [
     { name = "pytest" },
     { name = "pytest-cov" },
     { name = "pytest-picked" },
+    { name = "pytest-timeout" },
     { name = "ruff" },
     { name = "types-pyyaml" },
 ]
@@ -50,6 +51,7 @@ dev = [
     { name = "pytest", specifier = ">=8.0" },
     { name = "pytest-cov", specifier = ">=5.0" },
     { name = "pytest-picked", specifier = ">=0.5" },
+    { name = "pytest-timeout", specifier = ">=2.3" },
     { name = "ruff", specifier = ">=0.4" },
     { name = "types-pyyaml" },
 ]
@@ -781,6 +783,18 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/ba/e4/51a54dd6638fd4a7c45bb20a737235fd92cbb4d24b5ff681d64ace5d02e9/pytest_picked-0.5.1.tar.gz", hash = "sha256:6634c4356a560a5dc3dba35471865e6eb06bbd356b56b69c540593e9d5620ded", size = 8401, upload-time = "2024-11-06T23:19:52.538Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/c6/81/450c017746caab376c4b6700439de9f1cc7d8e1f22dec3c1eb235cd9ad3e/pytest_picked-0.5.1-py3-none-any.whl", hash = "sha256:af65c4763b51dc095ae4bc5073a962406902422ad9629c26d8b01122b677d998", size = 6608, upload-time = "2024-11-06T23:19:51.284Z" },
+]
+
+[[package]]
+name = "pytest-timeout"
+version = "2.4.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pytest" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/ac/82/4c9ecabab13363e72d880f2fb504c5f750433b2b6f16e99f4ec21ada284c/pytest_timeout-2.4.0.tar.gz", hash = "sha256:7e68e90b01f9eff71332b25001f85c75495fc4e3a836701876183c4bcfd0540a", size = 17973, upload-time = "2025-05-05T19:44:34.99Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fa/b6/3127540ecdf1464a00e5a01ee60a1b09175f6913f0644ac748494d9c4b21/pytest_timeout-2.4.0-py3-none-any.whl", hash = "sha256:c42667e5cdadb151aeb5b26d114aff6bdf5a907f176a007a30b940d3d865b5c2", size = 14382, upload-time = "2025-05-05T19:44:33.502Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes BUF-53.

## Summary

Builds the four-node, four-edge graph the GNN trainer consumes per Systems-spec System 08, with the System-09 structural validation hook and BUF-69 registry integration for snapshots.

- **Node types**: `player`, `team`, `patch`, `agent` — each with the four feature groups the spec mandates: `acs_norm`, `derived`, `inferred`, `context`.
- **Edge types**: `(player, plays_for, team)`, `(team, relates_to, team)`, `(team, sponsored_by, team)`, `(patch, affects, agent)`.
- **Validation hook (System 09)**: returns a full `ValidationReport` rather than raising on the first failure; covers schema parity, NaN/Inf, unit-interval, endpoint integrity, duplicate ids.
- **Snapshot registry**: built on the BUF-69 `Registry`. Idempotent — same source + same era + same config returns the existing `run_id` with no rebuild.

## Layout

```
services/ecosystem/src/ecosystem/graph/
  schema.py     declarative node + edge specs (SCHEMA_VERSION lives here)
  snapshot.py   numpy-backed HeteroData analog + lazy .to_pyg() adapter
  source.py     GraphDataSource Protocol + InMemoryDataSource fixture
  normalize.py  minmax / zscore / log1p_minmax / passthrough — fit per era
  builder.py    raw rows -> normalised tensors, deterministic ordering
  validate.py   System-09 structural checks
  export.py     orchestrator: build -> validate -> Registry register/finalize
```

`numpy>=1.26` is added to `services/ecosystem`. `torch` / `torch_geometric` stay optional and only import lazily inside `GraphSnapshot.to_pyg()` so the CI image stays small and the snapshot artifact stays language-portable.

## Acceptance

- [x] Full graph export for 3 eras passes all structural validation — `test_three_era_export_passes_validation`, `test_export_eras_three_era_acceptance`.
- [x] Feature matrices are fully normalized (no raw un-scaled columns) — every column declares a normalizer; the validator pins a `[0, 1]` range with `_UNIT_SLACK` tolerance.
- [x] Export runs in under 2 minutes per era — `test_export_eras_runs_in_under_two_minutes` enforces 30 s for three eras (two orders of magnitude headroom).

## Test plan

- [x] `uv run pytest services/ecosystem/tests` — 56 passed, <1s
- [x] `uv run pytest packages/shared/tests` — 264 passed, 72 skipped (Postgres-gated)
- [x] `uv run ruff check .` — clean
- [x] `uv run mypy services/ecosystem/src` — clean

## Deferred / follow-up

- A `SqlDataSource` adapter against the BUF-6 SQLAlchemy models — wires the builder to live Postgres data. The `GraphDataSource` Protocol is in place; the implementation lands when the per-player stats tables (`derived.player_match` etc. from `config/derivation.yaml`) ship.
- A `nexus graph export` CLI subcommand. The orchestrator API (`export_era`, `export_eras`) is ready; CLI plumbing follows the BUF-69 `nexus run` pattern.

https://claude.ai/code/session_01TuRPvVs6BF1vbJRqDoewYc

---
_Generated by [Claude Code](https://claude.ai/code/session_01TuRPvVs6BF1vbJRqDoewYc)_