### PR TITLE
VLR per-match player participation scraper (#23)

### DIFF
--- a/packages/shared/alembic/versions/20260503_0007_player_match_stat.py
+++ b/packages/shared/alembic/versions/20260503_0007_player_match_stat.py
@@ -1,0 +1,173 @@
+"""Per-map player participation table for the BUF-85 VLR /match/ scraper.
+
+Lands the ``player_match_stat`` table — one row per (map, player) — so the
+follow-up VLR per-match scraper can record who played which agent on
+which map with the canonical headline stats. Designed to also accept
+Riot API rows once that connector grows a stat-extraction step
+(RescuedBuffalo/agentic-esports-tycoon#2 currently writes the same
+shape into ``staging_record.payload`` but defers the typed write).
+
+Schema rationale:
+
+* ``map_result_id`` FKs straight to ``map_result.map_result_id`` with
+  ``ON DELETE CASCADE`` — a per-map stat without its parent map is
+  uninterpretable, and ``map_result`` is the row that owns the
+  ``vlr_game_id`` idempotency anchor BUF-8 v2 already maintains.
+* ``entity_id`` FKs to ``entity.canonical_id`` with ``ON DELETE
+  CASCADE`` — when a canonical entity is removed (a duplicate gets
+  merged away) the orphaned stats follow. Other tables (``match``)
+  use ``SET NULL`` instead because the row is still useful as a
+  "this happened" record without the participant; here, a stat row
+  with no player is just noise.
+* ``source`` + ``source_player_id`` keep the upstream identity intact
+  for audit and let two sources (VLR + Riot) coexist in the same
+  table. The dedup unique constraint is on ``(map_result_id,
+  entity_id)`` per the BUF-85 spec — first writer wins; a later VLR
+  pass over a Riot-seeded match no-ops on conflict.
+* Headline stats live in dedicated columns (kills/deaths/assists,
+  ACS, ADR, KAST, HS%, FK/FD, rating). Source-specific extras
+  (Riot's per-round detail, VLR's pistol/eco breakdown) go into the
+  ``extra`` JSONB blob — same pattern as ``map_result.team{1,2}_stats``.
+* ``agent`` is a free-form String(32) rather than an enum. Riot adds
+  agents per patch and we'd rather not gate the scraper on a
+  migration every time a new dueller ships; a downstream feature
+  extractor can validate against the canonical agent list in
+  ``data/agents/``.
+* ``team_side`` is the literal ``"team1"`` / ``"team2"`` matching the
+  ``map_result`` column names so a join can resolve which side of
+  the map the player was on without an extra mapping table. CHECK
+  constraint pins the value space.
+
+Revision ID: 0007
+Revises: 0006
+Create Date: 2026-05-03
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "0007"
+down_revision: str | None = "0006"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "player_match_stat",
+        sa.Column("player_match_stat_id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "map_result_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey(
+                "map_result.map_result_id",
+                ondelete="CASCADE",
+                name="fk_player_match_stat_map_result_id_map_result",
+            ),
+            nullable=False,
+        ),
+        sa.Column(
+            "entity_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey(
+                "entity.canonical_id",
+                ondelete="CASCADE",
+                name="fk_player_match_stat_entity_id_entity",
+            ),
+            nullable=False,
+        ),
+        # ``source`` is the writing connector's ``source_name``
+        # (e.g. ``"vlr"`` or ``"riot_api"``). Kept narrow because we
+        # only ever store an ingester id here, not a free-form string.
+        sa.Column("source", sa.String(32), nullable=False),
+        # The upstream identifier we used to mint the canonical alias.
+        # Riot's PUUID is 78 chars; VLR's numeric id is short. 128 covers
+        # both with margin.
+        sa.Column("source_player_id", sa.String(128), nullable=False),
+        # ``team1`` / ``team2`` — matches the ``map_result.team{1,2}_*``
+        # column naming so a downstream join on side knows which team
+        # rounds belong to the player.
+        sa.Column("team_side", sa.String(8), nullable=True),
+        sa.Column("agent", sa.String(32), nullable=True),
+        # Headline stats. Nullable across the board because forfeits,
+        # walkovers, and partial scrapes legitimately ship without
+        # every column.
+        sa.Column("rating", sa.Float(), nullable=True),
+        sa.Column("acs", sa.Float(), nullable=True),
+        sa.Column("kills", sa.Integer(), nullable=True),
+        sa.Column("deaths", sa.Integer(), nullable=True),
+        sa.Column("assists", sa.Integer(), nullable=True),
+        sa.Column("kast_pct", sa.Float(), nullable=True),
+        sa.Column("adr", sa.Float(), nullable=True),
+        sa.Column("hs_pct", sa.Float(), nullable=True),
+        sa.Column("first_kills", sa.Integer(), nullable=True),
+        sa.Column("first_deaths", sa.Integer(), nullable=True),
+        # Source-specific long-tail (Riot's per-round breakdown, VLR's
+        # 2K/3K/4K/5K columns, etc.) lives here so we don't bloat the
+        # column count for fields one source carries.
+        sa.Column(
+            "extra",
+            postgresql.JSONB,
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        # Idempotency anchor per the BUF-85 spec: re-running the
+        # scraper for the same match must no-op. ``map_result_id`` is
+        # 1:1 with ``vlr_game_id`` (its UNIQUE column) so this is the
+        # same as ``(vlr_game_id, entity_id)`` without the extra join.
+        sa.UniqueConstraint(
+            "map_result_id",
+            "entity_id",
+            name="uq_player_match_stat_map_result_entity",
+        ),
+        # The value space is closed at the application layer; pin it
+        # at the DB so a buggy writer can't insert ``"home"`` /
+        # ``"away"`` and silently break joins on ``map_result``.
+        sa.CheckConstraint(
+            "team_side IS NULL OR team_side IN ('team1', 'team2')",
+            name="ck_player_match_stat_team_side",
+        ),
+    )
+    # Both FK sides get an index — the typical query pattern is either
+    # "all stats for this map" (map_result_id) or "all stats for this
+    # player" (entity_id), and we don't want a seq-scan on either side
+    # of a 100k+ row table.
+    op.create_index(
+        "ix_player_match_stat_map_result_id",
+        "player_match_stat",
+        ["map_result_id"],
+    )
+    op.create_index(
+        "ix_player_match_stat_entity_id",
+        "player_match_stat",
+        ["entity_id"],
+    )
+    # Source-id lookup for re-scrape paths that key on the upstream id
+    # before the resolver has minted a canonical (e.g. dry-run audits).
+    op.create_index(
+        "ix_player_match_stat_source_source_player_id",
+        "player_match_stat",
+        ["source", "source_player_id"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index(
+        "ix_player_match_stat_source_source_player_id",
+        table_name="player_match_stat",
+    )
+    op.drop_index("ix_player_match_stat_entity_id", table_name="player_match_stat")
+    op.drop_index("ix_player_match_stat_map_result_id", table_name="player_match_stat")
+    op.drop_table("player_match_stat")

--- a/packages/shared/src/esports_sim/db/models.py
+++ b/packages/shared/src/esports_sim/db/models.py
@@ -591,6 +591,91 @@ class Match(Base):
     __table_args__ = (UniqueConstraint("vlr_match_id", name="uq_match_vlr_match_id"),)
 
 
+class PlayerMatchStat(Base):
+    """One per-map player participation row (BUF-85).
+
+    Lands one row per (map, player): which canonical entity played
+    which agent on which map, plus the headline stats VLR's per-match
+    page exposes (rating, ACS, K/D/A, KAST, ADR, HS%, FK/FD). Source-
+    specific long-tail columns live in the ``extra`` JSONB blob so
+    the typed schema doesn't have to grow per-source.
+
+    Idempotency: the unique constraint on ``(map_result_id,
+    entity_id)`` is the dedup anchor the BUF-85 spec calls for
+    (``vlr_game_id`` is 1:1 with ``map_result``, so this is the same
+    key without the join). A re-run of the scraper for the same match
+    no-ops on conflict; first-writer-wins keeps the schema simple
+    until cross-source merge logic is needed.
+
+    Source-agnostic by design. ``source`` + ``source_player_id``
+    preserve the upstream identity (VLR numeric id, Riot PUUID) so
+    the scraper can audit "who did we attribute this stat to" without
+    re-reading the alias table. The Riot connector
+    (RescuedBuffalo/agentic-esports-tycoon#2) currently writes only
+    to ``staging_record``; once it grows a stat-extraction step it
+    can land in this same table without a schema change.
+    """
+
+    __tablename__ = "player_match_stat"
+
+    player_match_stat_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+    map_result_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("map_result.map_result_id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    entity_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("entity.canonical_id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    source: Mapped[str] = mapped_column(String(32), nullable=False)
+    source_player_id: Mapped[str] = mapped_column(String(128), nullable=False)
+    # ``team1`` / ``team2`` — matches the ``map_result.team{1,2}_*``
+    # column naming so a join on side does not need a translation.
+    team_side: Mapped[str | None] = mapped_column(String(8), nullable=True)
+    agent: Mapped[str | None] = mapped_column(String(32), nullable=True)
+    rating: Mapped[float | None] = mapped_column(Float, nullable=True)
+    acs: Mapped[float | None] = mapped_column(Float, nullable=True)
+    kills: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    deaths: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    assists: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    kast_pct: Mapped[float | None] = mapped_column(Float, nullable=True)
+    adr: Mapped[float | None] = mapped_column(Float, nullable=True)
+    hs_pct: Mapped[float | None] = mapped_column(Float, nullable=True)
+    first_kills: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    first_deaths: Mapped[int | None] = mapped_column(Integer, nullable=True)
+    extra: Mapped[dict[str, Any]] = mapped_column(
+        JSONB,
+        nullable=False,
+        server_default=text("'{}'::jsonb"),
+        default=dict,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        nullable=False,
+    )
+
+    __table_args__ = (
+        UniqueConstraint(
+            "map_result_id",
+            "entity_id",
+            name="uq_player_match_stat_map_result_entity",
+        ),
+        CheckConstraint(
+            "team_side IS NULL OR team_side IN ('team1', 'team2')",
+            name="ck_player_match_stat_team_side",
+        ),
+    )
+
+
 class MapResult(Base):
     """One map within a :class:`Match` (BUF-8 v2).
 
@@ -660,6 +745,7 @@ __all__ = [
     "Match",
     "PatchEra",
     "PatchNote",
+    "PlayerMatchStat",
     "RawRecord",
     "StagingInvariantError",
     "StagingRecord",

--- a/services/data_pipeline/src/data_pipeline/connectors/vlr_match.py
+++ b/services/data_pipeline/src/data_pipeline/connectors/vlr_match.py
@@ -518,9 +518,7 @@ def scrape_vlr_match_players(
     # Pre-load existing (map_result_id, entity_id) pairs so the
     # idempotent re-run path doesn't hit the DB at all per row. We
     # query in one shot rather than per-row.
-    existing_stat_keys = _load_existing_stat_keys(
-        session, list(map_id_by_game_id.values())
-    )
+    existing_stat_keys = _load_existing_stat_keys(session, list(map_id_by_game_id.values()))
 
     for vlr_match_id in vlr_match_ids:
         stats.matches_seen += 1

--- a/services/data_pipeline/src/data_pipeline/connectors/vlr_match.py
+++ b/services/data_pipeline/src/data_pipeline/connectors/vlr_match.py
@@ -503,6 +503,18 @@ def scrape_vlr_match_players(
     robots_cache = robots_cache or _RobotsCache(base_url, user_agent=user_agent)
     stats = VlrMatchScrapeStats()
 
+    # Materialise the input once. The signature accepts ``Iterable[str]``
+    # so callers can pass a generator (notably
+    # :func:`iter_match_ids_from_db`, a one-shot ``session.execute(...)``
+    # iterator), but the scraper consumes the sequence twice — once for
+    # the ``map_result`` pre-load query and once in the main fetch loop.
+    # Without this list() conversion the second pass would silently see
+    # zero matches on a one-shot iterator and the scraper would write no
+    # stats. Materialising early also gives ``_load_map_results_for_matches``
+    # a stable list to bind into its ``IN (...)`` clause without paying for
+    # a second iteration.
+    vlr_match_id_list = list(vlr_match_ids)
+
     # Pre-load existing PLAYER aliases so the per-row create-or-get is
     # an O(1) hashmap probe instead of a SELECT per id. Only PLAYER
     # rows are relevant; the BUF-85 scraper writes nothing else.
@@ -513,14 +525,14 @@ def scrape_vlr_match_players(
     # ingested that match — we log + skip rather than mint a phantom
     # map_result row, since the seed is the canonical writer for that
     # column.
-    map_id_by_game_id = _load_map_results_for_matches(session, vlr_match_ids)
+    map_id_by_game_id = _load_map_results_for_matches(session, vlr_match_id_list)
 
     # Pre-load existing (map_result_id, entity_id) pairs so the
     # idempotent re-run path doesn't hit the DB at all per row. We
     # query in one shot rather than per-row.
     existing_stat_keys = _load_existing_stat_keys(session, list(map_id_by_game_id.values()))
 
-    for vlr_match_id in vlr_match_ids:
+    for vlr_match_id in vlr_match_id_list:
         stats.matches_seen += 1
         url = _match_page_url(base_url, vlr_match_id)
         if not robots_cache.allows(url):

--- a/services/data_pipeline/src/data_pipeline/connectors/vlr_match.py
+++ b/services/data_pipeline/src/data_pipeline/connectors/vlr_match.py
@@ -1,0 +1,814 @@
+"""VLR.gg per-match player participation scraper (BUF-85).
+
+Fills in the player layer the BUF-8 v2 CSV bootstrap deferred. The
+seed populated ``match`` + ``map_result`` rows with stable
+``vlr_match_id`` / ``vlr_game_id`` anchors but had no roster
+information — the CSV's ``Team1Game1..Team2Game5`` columns are
+recent-form match-id history, not lineups. Per-map rosters live on
+the per-match profile page at ``/match/<id>``, which this module
+scrapes.
+
+Pipeline shape:
+
+    list of vlr_match_ids -> rate-limited Playwright fetch
+        -> parse rosters/stats per map
+        -> create-or-get canonical PLAYER entity per (Platform.VLR, vlr_player_id)
+        -> upsert player_match_stat row keyed on (map_result_id, entity_id)
+
+The module deliberately bypasses the steady-state
+:func:`~data_pipeline.runner.run_ingestion` flow: that orchestrator
+only writes ``raw_record`` and ``staging_record``, and the BUF-85
+schema lands typed columns directly on ``player_match_stat``. The
+seed module (:mod:`data_pipeline.seeds.vlr`) follows the same
+shape — direct create-or-get on ``(Platform.VLR, platform_id)``,
+with ``EntityAlias`` namespaced via :func:`vlr_alias_platform_id`
+so VLR's overlapping per-resource id spaces (player vs. team vs.
+event) cannot collide on the alias unique constraint.
+
+Idempotency is the load-bearing property: a re-scrape over the
+same match list is a no-op. The unique constraint
+``uq_player_match_stat_map_result_entity`` is the schema-level
+guarantee; a ``begin_nested`` savepoint plus an ``IntegrityError``
+catch handles the race between two concurrent scrapers.
+
+Out of scope:
+
+* The ``StagingRecord`` write the steady-state runner would do. The
+  BUF-85 acceptance criteria is the typed ``player_match_stat`` row;
+  raw page HTML is preserved by the caller via ``page_fetcher``
+  logging if needed (we do not stash it in ``raw_record`` because
+  reprocessing a per-match page is cheap relative to a full crawl).
+* ``RoundResult`` per-round granularity. VLR's ``/match/`` page only
+  exposes per-map aggregates; the per-round Riot-API parity ticket
+  (RescuedBuffalo/agentic-esports-tycoon#2) feeds the same table
+  with its own extractor.
+* Backfill orchestration. Callers pass a ``vlr_match_ids`` iterable;
+  a configurable backfill range is just ``select(Match.vlr_match_id)``
+  with a ``where(Match.match_date > ...)`` and lives in the operator
+  CLI, not in this module.
+"""
+
+from __future__ import annotations
+
+import logging
+import re
+import urllib.parse
+import uuid
+from collections.abc import Iterable, Iterator
+from dataclasses import dataclass, field
+from html.parser import HTMLParser
+from typing import Any
+
+from esports_sim.db.enums import EntityType, Platform
+from esports_sim.db.models import Entity, EntityAlias, MapResult, PlayerMatchStat
+from sqlalchemy import select
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from data_pipeline.connectors.vlr import (
+    USER_AGENT,
+    VLR_BASE_URL,
+    PageFetcher,
+    _RobotsCache,
+    vlr_alias_platform_id,
+)
+from data_pipeline.errors import SchemaDriftError, TransientFetchError
+from data_pipeline.rate_limiter import TokenBucket
+
+logger = logging.getLogger(__name__)
+
+
+# Same 20 req/min budget the rest of the VLR connector pays — kept
+# consistent so a parallel run of both does not exceed the upstream
+# politeness limit at the host level.
+_VLR_TOKEN_REFILL_PER_SECOND: float = 20.0 / 60.0
+_VLR_TOKEN_CAPACITY: int = 1
+
+
+# Position-indexed columns inside the ``mod-overview`` stat row, after
+# the player and agent cells. VLR's column order has been stable across
+# the last several site revisions; if it ever shifts, the parser raises
+# :class:`SchemaDriftError` rather than silently mis-attributing stats.
+_STAT_ORDER: tuple[str, ...] = (
+    "rating",
+    "acs",
+    "kills",
+    "deaths",
+    "assists",
+    "kd_diff",  # ignored on the model; kept for position alignment
+    "kast_pct",
+    "adr",
+    "hs_pct",
+    "first_kills",
+    "first_deaths",
+    "fk_fd_diff",  # ignored on the model; kept for position alignment
+)
+
+# Column count in the VLR ``mod-overview`` per-map stat row. 14 = player
+# + agent + 12 stat cells. A row with a different count is treated as
+# upstream drift and the row is skipped (logged) rather than silently
+# attributing stats to the wrong column.
+_EXPECTED_CELL_COUNT: int = 14
+
+
+_PLAYER_HREF_RE = re.compile(r"^/player/(\d+)/([^/?#]+)")
+
+
+@dataclass(frozen=True)
+class ParsedPlayerStat:
+    """One per-map player row extracted from a VLR ``/match/<id>`` page.
+
+    ``vlr_game_id`` is the upstream id the seed already used as the
+    ``map_result.vlr_game_id`` anchor; ``vlr_player_id`` is what
+    :func:`vlr_alias_platform_id` namespaces with ``"player-"`` to
+    produce the alias ``platform_id``. Stats are kept as the
+    ``Optional[float|int]`` shape the model column expects — empty
+    cells become ``None`` so a forfeit/walkover row preserves the
+    absence rather than coercing to zero.
+    """
+
+    vlr_game_id: str
+    vlr_player_id: str
+    display_name: str
+    team_side: str | None
+    agent: str | None
+    rating: float | None
+    acs: float | None
+    kills: int | None
+    deaths: int | None
+    assists: int | None
+    kast_pct: float | None
+    adr: float | None
+    hs_pct: float | None
+    first_kills: int | None
+    first_deaths: int | None
+    extra: dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class VlrMatchScrapeStats:
+    """Counters from one :func:`scrape_vlr_match_players` invocation.
+
+    Each per-row outcome maps to exactly one counter so totals add up;
+    ``skipped_*`` buckets are non-fatal drops that the operator can
+    triage from the structured-log warnings without re-running.
+    """
+
+    matches_seen: int = 0
+    matches_fetched: int = 0
+    matches_skipped_fetch: int = 0
+    matches_skipped_drift: int = 0
+    players_parsed: int = 0
+    players_inserted: int = 0
+    players_existing: int = 0
+    players_skipped_no_map: int = 0
+
+
+# --- HTML parser ----------------------------------------------------------
+
+
+class _MatchPageParser(HTMLParser):
+    """State machine for the ``/match/<id>`` rendered DOM.
+
+    Tracks three pieces of state during the walk:
+
+    * The currently-open ``vm-stats-game`` block's ``data-game-id``,
+      maintained as a stack so a nested ``</div>`` from an inner
+      element does not pop the outer block. The same stack-frame-per-
+      open-tag discipline that :class:`_AnchorCollector` uses;
+      diverging here would silently mis-attribute every player row
+      below the first inner ``</div>``.
+    * The current ``<tr>`` row's accumulator: team side (from
+      ``mod-t1`` / ``mod-t2`` classes on the row or the player cell),
+      player anchor (vlr_player_id + display name), agent name (from
+      the first ``<img title="...">`` inside the row), and the list
+      of stat cells in order.
+    * Per-cell text accumulation. Each ``<td>`` contributes one entry
+      to the row's cell list; we strip whitespace at finalize time.
+
+    The parser is forgiving about which ``vm-stats-game`` div the
+    ``data-game-id`` lives on — VLR has historically attached it to
+    either the outer wrapper or an inner card, so we walk every open
+    ``vm-stats-game`` ancestor and use the topmost id we see. Only
+    rows that resolve to *both* a vlr_player_id and a vlr_game_id
+    are emitted; everything else is treated as page chrome and
+    silently dropped (a player anchor in the global header isn't a
+    map row).
+    """
+
+    _VOID_ELEMENTS = frozenset(
+        {
+            "area",
+            "base",
+            "br",
+            "col",
+            "embed",
+            "hr",
+            "img",
+            "input",
+            "link",
+            "meta",
+            "source",
+            "track",
+            "wbr",
+        }
+    )
+
+    def __init__(self) -> None:
+        super().__init__(convert_charrefs=True)
+        # Stack of (tag, game_id_or_none) — one frame per open non-void
+        # element so closing tags pop the correct frame.
+        self._tag_stack: list[tuple[str, str | None]] = []
+        # Current row state — None when we're not inside a player
+        # row's <tr>. We do not greedily start a row on every <tr>
+        # because the page also contains scoreboard/header tables;
+        # rows are committed only if a player anchor is seen inside.
+        self._row: dict[str, Any] | None = None
+        # Per-cell text buffer. Reset on each <td>.
+        self._cell_buffer: list[str] = []
+        self._in_cell = False
+        self._row_team_side: str | None = None
+        self.rows: list[ParsedPlayerStat] = []
+
+    def _current_game_id(self) -> str | None:
+        # Walk the stack from the top, returning the closest non-None
+        # game id. Multiple nested ``vm-stats-game`` blocks would be a
+        # pathological VLR layout, but keeping the lookup explicit
+        # means an inner block does override an outer one.
+        for _tag, game_id in reversed(self._tag_stack):
+            if game_id is not None:
+                return game_id
+        return None
+
+    def handle_starttag(self, tag: str, attrs: list[tuple[str, str | None]]) -> None:
+        attr_map = {k: v for k, v in attrs if v is not None}
+        classes = set((attr_map.get("class") or "").split())
+
+        # Track the game-id when entering a vm-stats-game block. Other
+        # ``data-game-id`` attributes elsewhere on the page are
+        # ignored — only the wrapping block sets the context.
+        game_id_to_push: str | None = None
+        if "vm-stats-game" in classes:
+            game_id_to_push = attr_map.get("data-game-id")
+
+        if tag in self._VOID_ELEMENTS:
+            # Void elements never push frames — they have no closing
+            # tag and would leak onto the stack. Their attribute
+            # handling (e.g. agent <img>) happens here in starttag.
+            if tag == "img" and self._in_cell and self._row is not None:
+                # Agent name comes from the img's title attribute (the
+                # tooltip VLR renders); fall back to alt for older
+                # snapshots that used alt instead.
+                title = attr_map.get("title") or attr_map.get("alt")
+                if title and self._row.get("agent") is None:
+                    self._row["agent"] = title.strip().lower() or None
+            return
+
+        self._tag_stack.append((tag, game_id_to_push))
+
+        if tag == "tr" and self._current_game_id() is not None:
+            # Start a new candidate row. Whether it actually becomes a
+            # player row depends on whether we see a /player/ anchor
+            # before the closing </tr>.
+            self._row = {
+                "game_id": self._current_game_id(),
+                "vlr_player_id": None,
+                "display_name": None,
+                "agent": None,
+                "cells": [],
+            }
+            self._row_team_side = None
+            if "mod-t1" in classes:
+                self._row_team_side = "team1"
+            elif "mod-t2" in classes:
+                self._row_team_side = "team2"
+            return
+
+        if tag == "td" and self._row is not None:
+            self._in_cell = True
+            self._cell_buffer = []
+            # Some VLR layouts put the team side on the player cell
+            # rather than the row. Pick it up either way.
+            if self._row_team_side is None:
+                if "mod-t1" in classes:
+                    self._row_team_side = "team1"
+                elif "mod-t2" in classes:
+                    self._row_team_side = "team2"
+            return
+
+        if tag == "a" and self._in_cell and self._row is not None:
+            href = attr_map.get("href", "")
+            match = _PLAYER_HREF_RE.match(href)
+            if match and self._row["vlr_player_id"] is None:
+                self._row["vlr_player_id"] = match.group(1)
+                # Slug is fallback display_name if the anchor text is
+                # empty — same logic the BUF-10 parser uses.
+                self._row["_player_slug"] = match.group(2)
+            return
+
+    def handle_endtag(self, tag: str) -> None:
+        if tag in self._VOID_ELEMENTS:
+            return
+
+        if tag == "td" and self._in_cell and self._row is not None:
+            text = "".join(self._cell_buffer).strip()
+            self._row["cells"].append(text)
+            self._in_cell = False
+            self._cell_buffer = []
+            # The first cell holds the player name (anchor text). Cache
+            # it once so a later cell with the same text doesn't
+            # overwrite. ``len(cells) == 1`` is the just-finished
+            # player cell.
+            if (
+                len(self._row["cells"]) == 1
+                and self._row.get("display_name") is None
+                and self._row.get("vlr_player_id") is not None
+            ):
+                # The cell text is the anchor's display name; fall
+                # back to the slug if the anchor was empty.
+                slug_fallback = self._row.get("_player_slug") or ""
+                self._row["display_name"] = text or slug_fallback
+
+        if tag == "tr" and self._row is not None:
+            row = self._row
+            self._row = None
+            try:
+                if row.get("vlr_player_id") and row.get("game_id"):
+                    try:
+                        parsed = _row_to_parsed_stat(row, team_side=self._row_team_side)
+                    except SchemaDriftError as exc:
+                        # One malformed row should not abort the whole
+                        # page — losing nine valid players to one drift
+                        # event would defeat the BUF-85 backfill. Log
+                        # and skip; the orchestrator's per-page
+                        # ``schema_drift`` counter increments only when
+                        # the page itself is unparseable.
+                        logger.warning(
+                            "vlr_match.row_drift",
+                            extra={
+                                "vlr_game_id": row.get("game_id"),
+                                "vlr_player_id": row.get("vlr_player_id"),
+                                "detail": str(exc),
+                            },
+                        )
+                    else:
+                        self.rows.append(parsed)
+            finally:
+                self._row_team_side = None
+
+        # Pop the matching frame. Well-formed HTML: top of stack
+        # matches; misnested HTML walks back to the most recent open
+        # tag of the same name and closes everything above it. The
+        # inheritance-stack discipline mirrors :class:`_AnchorCollector`.
+        if self._tag_stack and self._tag_stack[-1][0] == tag:
+            self._tag_stack.pop()
+            return
+        for index in range(len(self._tag_stack) - 1, -1, -1):
+            if self._tag_stack[index][0] == tag:
+                del self._tag_stack[index:]
+                return
+
+    def handle_data(self, data: str) -> None:
+        if self._in_cell:
+            self._cell_buffer.append(data)
+
+
+def _row_to_parsed_stat(row: dict[str, Any], *, team_side: str | None) -> ParsedPlayerStat:
+    """Project an accumulated row dict into a :class:`ParsedPlayerStat`.
+
+    Stat cells beyond the player + agent columns map onto
+    :data:`_STAT_ORDER` by position. A row whose cell count diverges
+    from :data:`_EXPECTED_CELL_COUNT` is treated as schema drift —
+    silently re-mapping by position would attribute, say, ACS into
+    the rating column.
+    """
+    cells: list[str] = row["cells"]
+    if len(cells) != _EXPECTED_CELL_COUNT:
+        raise SchemaDriftError(
+            f"vlr /match row for player {row.get('vlr_player_id')!r} has "
+            f"{len(cells)} cells, expected {_EXPECTED_CELL_COUNT}"
+        )
+    # cells[0] = player (handled), cells[1] = agent (handled via img).
+    stat_cells = cells[2:]
+    stat_map: dict[str, str] = dict(zip(_STAT_ORDER, stat_cells, strict=True))
+    return ParsedPlayerStat(
+        vlr_game_id=row["game_id"],
+        vlr_player_id=row["vlr_player_id"],
+        display_name=row.get("display_name") or row.get("_player_slug") or "",
+        team_side=team_side,
+        agent=row.get("agent"),
+        rating=_parse_float(stat_map["rating"]),
+        acs=_parse_float(stat_map["acs"]),
+        kills=_parse_int(stat_map["kills"]),
+        deaths=_parse_int(stat_map["deaths"]),
+        assists=_parse_int(stat_map["assists"]),
+        kast_pct=_parse_percent(stat_map["kast_pct"]),
+        adr=_parse_float(stat_map["adr"]),
+        hs_pct=_parse_percent(stat_map["hs_pct"]),
+        first_kills=_parse_int(stat_map["first_kills"]),
+        first_deaths=_parse_int(stat_map["first_deaths"]),
+    )
+
+
+def parse_match_page(html: str) -> list[ParsedPlayerStat]:
+    """Public entry point: rendered HTML -> list of player rows.
+
+    Caller is expected to have already obtained the HTML via
+    Playwright (or an injected fake in tests). Returns a flat list
+    across every map on the page; the consumer keys on
+    ``vlr_game_id`` to bucket per-map.
+    """
+    parser = _MatchPageParser()
+    parser.feed(html)
+    parser.close()
+    return list(parser.rows)
+
+
+# --- numeric parsers ------------------------------------------------------
+
+
+def _parse_float(value: str) -> float | None:
+    candidate = (value or "").strip()
+    if not candidate or candidate == "-":
+        return None
+    # Strip a leading + so "+3" parses; bare "-" is the upstream
+    # null sentinel and was handled above.
+    if candidate.startswith("+"):
+        candidate = candidate[1:]
+    try:
+        return float(candidate)
+    except ValueError:
+        return None
+
+
+def _parse_int(value: str) -> int | None:
+    f = _parse_float(value)
+    if f is None:
+        return None
+    if not float(f).is_integer():
+        return None
+    return int(f)
+
+
+def _parse_percent(value: str) -> float | None:
+    """Parse ``"75%"`` into ``75.0``; bare numerics pass through."""
+    candidate = (value or "").strip()
+    if not candidate or candidate == "-":
+        return None
+    if candidate.endswith("%"):
+        candidate = candidate[:-1]
+    return _parse_float(candidate)
+
+
+# --- scraper orchestrator -------------------------------------------------
+
+
+def scrape_vlr_match_players(
+    session: Session,
+    *,
+    vlr_match_ids: Iterable[str],
+    page_fetcher: PageFetcher,
+    rate_limiter: TokenBucket | None = None,
+    robots_cache: _RobotsCache | None = None,
+    base_url: str = VLR_BASE_URL,
+    user_agent: str = USER_AGENT,
+) -> VlrMatchScrapeStats:
+    """Backfill ``player_match_stat`` for every match in ``vlr_match_ids``.
+
+    Reads each ``/match/<id>`` page through ``page_fetcher`` (a
+    Playwright shim in production, an injected fake in tests),
+    parses player rows per map, resolves canonical PLAYER entities
+    via direct create-or-get (bypassing fuzzy — the rationale matches
+    :func:`seed_from_vlr_csv`'s decision tree), and upserts
+    ``player_match_stat`` rows keyed on ``(map_result_id, entity_id)``.
+
+    Idempotency rests on three layers:
+
+    1. The unique constraint ``uq_player_match_stat_map_result_entity``
+       at the schema level; the migration owns the guarantee.
+    2. A per-row in-memory check before the insert to avoid the
+       savepoint round-trip when the row is already known.
+    3. A ``begin_nested`` savepoint around the actual insert so a
+       race with a concurrent scraper resolves to a clean
+       ``IntegrityError`` rather than aborting the outer transaction.
+
+    Caller owns the transaction. The scraper ``flush``es as it goes
+    so existing-row checks within a run see fresh inserts; it does
+    not ``commit``.
+    """
+    rate_limiter = rate_limiter or TokenBucket(
+        capacity=_VLR_TOKEN_CAPACITY,
+        refill_per_second=_VLR_TOKEN_REFILL_PER_SECOND,
+    )
+    robots_cache = robots_cache or _RobotsCache(base_url, user_agent=user_agent)
+    stats = VlrMatchScrapeStats()
+
+    # Pre-load existing PLAYER aliases so the per-row create-or-get is
+    # an O(1) hashmap probe instead of a SELECT per id. Only PLAYER
+    # rows are relevant; the BUF-85 scraper writes nothing else.
+    existing_alias_canonical = _load_existing_player_aliases(session)
+
+    # Pre-load (vlr_game_id -> map_result_id) for every map in the
+    # configured match list. A scrape-time miss means the seed never
+    # ingested that match — we log + skip rather than mint a phantom
+    # map_result row, since the seed is the canonical writer for that
+    # column.
+    map_id_by_game_id = _load_map_results_for_matches(session, vlr_match_ids)
+
+    # Pre-load existing (map_result_id, entity_id) pairs so the
+    # idempotent re-run path doesn't hit the DB at all per row. We
+    # query in one shot rather than per-row.
+    existing_stat_keys = _load_existing_stat_keys(
+        session, list(map_id_by_game_id.values())
+    )
+
+    for vlr_match_id in vlr_match_ids:
+        stats.matches_seen += 1
+        url = _match_page_url(base_url, vlr_match_id)
+        if not robots_cache.allows(url):
+            logger.info("vlr_match.skip_disallowed", extra={"url": url})
+            continue
+
+        rate_limiter.acquire()
+        try:
+            html = page_fetcher(url)
+        except TransientFetchError as exc:
+            logger.warning(
+                "vlr_match.transient_fetch_error",
+                extra={"url": url, "vlr_match_id": vlr_match_id, "detail": str(exc)},
+            )
+            stats.matches_skipped_fetch += 1
+            continue
+        except Exception as exc:
+            # Match-page failures are kept non-fatal so a single
+            # broken page doesn't abort a 1000-match backfill. The
+            # operator triages from the structured warnings + the
+            # final stats counters.
+            logger.warning(
+                "vlr_match.connector_error",
+                extra={
+                    "url": url,
+                    "vlr_match_id": vlr_match_id,
+                    "error_type": type(exc).__name__,
+                    "detail": str(exc),
+                },
+            )
+            stats.matches_skipped_fetch += 1
+            continue
+
+        try:
+            parsed_rows = parse_match_page(html)
+        except SchemaDriftError as exc:
+            logger.warning(
+                "vlr_match.schema_drift",
+                extra={"url": url, "vlr_match_id": vlr_match_id, "detail": str(exc)},
+            )
+            stats.matches_skipped_drift += 1
+            continue
+        stats.matches_fetched += 1
+
+        for parsed in parsed_rows:
+            stats.players_parsed += 1
+            map_result_id = map_id_by_game_id.get(parsed.vlr_game_id)
+            if map_result_id is None:
+                # Seeded matches must own their map_result rows; a
+                # scrape-time miss usually means the seed never ran
+                # for this match. Skip rather than mint a
+                # ``map_result`` row from the scraper — the seed is
+                # the documented owner of that column.
+                stats.players_skipped_no_map += 1
+                logger.warning(
+                    "vlr_match.no_map_result",
+                    extra={
+                        "vlr_match_id": vlr_match_id,
+                        "vlr_game_id": parsed.vlr_game_id,
+                        "vlr_player_id": parsed.vlr_player_id,
+                    },
+                )
+                continue
+
+            entity_id = _resolve_player_canonical(
+                session,
+                vlr_player_id=parsed.vlr_player_id,
+                display_name=parsed.display_name,
+                existing=existing_alias_canonical,
+            )
+
+            if (map_result_id, entity_id) in existing_stat_keys:
+                stats.players_existing += 1
+                continue
+
+            inserted = _insert_player_match_stat(
+                session,
+                parsed=parsed,
+                map_result_id=map_result_id,
+                entity_id=entity_id,
+            )
+            if inserted:
+                existing_stat_keys.add((map_result_id, entity_id))
+                stats.players_inserted += 1
+            else:
+                stats.players_existing += 1
+
+        session.flush()
+
+    logger.info(
+        "vlr_match.done matches_fetched=%d players_inserted=%d players_existing=%d",
+        stats.matches_fetched,
+        stats.players_inserted,
+        stats.players_existing,
+    )
+    return stats
+
+
+# --- internals ------------------------------------------------------------
+
+
+def _match_page_url(base_url: str, vlr_match_id: str) -> str:
+    """Compose the ``/match/<id>`` URL the scraper hits."""
+    return f"{base_url.rstrip('/')}/match/{urllib.parse.quote(vlr_match_id, safe='')}"
+
+
+def _load_existing_player_aliases(session: Session) -> dict[str, uuid.UUID]:
+    """Map every existing ``platform-namespaced player id -> canonical_id``.
+
+    Loaded once before the per-row resolve so the inner loop is a
+    hashmap probe rather than a SELECT per id. Mirrors the seed's
+    pre-load pattern.
+    """
+    rows = session.execute(
+        select(EntityAlias.platform_id, EntityAlias.canonical_id).where(
+            EntityAlias.platform == Platform.VLR,
+            EntityAlias.platform_id.like("player-%"),
+        )
+    ).all()
+    return {platform_id: canonical_id for platform_id, canonical_id in rows}
+
+
+def _load_map_results_for_matches(
+    session: Session, vlr_match_ids: Iterable[str]
+) -> dict[str, uuid.UUID]:
+    """Return a dict of ``vlr_game_id -> map_result_id`` for every map of every input match.
+
+    Materialising the input ids once means we can query in a single
+    round-trip with a JOIN, and a per-map FK lookup during the scrape
+    is a hashmap probe.
+    """
+    ids = list(vlr_match_ids)
+    if not ids:
+        return {}
+    # Lazy import to avoid a top-level circular with Match.
+    from esports_sim.db.models import Match
+
+    rows = session.execute(
+        select(MapResult.vlr_game_id, MapResult.map_result_id)
+        .join(Match, Match.match_id == MapResult.match_id)
+        .where(Match.vlr_match_id.in_(ids))
+    ).all()
+    return {vlr_game_id: map_result_id for vlr_game_id, map_result_id in rows}
+
+
+def _load_existing_stat_keys(
+    session: Session, map_result_ids: list[uuid.UUID]
+) -> set[tuple[uuid.UUID, uuid.UUID]]:
+    """Pre-load ``{(map_result_id, entity_id), ...}`` for every map in scope.
+
+    Lets the per-player insert path skip the savepoint round-trip on
+    re-runs, which is what makes a 1000-match idempotent re-scrape
+    cheap. Out-of-scope map ids would just bloat the set without
+    helping, so we restrict to the maps the current call touches.
+    """
+    if not map_result_ids:
+        return set()
+    rows = session.execute(
+        select(PlayerMatchStat.map_result_id, PlayerMatchStat.entity_id).where(
+            PlayerMatchStat.map_result_id.in_(map_result_ids)
+        )
+    ).all()
+    return {(map_result_id, entity_id) for map_result_id, entity_id in rows}
+
+
+def _resolve_player_canonical(
+    session: Session,
+    *,
+    vlr_player_id: str,
+    display_name: str,
+    existing: dict[str, uuid.UUID],
+) -> uuid.UUID:
+    """Create-or-get the canonical PLAYER entity for one VLR player id.
+
+    Bypasses the fuzzy resolver intentionally — VLR's numeric ids are
+    immutable and unique per player; running fuzzy on display names
+    would risk auto-merging two distinct players who share a handle
+    (a documented historic problem with names like "Dgzin"). The
+    direct (Platform.VLR, ``vlr_alias_platform_id`` namespaced) path
+    is what the resolver's exact-alias lookup would do anyway in the
+    no-fuzzy path.
+
+    Race-safety: a savepoint scopes the insert; a concurrent
+    inserter that beat us to the alias row produces an
+    ``IntegrityError`` on the unique ``(platform, platform_id)``
+    constraint, which we catch and degrade to "existing".
+    """
+    namespaced_id = vlr_alias_platform_id(EntityType.PLAYER, vlr_player_id)
+    cached = existing.get(namespaced_id)
+    if cached is not None:
+        return cached
+
+    try:
+        with session.begin_nested():
+            entity = Entity(entity_type=EntityType.PLAYER)
+            session.add(entity)
+            session.flush()  # populate canonical_id
+            session.add(
+                EntityAlias(
+                    canonical_id=entity.canonical_id,
+                    platform=Platform.VLR,
+                    platform_id=namespaced_id,
+                    platform_name=display_name or namespaced_id,
+                    confidence=1.0,
+                )
+            )
+            session.flush()
+    except IntegrityError as exc:
+        if "uq_entity_alias_platform_platform_id" not in str(exc):
+            raise
+        existing_canonical = session.execute(
+            select(EntityAlias.canonical_id).where(
+                EntityAlias.platform == Platform.VLR,
+                EntityAlias.platform_id == namespaced_id,
+            )
+        ).scalar_one()
+        existing[namespaced_id] = existing_canonical
+        return existing_canonical
+
+    existing[namespaced_id] = entity.canonical_id
+    return entity.canonical_id
+
+
+def _insert_player_match_stat(
+    session: Session,
+    *,
+    parsed: ParsedPlayerStat,
+    map_result_id: uuid.UUID,
+    entity_id: uuid.UUID,
+) -> bool:
+    """Insert one row; return True on success, False on idempotent conflict.
+
+    Wrapping the add+flush in a ``begin_nested`` savepoint means a
+    concurrent scraper that already inserted the same key triggers
+    an ``IntegrityError`` on flush, which we catch and translate
+    into the documented "already-exists" outcome — same pattern the
+    seed module uses for its alias create-or-get.
+    """
+    try:
+        with session.begin_nested():
+            row = PlayerMatchStat(
+                map_result_id=map_result_id,
+                entity_id=entity_id,
+                source="vlr",
+                source_player_id=parsed.vlr_player_id,
+                team_side=parsed.team_side,
+                agent=parsed.agent,
+                rating=parsed.rating,
+                acs=parsed.acs,
+                kills=parsed.kills,
+                deaths=parsed.deaths,
+                assists=parsed.assists,
+                kast_pct=parsed.kast_pct,
+                adr=parsed.adr,
+                hs_pct=parsed.hs_pct,
+                first_kills=parsed.first_kills,
+                first_deaths=parsed.first_deaths,
+                extra=dict(parsed.extra),
+            )
+            session.add(row)
+            session.flush()
+    except IntegrityError as exc:
+        if "uq_player_match_stat_map_result_entity" not in str(exc):
+            raise
+        return False
+    return True
+
+
+def iter_match_ids_from_db(session: Session) -> Iterator[str]:
+    """Convenience producer: every ``vlr_match_id`` in the ``match`` table.
+
+    The CLI/operator script default. Wrap in a date filter for a
+    backfill range. Kept here (rather than at the call site) so the
+    scraper module is self-contained for tests that want to drive
+    the full backfill loop with a real DB.
+    """
+    from esports_sim.db.models import Match
+
+    rows = session.execute(select(Match.vlr_match_id).order_by(Match.match_date.desc())).scalars()
+    yield from rows
+
+
+__all__ = [
+    "ParsedPlayerStat",
+    "VlrMatchScrapeStats",
+    "iter_match_ids_from_db",
+    "parse_match_page",
+    "scrape_vlr_match_players",
+]

--- a/services/data_pipeline/src/data_pipeline/seeds/vlr.py
+++ b/services/data_pipeline/src/data_pipeline/seeds/vlr.py
@@ -260,8 +260,13 @@ def seed_from_vlr_csv(
     # so a re-run that lands a new map under an already-seeded match
     # has its parent UUID in hand without an extra SELECT. Same for
     # the existing-game-id set, which only needs membership checks.
+    # ``.tuples()`` projects the SELECT result as ``Sequence[tuple[str, UUID]]``
+    # rather than the default ``Sequence[Row[...]]``, which the ``dict()``
+    # constructor's signature expects. Without it mypy flags the conversion
+    # — Row is iterable at runtime but not declared as the ``tuple`` shape
+    # ``dict.__init__`` types its iterable argument as.
     match_canonical_by_vlr_id: dict[str, uuid.UUID] = dict(
-        session.execute(select(Match.vlr_match_id, Match.match_id)).all()
+        session.execute(select(Match.vlr_match_id, Match.match_id)).tuples().all()
     )
     pre_existing_match_ids: frozenset[str] = frozenset(match_canonical_by_vlr_id)
     existing_game_ids: set[str] = set(

--- a/services/data_pipeline/tests/fixtures/vlr/match_300001.html
+++ b/services/data_pipeline/tests/fixtures/vlr/match_300001.html
@@ -1,0 +1,104 @@
+<!doctype html>
+<html lang="en">
+<head><meta charset="utf-8"><title>VLR fixture: /match/300001</title></head>
+<body>
+  <div class="match-header">
+    <a href="/team/2/sentinels">Sentinels</a>
+    <a href="/team/120/100-thieves">100 Thieves</a>
+  </div>
+
+  <div class="vm-stats-game" data-game-id="g-100001">
+    <table class="wf-table-inset mod-overview">
+      <tbody>
+        <tr class="mod-t1">
+          <td class="mod-player"><a href="/player/9/tenz"><div class="text-of">TenZ</div></a></td>
+          <td class="mod-agents"><span class="mod-agent"><img title="Jett" alt="jett"/></span></td>
+          <td class="mod-stat mod-vlr-rating"><span class="side mod-both">1.32</span></td>
+          <td class="mod-stat"><span class="side mod-both">285</span></td>
+          <td class="mod-stat"><span class="side mod-both">22</span></td>
+          <td class="mod-stat"><span class="side mod-both">11</span></td>
+          <td class="mod-stat"><span class="side mod-both">5</span></td>
+          <td class="mod-stat"><span class="side mod-both">+11</span></td>
+          <td class="mod-stat"><span class="side mod-both">75%</span></td>
+          <td class="mod-stat"><span class="side mod-both">155.4</span></td>
+          <td class="mod-stat"><span class="side mod-both">35%</span></td>
+          <td class="mod-stat"><span class="side mod-both">5</span></td>
+          <td class="mod-stat"><span class="side mod-both">2</span></td>
+          <td class="mod-stat"><span class="side mod-both">+3</span></td>
+        </tr>
+        <tr class="mod-t1">
+          <td class="mod-player"><a href="/player/729/zekken"><div class="text-of">Zekken</div></a></td>
+          <td class="mod-agents"><span class="mod-agent"><img title="Sova" alt="sova"/></span></td>
+          <td class="mod-stat mod-vlr-rating"><span class="side mod-both">1.05</span></td>
+          <td class="mod-stat"><span class="side mod-both">220</span></td>
+          <td class="mod-stat"><span class="side mod-both">17</span></td>
+          <td class="mod-stat"><span class="side mod-both">14</span></td>
+          <td class="mod-stat"><span class="side mod-both">7</span></td>
+          <td class="mod-stat"><span class="side mod-both">+3</span></td>
+          <td class="mod-stat"><span class="side mod-both">70%</span></td>
+          <td class="mod-stat"><span class="side mod-both">141.0</span></td>
+          <td class="mod-stat"><span class="side mod-both">22%</span></td>
+          <td class="mod-stat"><span class="side mod-both">3</span></td>
+          <td class="mod-stat"><span class="side mod-both">3</span></td>
+          <td class="mod-stat"><span class="side mod-both">0</span></td>
+        </tr>
+        <tr class="mod-t2">
+          <td class="mod-player"><a href="/player/2329/asuna"><div class="text-of">Asuna</div></a></td>
+          <td class="mod-agents"><span class="mod-agent"><img title="Raze" alt="raze"/></span></td>
+          <td class="mod-stat mod-vlr-rating"><span class="side mod-both">0.98</span></td>
+          <td class="mod-stat"><span class="side mod-both">198</span></td>
+          <td class="mod-stat"><span class="side mod-both">15</span></td>
+          <td class="mod-stat"><span class="side mod-both">16</span></td>
+          <td class="mod-stat"><span class="side mod-both">4</span></td>
+          <td class="mod-stat"><span class="side mod-both">-1</span></td>
+          <td class="mod-stat"><span class="side mod-both">68%</span></td>
+          <td class="mod-stat"><span class="side mod-both">130.5</span></td>
+          <td class="mod-stat"><span class="side mod-both">28%</span></td>
+          <td class="mod-stat"><span class="side mod-both">2</span></td>
+          <td class="mod-stat"><span class="side mod-both">4</span></td>
+          <td class="mod-stat"><span class="side mod-both">-2</span></td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+
+  <div class="vm-stats-game" data-game-id="g-100002">
+    <table class="wf-table-inset mod-overview">
+      <tbody>
+        <tr class="mod-t1">
+          <td class="mod-player"><a href="/player/9/tenz"><div class="text-of">TenZ</div></a></td>
+          <td class="mod-agents"><span class="mod-agent"><img title="Chamber" alt="chamber"/></span></td>
+          <td class="mod-stat mod-vlr-rating"><span class="side mod-both">1.18</span></td>
+          <td class="mod-stat"><span class="side mod-both">240</span></td>
+          <td class="mod-stat"><span class="side mod-both">19</span></td>
+          <td class="mod-stat"><span class="side mod-both">13</span></td>
+          <td class="mod-stat"><span class="side mod-both">3</span></td>
+          <td class="mod-stat"><span class="side mod-both">+6</span></td>
+          <td class="mod-stat"><span class="side mod-both">72%</span></td>
+          <td class="mod-stat"><span class="side mod-both">148.0</span></td>
+          <td class="mod-stat"><span class="side mod-both">31%</span></td>
+          <td class="mod-stat"><span class="side mod-both">4</span></td>
+          <td class="mod-stat"><span class="side mod-both">2</span></td>
+          <td class="mod-stat"><span class="side mod-both">+2</span></td>
+        </tr>
+        <tr class="mod-t2">
+          <td class="mod-player"><a href="/player/2329/asuna"><div class="text-of">Asuna</div></a></td>
+          <td class="mod-agents"><span class="mod-agent"><img title="Jett" alt="jett"/></span></td>
+          <td class="mod-stat mod-vlr-rating"><span class="side mod-both">1.10</span></td>
+          <td class="mod-stat"><span class="side mod-both">232</span></td>
+          <td class="mod-stat"><span class="side mod-both">18</span></td>
+          <td class="mod-stat"><span class="side mod-both">15</span></td>
+          <td class="mod-stat"><span class="side mod-both">2</span></td>
+          <td class="mod-stat"><span class="side mod-both">+3</span></td>
+          <td class="mod-stat"><span class="side mod-both">70%</span></td>
+          <td class="mod-stat"><span class="side mod-both">142.5</span></td>
+          <td class="mod-stat"><span class="side mod-both">27%</span></td>
+          <td class="mod-stat"><span class="side mod-both">3</span></td>
+          <td class="mod-stat"><span class="side mod-both">3</span></td>
+          <td class="mod-stat"><span class="side mod-both">0</span></td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</body>
+</html>

--- a/services/data_pipeline/tests/test_vlr_match_scraper.py
+++ b/services/data_pipeline/tests/test_vlr_match_scraper.py
@@ -102,9 +102,7 @@ def test_parser_extracts_agent_from_image_title() -> None:
 def test_parser_extracts_headline_stats_in_correct_columns() -> None:
     """The position-based mapping must put ACS in ACS, K in K, etc."""
     rows = parse_match_page(_read_fixture("match_300001.html"))
-    tenz_map1 = next(
-        r for r in rows if r.vlr_game_id == "g-100001" and r.vlr_player_id == "9"
-    )
+    tenz_map1 = next(r for r in rows if r.vlr_game_id == "g-100001" and r.vlr_player_id == "9")
     assert tenz_map1.rating == pytest.approx(1.32)
     assert tenz_map1.acs == pytest.approx(285.0)
     assert tenz_map1.kills == 22
@@ -120,9 +118,7 @@ def test_parser_extracts_headline_stats_in_correct_columns() -> None:
 def test_parser_handles_negative_diff_and_percent_signs() -> None:
     """Stats like KD diff ship as ``+11`` / ``-1`` and KAST as ``75%``."""
     rows = parse_match_page(_read_fixture("match_300001.html"))
-    asuna_map1 = next(
-        r for r in rows if r.vlr_game_id == "g-100001" and r.vlr_player_id == "2329"
-    )
+    asuna_map1 = next(r for r in rows if r.vlr_game_id == "g-100001" and r.vlr_player_id == "2329")
     # Negative diff kept on the unmapped column wouldn't surface here,
     # but kast/hs need the % stripping path.
     assert asuna_map1.kast_pct == pytest.approx(68.0)
@@ -359,9 +355,7 @@ def test_player_aliases_reused_across_maps_and_matches(db_session) -> None:
     # TenZ (vlr id 9) appears on both maps. The two stat rows must
     # share one entity_id.
     rows = (
-        db_session.execute(
-            select(PlayerMatchStat).where(PlayerMatchStat.source_player_id == "9")
-        )
+        db_session.execute(select(PlayerMatchStat).where(PlayerMatchStat.source_player_id == "9"))
         .scalars()
         .all()
     )

--- a/services/data_pipeline/tests/test_vlr_match_scraper.py
+++ b/services/data_pipeline/tests/test_vlr_match_scraper.py
@@ -501,6 +501,46 @@ def test_rate_limiter_paces_fetch(db_session) -> None:
     assert clock.now >= 2 * 3.0 - 1e-9
 
 
+@pytestmark_integration
+def test_scrape_accepts_one_shot_generator(db_session) -> None:
+    """The signature accepts ``Iterable[str]`` — a one-shot generator must work.
+
+    The scraper consumes ``vlr_match_ids`` twice — once for the
+    ``map_result`` pre-load query and once in the main fetch loop.
+    Without an early ``list()`` materialisation the generator drains
+    on the first pass and the loop sees zero matches, silently writing
+    no stats. Pin the contract here so a future refactor that removes
+    the materialisation re-introduces the regression visibly.
+    """
+    from esports_sim.db.models import PlayerMatchStat
+
+    _seed_match(
+        db_session,
+        vlr_match_id="m-300001",
+        map_payloads=[{"vlr_game_id": "g-100001"}, {"vlr_game_id": "g-100002"}],
+    )
+    url = f"{VLR_BASE_URL}/match/m-300001"
+    fetcher = _make_fetcher({url: _read_fixture("match_300001.html")})
+
+    # A one-shot generator: re-iterating it after exhaustion yields
+    # nothing. If the scraper ever consumes it twice, the second pass
+    # is empty.
+    def one_shot() -> Any:
+        yield "m-300001"
+
+    stats = scrape_vlr_match_players(
+        db_session,
+        vlr_match_ids=one_shot(),
+        page_fetcher=fetcher,
+        rate_limiter=_free_bucket(),
+        robots_cache=_stub_robots(),
+    )
+    assert stats.matches_fetched == 1
+    assert stats.players_inserted == 5
+    rows = db_session.execute(select(PlayerMatchStat)).scalars().all()
+    assert len(rows) == 5
+
+
 # --- ParsedPlayerStat dataclass --------------------------------------------
 
 

--- a/services/data_pipeline/tests/test_vlr_match_scraper.py
+++ b/services/data_pipeline/tests/test_vlr_match_scraper.py
@@ -1,0 +1,535 @@
+"""Tests for the BUF-85 VLR per-match player participation scraper.
+
+The parser unit tests run without a database — they exercise the
+HTML-state machine against canned ``/match/<id>`` fixtures. The
+end-to-end ``scrape_vlr_match_players`` test is gated on
+``TEST_DATABASE_URL`` (it consumes the ``db_session`` fixture in
+``conftest.py``), so a fresh clone with no Postgres still has a
+green ``uv run pytest``.
+"""
+
+from __future__ import annotations
+
+import uuid
+from collections.abc import Callable
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+import pytest
+from data_pipeline.connectors.vlr import (
+    USER_AGENT,
+    VLR_BASE_URL,
+    _RobotsCache,
+)
+from data_pipeline.connectors.vlr_match import (
+    ParsedPlayerStat,
+    parse_match_page,
+    scrape_vlr_match_players,
+)
+from data_pipeline.errors import TransientFetchError
+from data_pipeline.rate_limiter import TokenBucket
+from esports_sim.db.enums import EntityType, Platform
+from sqlalchemy import select
+
+_FIXTURE_DIR = Path(__file__).resolve().parent / "fixtures" / "vlr"
+
+
+def _read_fixture(name: str) -> str:
+    return (_FIXTURE_DIR / name).read_text(encoding="utf-8")
+
+
+def _stub_robots(allow_all: bool = True) -> _RobotsCache:
+    cache = _RobotsCache(VLR_BASE_URL, user_agent=USER_AGENT, fetcher=lambda _url: "")
+    cache._loaded = True
+    cache._disallows = [] if allow_all else ["/"]
+    return cache
+
+
+def _make_fetcher(mapping: dict[str, str]) -> Callable[[str], str]:
+    return lambda url: mapping[url]
+
+
+def _free_bucket() -> TokenBucket:
+    """Effectively unlimited bucket for tests — pace is checked in BUF-10's tests."""
+    return TokenBucket(capacity=100, refill_per_second=100.0)
+
+
+# --- parser ----------------------------------------------------------------
+
+
+def test_parser_extracts_one_row_per_player_per_map() -> None:
+    rows = parse_match_page(_read_fixture("match_300001.html"))
+    # 3 players on map 1 + 2 players on map 2 = 5 total rows.
+    assert len(rows) == 5
+    # Each row carries a vlr_player_id, vlr_game_id, and display_name.
+    for row in rows:
+        assert row.vlr_player_id, "vlr_player_id must be present"
+        assert row.vlr_game_id, "vlr_game_id must be present"
+        assert row.display_name
+
+
+def test_parser_links_player_to_correct_map() -> None:
+    rows = parse_match_page(_read_fixture("match_300001.html"))
+    by_map: dict[str, set[str]] = {}
+    for row in rows:
+        by_map.setdefault(row.vlr_game_id, set()).add(row.vlr_player_id)
+    assert by_map == {
+        "g-100001": {"9", "729", "2329"},
+        "g-100002": {"9", "2329"},
+    }
+
+
+def test_parser_extracts_team_side_from_row_class() -> None:
+    rows = parse_match_page(_read_fixture("match_300001.html"))
+    # TenZ + Zekken on team1 of g-100001; Asuna on team2 of g-100001.
+    by_player_map = {(r.vlr_game_id, r.vlr_player_id): r.team_side for r in rows}
+    assert by_player_map[("g-100001", "9")] == "team1"
+    assert by_player_map[("g-100001", "729")] == "team1"
+    assert by_player_map[("g-100001", "2329")] == "team2"
+
+
+def test_parser_extracts_agent_from_image_title() -> None:
+    rows = parse_match_page(_read_fixture("match_300001.html"))
+    by_player_map = {(r.vlr_game_id, r.vlr_player_id): r.agent for r in rows}
+    # Different agents per map should round-trip through the parser.
+    assert by_player_map[("g-100001", "9")] == "jett"
+    assert by_player_map[("g-100002", "9")] == "chamber"
+    assert by_player_map[("g-100001", "2329")] == "raze"
+    assert by_player_map[("g-100002", "2329")] == "jett"
+
+
+def test_parser_extracts_headline_stats_in_correct_columns() -> None:
+    """The position-based mapping must put ACS in ACS, K in K, etc."""
+    rows = parse_match_page(_read_fixture("match_300001.html"))
+    tenz_map1 = next(
+        r for r in rows if r.vlr_game_id == "g-100001" and r.vlr_player_id == "9"
+    )
+    assert tenz_map1.rating == pytest.approx(1.32)
+    assert tenz_map1.acs == pytest.approx(285.0)
+    assert tenz_map1.kills == 22
+    assert tenz_map1.deaths == 11
+    assert tenz_map1.assists == 5
+    assert tenz_map1.kast_pct == pytest.approx(75.0)
+    assert tenz_map1.adr == pytest.approx(155.4)
+    assert tenz_map1.hs_pct == pytest.approx(35.0)
+    assert tenz_map1.first_kills == 5
+    assert tenz_map1.first_deaths == 2
+
+
+def test_parser_handles_negative_diff_and_percent_signs() -> None:
+    """Stats like KD diff ship as ``+11`` / ``-1`` and KAST as ``75%``."""
+    rows = parse_match_page(_read_fixture("match_300001.html"))
+    asuna_map1 = next(
+        r for r in rows if r.vlr_game_id == "g-100001" and r.vlr_player_id == "2329"
+    )
+    # Negative diff kept on the unmapped column wouldn't surface here,
+    # but kast/hs need the % stripping path.
+    assert asuna_map1.kast_pct == pytest.approx(68.0)
+    assert asuna_map1.hs_pct == pytest.approx(28.0)
+
+
+def test_parser_skips_player_anchors_outside_stats_block() -> None:
+    """Header anchors are not player rows.
+
+    ``match_300001.html`` puts Sentinels/100 Thieves header anchors
+    above the ``vm-stats-game`` blocks. They must not land in the
+    parsed player list.
+    """
+    rows = parse_match_page(_read_fixture("match_300001.html"))
+    # Only player ids from the fixture's stat tables.
+    parsed_ids = {row.vlr_player_id for row in rows}
+    assert parsed_ids == {"9", "729", "2329"}
+
+
+def test_parser_drops_rows_with_unexpected_cell_count() -> None:
+    """A row with a wrong column count should not silently mis-attribute stats.
+
+    The parser logs the drift event per row and continues — so the
+    surrounding well-formed rows remain in the output.
+    """
+    drifted = """
+    <html><body>
+      <div class="vm-stats-game" data-game-id="g-broken">
+        <table class="wf-table-inset mod-overview">
+          <tbody>
+            <tr class="mod-t1">
+              <td class="mod-player"><a href="/player/9/tenz">TenZ</a></td>
+              <td class="mod-agents"><img title="Jett"/></td>
+              <td class="mod-stat">1.32</td>
+              <td class="mod-stat">285</td>
+            </tr>
+            <tr class="mod-t1">
+              <td class="mod-player"><a href="/player/729/zekken">Zekken</a></td>
+              <td class="mod-agents"><img title="Sova"/></td>
+              <td class="mod-stat">1.05</td>
+              <td class="mod-stat">220</td>
+              <td class="mod-stat">17</td>
+              <td class="mod-stat">14</td>
+              <td class="mod-stat">7</td>
+              <td class="mod-stat">+3</td>
+              <td class="mod-stat">70%</td>
+              <td class="mod-stat">141.0</td>
+              <td class="mod-stat">22%</td>
+              <td class="mod-stat">3</td>
+              <td class="mod-stat">3</td>
+              <td class="mod-stat">0</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </body></html>
+    """
+    rows = parse_match_page(drifted)
+    # First row drops on cell-count mismatch; the second row (full
+    # 14-column shape) survives.
+    assert [r.vlr_player_id for r in rows] == ["729"]
+
+
+# --- scraper (integration) -------------------------------------------------
+
+
+pytestmark_integration = pytest.mark.integration
+
+
+def _seed_match(
+    db_session: Any,
+    *,
+    vlr_match_id: str,
+    map_payloads: list[dict[str, Any]],
+) -> dict[str, uuid.UUID]:
+    """Seed one match + N map_results so the scraper has FK targets.
+
+    Returns a mapping ``vlr_game_id -> map_result_id`` so tests can
+    join back to the canonical UUIDs the scraper writes against.
+    """
+    from esports_sim.db.models import MapResult, Match
+
+    match = Match(
+        match_id=uuid.uuid4(),
+        vlr_match_id=vlr_match_id,
+        match_date=datetime(2026, 4, 26, 18, tzinfo=UTC),
+    )
+    db_session.add(match)
+    db_session.flush()
+
+    map_ids: dict[str, uuid.UUID] = {}
+    for payload in map_payloads:
+        mr = MapResult(
+            map_result_id=uuid.uuid4(),
+            match_id=match.match_id,
+            vlr_game_id=payload["vlr_game_id"],
+            vlr_map_id=payload.get("vlr_map_id", 1),
+            team1_rounds=13,
+            team2_rounds=10,
+            team1_atk_rounds=7,
+            team1_def_rounds=6,
+            team2_atk_rounds=4,
+            team2_def_rounds=6,
+            team1_rating=1.10,
+            team2_rating=0.95,
+            team1_stats={},
+            team2_stats={},
+        )
+        db_session.add(mr)
+        map_ids[payload["vlr_game_id"]] = mr.map_result_id
+    db_session.flush()
+    return map_ids
+
+
+@pytestmark_integration
+def test_scrape_writes_player_match_stat_rows(db_session) -> None:
+    """End-to-end happy path: every parsed player lands one stat row."""
+    from esports_sim.db.models import EntityAlias, PlayerMatchStat
+
+    map_ids = _seed_match(
+        db_session,
+        vlr_match_id="m-300001",
+        map_payloads=[
+            {"vlr_game_id": "g-100001", "vlr_map_id": 1},
+            {"vlr_game_id": "g-100002", "vlr_map_id": 2},
+        ],
+    )
+
+    url = f"{VLR_BASE_URL}/match/m-300001"
+    fetcher = _make_fetcher({url: _read_fixture("match_300001.html")})
+
+    stats = scrape_vlr_match_players(
+        db_session,
+        vlr_match_ids=["m-300001"],
+        page_fetcher=fetcher,
+        rate_limiter=_free_bucket(),
+        robots_cache=_stub_robots(),
+    )
+
+    assert stats.matches_fetched == 1
+    assert stats.players_parsed == 5
+    assert stats.players_inserted == 5
+    assert stats.players_existing == 0
+
+    rows = db_session.execute(select(PlayerMatchStat)).scalars().all()
+    assert len(rows) == 5
+
+    # Every alias was minted under the namespaced platform_id.
+    aliases = (
+        db_session.execute(
+            select(EntityAlias.platform_id).where(EntityAlias.platform == Platform.VLR)
+        )
+        .scalars()
+        .all()
+    )
+    expected_ids = {"player-9", "player-729", "player-2329"}
+    assert expected_ids.issubset(set(aliases))
+
+    # Each stat row resolves to the right map_result via vlr_game_id.
+    by_pair = {(row.map_result_id, row.source_player_id) for row in rows}
+    assert (map_ids["g-100001"], "9") in by_pair
+    assert (map_ids["g-100002"], "9") in by_pair
+    assert (map_ids["g-100002"], "2329") in by_pair
+
+
+@pytestmark_integration
+def test_rerun_is_idempotent(db_session) -> None:
+    """Re-running the scraper for the same match must add zero rows."""
+    from esports_sim.db.models import PlayerMatchStat
+
+    _seed_match(
+        db_session,
+        vlr_match_id="m-300001",
+        map_payloads=[
+            {"vlr_game_id": "g-100001"},
+            {"vlr_game_id": "g-100002"},
+        ],
+    )
+    url = f"{VLR_BASE_URL}/match/m-300001"
+    fetcher = _make_fetcher({url: _read_fixture("match_300001.html")})
+
+    first = scrape_vlr_match_players(
+        db_session,
+        vlr_match_ids=["m-300001"],
+        page_fetcher=fetcher,
+        rate_limiter=_free_bucket(),
+        robots_cache=_stub_robots(),
+    )
+    assert first.players_inserted == 5
+
+    # Second pass: the in-memory ``existing_stat_keys`` pre-load picks
+    # up every (map_result_id, entity_id) row from the first pass and
+    # skips before the savepoint round-trip.
+    second = scrape_vlr_match_players(
+        db_session,
+        vlr_match_ids=["m-300001"],
+        page_fetcher=fetcher,
+        rate_limiter=_free_bucket(),
+        robots_cache=_stub_robots(),
+    )
+    assert second.players_inserted == 0
+    assert second.players_existing == 5
+
+    rows = db_session.execute(select(PlayerMatchStat)).scalars().all()
+    # Schema-level dedup also confirmed: only 5 rows total even though
+    # the scraper ran twice.
+    assert len(rows) == 5
+
+
+@pytestmark_integration
+def test_player_aliases_reused_across_maps_and_matches(db_session) -> None:
+    """Same vlr_player_id across maps must resolve to one canonical_id."""
+    from esports_sim.db.models import Entity, PlayerMatchStat
+
+    _seed_match(
+        db_session,
+        vlr_match_id="m-300001",
+        map_payloads=[
+            {"vlr_game_id": "g-100001"},
+            {"vlr_game_id": "g-100002"},
+        ],
+    )
+    url = f"{VLR_BASE_URL}/match/m-300001"
+    fetcher = _make_fetcher({url: _read_fixture("match_300001.html")})
+
+    scrape_vlr_match_players(
+        db_session,
+        vlr_match_ids=["m-300001"],
+        page_fetcher=fetcher,
+        rate_limiter=_free_bucket(),
+        robots_cache=_stub_robots(),
+    )
+
+    # TenZ (vlr id 9) appears on both maps. The two stat rows must
+    # share one entity_id.
+    rows = (
+        db_session.execute(
+            select(PlayerMatchStat).where(PlayerMatchStat.source_player_id == "9")
+        )
+        .scalars()
+        .all()
+    )
+    assert len(rows) == 2
+    assert rows[0].entity_id == rows[1].entity_id
+
+    # And the canonical entity is a PLAYER.
+    entity = db_session.execute(
+        select(Entity).where(Entity.canonical_id == rows[0].entity_id)
+    ).scalar_one()
+    assert entity.entity_type is EntityType.PLAYER
+
+
+@pytestmark_integration
+def test_skip_when_map_result_missing(db_session) -> None:
+    """A scraped game id with no matching map_result skips with a warning."""
+    from esports_sim.db.models import PlayerMatchStat
+
+    # Seed only one of the two maps from the fixture.
+    _seed_match(
+        db_session,
+        vlr_match_id="m-300001",
+        map_payloads=[{"vlr_game_id": "g-100001"}],
+    )
+    url = f"{VLR_BASE_URL}/match/m-300001"
+    fetcher = _make_fetcher({url: _read_fixture("match_300001.html")})
+
+    stats = scrape_vlr_match_players(
+        db_session,
+        vlr_match_ids=["m-300001"],
+        page_fetcher=fetcher,
+        rate_limiter=_free_bucket(),
+        robots_cache=_stub_robots(),
+    )
+    # 5 players parsed total (3 on g-100001, 2 on g-100002).
+    # The 2 on the un-seeded g-100002 are skipped.
+    assert stats.players_parsed == 5
+    assert stats.players_skipped_no_map == 2
+    assert stats.players_inserted == 3
+
+    rows = db_session.execute(select(PlayerMatchStat)).scalars().all()
+    # Only the 3 players from the seeded map landed.
+    assert len(rows) == 3
+
+
+@pytestmark_integration
+def test_fetcher_failure_skips_match_and_continues(db_session) -> None:
+    """A transient fetch error on one match must not abort the run."""
+    from esports_sim.db.models import PlayerMatchStat
+
+    _seed_match(
+        db_session,
+        vlr_match_id="m-300001",
+        map_payloads=[{"vlr_game_id": "g-100001"}, {"vlr_game_id": "g-100002"}],
+    )
+    _seed_match(
+        db_session,
+        vlr_match_id="m-300002",
+        map_payloads=[{"vlr_game_id": "g-100099"}],
+    )
+
+    bad_url = f"{VLR_BASE_URL}/match/m-300002"
+
+    def selective_fetcher(url: str) -> str:
+        if url == bad_url:
+            raise TransientFetchError("503 simulated")
+        return _read_fixture("match_300001.html")
+
+    stats = scrape_vlr_match_players(
+        db_session,
+        vlr_match_ids=["m-300002", "m-300001"],
+        page_fetcher=selective_fetcher,
+        rate_limiter=_free_bucket(),
+        robots_cache=_stub_robots(),
+    )
+    assert stats.matches_fetched == 1
+    assert stats.matches_skipped_fetch == 1
+    # The good match's 5 players still landed.
+    rows = db_session.execute(select(PlayerMatchStat)).scalars().all()
+    assert len(rows) == 5
+
+
+@pytestmark_integration
+def test_rate_limiter_paces_fetch(db_session) -> None:
+    """A capacity=1 / refill=20rpm bucket must throttle each fetch.
+
+    With three matches and the BUF-85 ``20 req/min`` limit, two of
+    the three calls each pay one 3-second wait. The first call is
+    free (full bucket), so the fake clock should advance by at least
+    ``2 * 3.0`` seconds across the run.
+    """
+
+    class _FakeClock:
+        def __init__(self) -> None:
+            self.now = 0.0
+
+        def time(self) -> float:
+            return self.now
+
+        def sleep(self, seconds: float) -> None:
+            if seconds > 0:
+                self.now += seconds
+
+    _seed_match(
+        db_session,
+        vlr_match_id="m-pace-1",
+        map_payloads=[{"vlr_game_id": "g-100001"}, {"vlr_game_id": "g-100002"}],
+    )
+    _seed_match(
+        db_session,
+        vlr_match_id="m-pace-2",
+        map_payloads=[{"vlr_game_id": "g-200001"}],
+    )
+    _seed_match(
+        db_session,
+        vlr_match_id="m-pace-3",
+        map_payloads=[{"vlr_game_id": "g-300001"}],
+    )
+
+    clock = _FakeClock()
+    bucket = TokenBucket(
+        capacity=1,
+        refill_per_second=20.0 / 60.0,
+        clock=clock.time,
+        sleeper=clock.sleep,
+    )
+
+    def fetcher(_url: str) -> str:
+        # Same fixture for every match; only the first one has the
+        # matching vlr_game_ids, the others get "no map result"
+        # skips. We're measuring rate-limit pacing, not insertion.
+        return _read_fixture("match_300001.html")
+
+    scrape_vlr_match_players(
+        db_session,
+        vlr_match_ids=["m-pace-1", "m-pace-2", "m-pace-3"],
+        page_fetcher=fetcher,
+        rate_limiter=bucket,
+        robots_cache=_stub_robots(),
+    )
+
+    # Two waits at 3 seconds each — first call was free.
+    assert clock.now >= 2 * 3.0 - 1e-9
+
+
+# --- ParsedPlayerStat dataclass --------------------------------------------
+
+
+def test_parsed_player_stat_is_frozen_with_default_extra() -> None:
+    """The dataclass is value-typed (hashable, frozen) with an empty default extra."""
+    row = ParsedPlayerStat(
+        vlr_game_id="g-1",
+        vlr_player_id="9",
+        display_name="TenZ",
+        team_side="team1",
+        agent="jett",
+        rating=1.0,
+        acs=200.0,
+        kills=15,
+        deaths=10,
+        assists=5,
+        kast_pct=70.0,
+        adr=140.0,
+        hs_pct=30.0,
+        first_kills=2,
+        first_deaths=1,
+    )
+    assert row.extra == {}
+    # Frozen dataclass — assignment must raise FrozenInstanceError.
+    with pytest.raises(AttributeError):
+        row.vlr_player_id = "X"  # type: ignore[misc]


### PR DESCRIPTION
## Summary

Closes #23. Lands the player layer the BUF-8 v2 CSV bootstrap deferred — the seed populated `match` + `map_result` rows with stable `vlr_match_id` / `vlr_game_id` anchors but had no roster data. This change scrapes VLR's `/match/<id>` profile pages and writes per-map player participation into a new `player_match_stat` table.

- **`player_match_stat` (alembic `0007`)** — one row per (map, player) keyed on `(map_result_id, entity_id)` for idempotency. Source-agnostic by design (`source` + `source_player_id` columns) so the Riot connector (#2) can land in the same shape once it grows a stat-extraction step.
- **`data_pipeline.connectors.vlr_match`** — parser + Playwright-shaped orchestrator. Reuses the BUF-10 20-rpm rate budget and `_RobotsCache`. Resolves canonical PLAYER entities via direct create-or-get on `(Platform.VLR, vlr_alias_platform_id(EntityType.PLAYER, vlr_player_id))` — same path the BUF-8 v2 seed uses, bypassing fuzzy matching for VLR's immutable numeric ids.
- **Idempotent re-runs** — in-memory pre-load of existing `(map_result_id, entity_id)` keys plus a savepoint-scoped insert with `IntegrityError` catch keeps a re-scrape at zero net writes; the schema-level unique constraint is the backstop.

Per-row schema drift (cell-count mismatch on a single player) logs and continues — losing nine valid players to one drift event would defeat the BUF-85 backfill. Per-page fetch failures (transient + arbitrary) are caught and logged so a 1000-match backfill survives a single bad page.

## Test plan

- [x] Parser unit tests (no DB): per-map player linkage, team-side extraction, agent from `<img title>`, position-based stat mapping, KAST/HS% percent stripping, header-anchor exclusion, per-row drift isolation.
- [x] Scraper integration tests (gated on `TEST_DATABASE_URL`): happy-path insert, idempotent re-run = 0 inserts, alias reuse across maps for the same `vlr_player_id`, skip-when-map-missing, transient-fetch-error skip continues run, `20 req/min` token bucket pacing.
- [x] `ParsedPlayerStat` frozen-dataclass invariants.
- [x] `uv run ruff check .` — clean.
- [x] `uv run mypy` — no new errors (one pre-existing error in `seeds/vlr.py:264` unrelated to this PR).
- [x] `uv run pytest packages/shared/tests/` — 208 passed.
- [x] `uv run pytest services/data_pipeline/tests/` (excluding the unrelated `test_rate_limiter.py` that hangs locally on a CPU-bound test) — 143 passed.

https://claude.ai/code/session_01B8aXDbxCcsRfyzda6yqMn2

---
_Generated by [Claude Code](https://claude.ai/code/session_01B8aXDbxCcsRfyzda6yqMn2)_