### PR TITLE
BUF-26: relationship edges with sentiment + exponential decay (System 07)

### DIFF
--- a/packages/shared/alembic/versions/20260503_0010_relationship_edge.py
+++ b/packages/shared/alembic/versions/20260503_0010_relationship_edge.py
@@ -1,0 +1,239 @@
+"""Add relationship_edge + relationship_event tables (BUF-26, System 07).
+
+System 07 in the Systems-spec: pairwise relationships between canonical
+entities, carrying both a magnitude (``strength``, decays exponentially
+with no signal) and a valence (``sentiment``, persistent). The two
+tables this migration installs are:
+
+* ``relationship_edge`` — one row per (src, dst, kind) triple. Symmetric
+  kinds (teammate, ex-teammate, rival, friend) must be persisted with
+  ``src_id < dst_id`` so a single canonical pair owns at most one row
+  of that type. Asymmetric kinds (mentor, manager_of) keep direction.
+* ``relationship_event`` — append-only signal log. Every event that
+  should affect an edge lands here first; the writer that produces it
+  also folds the deltas into the parent edge and bumps
+  ``last_updated_at`` so the next decay pass measures from the
+  refreshed reference point.
+
+Schema rationale:
+
+* ``edge_type`` is a Postgres ENUM rather than a free-form string. The
+  finite kind set drives the ``DECAY_RATES`` lookup in
+  :data:`ecosystem.relationships.DECAY_RATES`; gating it at the DB
+  catches a typo'd writer at insert time rather than letting it land
+  a row the decay job will later silently skip.
+* The symmetric-canonical CHECK lists the symmetric kinds inline so
+  the migration is self-contained — adding a new symmetric kind is a
+  coordinated migration + enum + Python frozenset change, not a
+  silent runtime-only update.
+* Both ``src_id`` and ``dst_id`` get their own indexes so the typical
+  query pattern ("all edges this player is involved in", regardless of
+  direction) stays O(log n) on either side of the pair.
+* ``relationship_event`` cascades on ``ON DELETE CASCADE`` from the
+  parent edge — an event without its edge is just noise, and orphaning
+  rows would mask a buggy edge cleanup. Same FK posture as
+  ``map_result -> player_match_stat``.
+* ``last_updated_at`` is the anchor :func:`decay_strength` reads. The
+  decay job is the canonical writer; ad-hoc writers set it explicitly.
+
+Revision ID: 0010
+Revises: 0009
+Create Date: 2026-05-03
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+from sqlalchemy.dialects import postgresql
+
+# revision identifiers, used by Alembic.
+revision: str = "0010"
+down_revision: str | None = "0009"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+# Mirror of ``esports_sim.db.enums.RelationshipEdgeType``. Kept as
+# literals (not imported) so the migration keeps applying even if the
+# Python enum is later refactored — adding a value is a follow-up
+# ALTER TYPE migration, same convention the BUF-6 enums use.
+_RELATIONSHIP_EDGE_TYPES = (
+    "teammate",
+    "ex_teammate",
+    "rival",
+    "friend",
+    "mentor",
+    "manager_of",
+)
+
+
+def upgrade() -> None:
+    postgresql.ENUM(
+        *_RELATIONSHIP_EDGE_TYPES,
+        name="relationship_edge_type",
+    ).create(op.get_bind(), checkfirst=True)
+
+    op.create_table(
+        "relationship_edge",
+        sa.Column("edge_id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "src_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey(
+                "entity.canonical_id",
+                ondelete="CASCADE",
+                name="fk_relationship_edge_src_id_entity",
+            ),
+            nullable=False,
+        ),
+        sa.Column(
+            "dst_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey(
+                "entity.canonical_id",
+                ondelete="CASCADE",
+                name="fk_relationship_edge_dst_id_entity",
+            ),
+            nullable=False,
+        ),
+        sa.Column(
+            "edge_type",
+            postgresql.ENUM(
+                *_RELATIONSHIP_EDGE_TYPES,
+                name="relationship_edge_type",
+                create_type=False,
+            ),
+            nullable=False,
+        ),
+        sa.Column("strength", sa.Float(), nullable=False, server_default=sa.text("0")),
+        sa.Column("sentiment", sa.Float(), nullable=False, server_default=sa.text("0")),
+        sa.Column(
+            "last_updated_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        sa.Column(
+            "extra",
+            postgresql.JSONB,
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+        # One row per (pair, kind). Symmetric kinds canonicalise endpoints
+        # to ``src < dst`` so this is also one row per (unordered pair,
+        # kind) for those types; asymmetric kinds keep direction.
+        sa.UniqueConstraint(
+            "src_id",
+            "dst_id",
+            "edge_type",
+            name="uq_relationship_edge_src_dst_type",
+        ),
+        sa.CheckConstraint(
+            "src_id <> dst_id",
+            name="ck_relationship_edge_no_self_edge",
+        ),
+        # Symmetric kinds must be stored canonically (src < dst). The
+        # set of symmetric kinds is mirrored in
+        # ``esports_sim.db.enums.SYMMETRIC_RELATIONSHIP_EDGE_TYPES``;
+        # adding a new symmetric kind requires updating both.
+        sa.CheckConstraint(
+            "edge_type NOT IN ('teammate', 'ex_teammate', 'rival', 'friend') " "OR src_id < dst_id",
+            name="ck_relationship_edge_symmetric_canonical",
+        ),
+        sa.CheckConstraint(
+            "strength >= 0 AND strength <= 1",
+            name="ck_relationship_edge_strength_range",
+        ),
+        sa.CheckConstraint(
+            "sentiment >= -1 AND sentiment <= 1",
+            name="ck_relationship_edge_sentiment_range",
+        ),
+    )
+    # Both endpoints are query-able pivots ("all edges where this
+    # player is involved, regardless of direction"); index each
+    # column standalone so the OR / UNION ALL pattern doesn't seq-scan
+    # one side of the pair.
+    op.create_index(
+        "ix_relationship_edge_src_id",
+        "relationship_edge",
+        ["src_id"],
+    )
+    op.create_index(
+        "ix_relationship_edge_dst_id",
+        "relationship_edge",
+        ["dst_id"],
+    )
+    # The decay job filters on ``edge_type`` to apply per-type rates;
+    # the index keeps that O(log n) once the table is fully seeded.
+    op.create_index(
+        "ix_relationship_edge_edge_type",
+        "relationship_edge",
+        ["edge_type"],
+    )
+
+    op.create_table(
+        "relationship_event",
+        sa.Column("event_id", postgresql.UUID(as_uuid=True), primary_key=True),
+        sa.Column(
+            "edge_id",
+            postgresql.UUID(as_uuid=True),
+            sa.ForeignKey(
+                "relationship_edge.edge_id",
+                ondelete="CASCADE",
+                name="fk_relationship_event_edge_id_relationship_edge",
+            ),
+            nullable=False,
+        ),
+        sa.Column("event_kind", sa.String(64), nullable=False),
+        sa.Column("delta_strength", sa.Float(), nullable=False, server_default=sa.text("0")),
+        sa.Column("delta_sentiment", sa.Float(), nullable=False, server_default=sa.text("0")),
+        sa.Column(
+            "occurred_at",
+            sa.DateTime(timezone=True),
+            nullable=False,
+        ),
+        sa.Column(
+            "payload",
+            postgresql.JSONB,
+            nullable=False,
+            server_default=sa.text("'{}'::jsonb"),
+        ),
+        sa.Column(
+            "created_at",
+            sa.DateTime(timezone=True),
+            server_default=sa.func.now(),
+            nullable=False,
+        ),
+    )
+    op.create_index(
+        "ix_relationship_event_edge_id",
+        "relationship_event",
+        ["edge_id"],
+    )
+    op.create_index(
+        "ix_relationship_event_occurred_at",
+        "relationship_event",
+        ["occurred_at"],
+    )
+
+
+def downgrade() -> None:
+    op.drop_index("ix_relationship_event_occurred_at", table_name="relationship_event")
+    op.drop_index("ix_relationship_event_edge_id", table_name="relationship_event")
+    op.drop_table("relationship_event")
+
+    op.drop_index("ix_relationship_edge_edge_type", table_name="relationship_edge")
+    op.drop_index("ix_relationship_edge_dst_id", table_name="relationship_edge")
+    op.drop_index("ix_relationship_edge_src_id", table_name="relationship_edge")
+    op.drop_table("relationship_edge")
+
+    op.execute("DROP TYPE IF EXISTS relationship_edge_type")

--- a/packages/shared/src/esports_sim/db/__init__.py
+++ b/packages/shared/src/esports_sim/db/__init__.py
@@ -26,7 +26,14 @@ schema. Migrations live at ``packages/shared/alembic/``.
 """
 
 from esports_sim.db.base import Base
-from esports_sim.db.enums import EntityType, Platform, ReviewStatus, StagingStatus
+from esports_sim.db.enums import (
+    SYMMETRIC_RELATIONSHIP_EDGE_TYPES,
+    EntityType,
+    Platform,
+    RelationshipEdgeType,
+    ReviewStatus,
+    StagingStatus,
+)
 from esports_sim.db.models import (
     EMBEDDING_DIM,
     AliasReviewQueue,
@@ -37,6 +44,8 @@ from esports_sim.db.models import (
     PatchNote,
     PersonalityEmbedding,
     RawRecord,
+    RelationshipEdge,
+    RelationshipEvent,
     StagingInvariantError,
     StagingRecord,
     TemporalBleedError,
@@ -56,10 +65,14 @@ __all__ = [
     "PersonalityEmbedding",
     "Platform",
     "RawRecord",
+    "RelationshipEdge",
+    "RelationshipEdgeType",
+    "RelationshipEvent",
     "ReviewStatus",
     "StagingInvariantError",
     "StagingRecord",
     "StagingStatus",
+    "SYMMETRIC_RELATIONSHIP_EDGE_TYPES",
     "TemporalBleedError",
     "TranscriptChunkEmbedding",
 ]

--- a/packages/shared/src/esports_sim/db/enums.py
+++ b/packages/shared/src/esports_sim/db/enums.py
@@ -68,3 +68,43 @@ class ReviewStatus(enum.StrEnum):
     RESOLVED = "resolved"
     SKIPPED = "skipped"
     BLOCKED = "blocked"
+
+
+class RelationshipEdgeType(enum.StrEnum):
+    """Kinds of pairwise relationships the ecosystem layer tracks (BUF-26, System 07).
+
+    Each kind has its own decay rate in
+    :data:`ecosystem.relationships.DECAY_RATES`; bumping the dict and the
+    enum together is a versioned event that Phase-1 retro-decay analyses
+    have to re-run against. Members are deliberately coarse — finer
+    distinctions live in ``relationship_event.event_kind`` so a downstream
+    feature extractor can split a TEAMMATE edge into "shared scrim" vs
+    "co-clutch" without forcing a new edge type.
+
+    Symmetric kinds (teammate, ex-teammate, rival, friend) MUST be
+    persisted with ``src_id < dst_id`` so a single pair owns at most one
+    row of that type — see :data:`SYMMETRIC_RELATIONSHIP_EDGE_TYPES`
+    and the partial check in the migration.
+    """
+
+    TEAMMATE = "teammate"
+    EX_TEAMMATE = "ex_teammate"
+    RIVAL = "rival"
+    FRIEND = "friend"
+    MENTOR = "mentor"
+    MANAGER_OF = "manager_of"
+
+
+# Edge kinds whose semantics are symmetric: the relationship "A is a
+# teammate of B" is the same fact as "B is a teammate of A". The
+# bootstrap and the application API enforce ``src_id < dst_id`` for
+# these, so a pair of players never owns two rows of the same symmetric
+# kind. Asymmetric kinds (mentor, manager_of) keep direction.
+SYMMETRIC_RELATIONSHIP_EDGE_TYPES: frozenset[RelationshipEdgeType] = frozenset(
+    {
+        RelationshipEdgeType.TEAMMATE,
+        RelationshipEdgeType.EX_TEAMMATE,
+        RelationshipEdgeType.RIVAL,
+        RelationshipEdgeType.FRIEND,
+    }
+)

--- a/packages/shared/src/esports_sim/db/models.py
+++ b/packages/shared/src/esports_sim/db/models.py
@@ -33,7 +33,13 @@ from sqlalchemy.engine import Connection
 from sqlalchemy.orm import Mapped, Mapper, Session, mapped_column, relationship
 
 from esports_sim.db.base import Base
-from esports_sim.db.enums import EntityType, Platform, ReviewStatus, StagingStatus
+from esports_sim.db.enums import (
+    EntityType,
+    Platform,
+    RelationshipEdgeType,
+    ReviewStatus,
+    StagingStatus,
+)
 
 # all-MiniLM-L6-v2's output width (BUF-28, ADR-006). Pinned as a
 # module-level constant so the model declarations, the migration, and
@@ -65,6 +71,12 @@ _staging_status = PgEnum(
 _review_status = PgEnum(
     ReviewStatus,
     name="review_status",
+    create_type=False,
+    values_callable=lambda e: [v.value for v in e],
+)
+_relationship_edge_type = PgEnum(
+    RelationshipEdgeType,
+    name="relationship_edge_type",
     create_type=False,
     values_callable=lambda e: [v.value for v in e],
 )
@@ -937,6 +949,214 @@ class TranscriptChunkEmbedding(Base):
     )
 
 
+class RelationshipEdge(Base):
+    """One pairwise relationship between two canonical entities (BUF-26, System 07).
+
+    Each row encodes a single directed claim of the form "``src_id``
+    relates to ``dst_id`` as ``edge_type``" together with two scalar
+    attributes:
+
+    * ``strength`` (``[0, 1]``) — how vigorous the relationship is
+      *right now*. Decays exponentially with no signal — see
+      :func:`ecosystem.relationships.decay_strength`. New
+      :class:`RelationshipEvent` rows reset the clock and add to it.
+    * ``sentiment`` (``[-1, 1]``) — valence. Does **not** decay; an
+      ex-teammate edge keeps its positive sentiment after the strength
+      has bled out. Negative sentiment is what turns a TEAMMATE edge
+      into a feud rather than a friendship.
+
+    Symmetric edge types (see
+    :data:`esports_sim.db.enums.SYMMETRIC_RELATIONSHIP_EDGE_TYPES`)
+    must be persisted with ``src_id < dst_id`` so a single canonical
+    pair owns at most one row of that type. The migration enforces the
+    rule with a CHECK; the bootstrap and the application API
+    canonicalise endpoints up front. Asymmetric kinds (mentor,
+    manager_of) keep their direction.
+
+    ``last_updated_at`` is the anchor :func:`decay_strength` reads to
+    decide how many weeks of decay to apply on the next read or job
+    pass. The monthly decay job (see
+    :func:`ecosystem.relationships.run_monthly_decay`) is the canonical
+    writer; ad-hoc updates set it explicitly.
+    """
+
+    __tablename__ = "relationship_edge"
+
+    edge_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+    src_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("entity.canonical_id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    dst_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("entity.canonical_id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    edge_type: Mapped[RelationshipEdgeType] = mapped_column(
+        _relationship_edge_type,
+        nullable=False,
+        index=True,
+    )
+    strength: Mapped[float] = mapped_column(
+        Float,
+        nullable=False,
+        server_default="0",
+    )
+    sentiment: Mapped[float] = mapped_column(
+        Float,
+        nullable=False,
+        server_default="0",
+    )
+    # Anchor for the next ``decay_strength`` call. Initialised to the
+    # creation time of the row when the bootstrap or steady-state writer
+    # mints it; updated in place by the monthly decay job and by every
+    # event that touches strength so the next decay pass measures from
+    # the right reference point.
+    last_updated_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        nullable=False,
+    )
+    # Free-form provenance. The bootstrap stamps ``shared_maps`` /
+    # ``last_shared_match_at`` here so a downstream debug query can
+    # explain why a particular edge ended up TEAMMATE vs EX_TEAMMATE.
+    extra: Mapped[dict[str, Any]] = mapped_column(
+        JSONB,
+        nullable=False,
+        server_default=text("'{}'::jsonb"),
+        default=dict,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        nullable=False,
+    )
+
+    events: Mapped[list[RelationshipEvent]] = relationship(
+        back_populates="edge",
+        cascade="all, delete-orphan",
+        lazy="selectin",
+    )
+
+    __table_args__ = (
+        # One row per (pair, kind). For symmetric kinds the bootstrap
+        # canonicalises endpoints to ``src < dst`` so the pair owns at
+        # most one row of that type; for asymmetric kinds (mentor,
+        # manager_of) the unique constraint distinguishes the two
+        # directions.
+        UniqueConstraint(
+            "src_id",
+            "dst_id",
+            "edge_type",
+            name="uq_relationship_edge_src_dst_type",
+        ),
+        # A self-edge is meaningless and would always sort to the wrong
+        # side of the symmetry CHECK below; pin it out at the schema
+        # layer rather than relying on every writer to remember.
+        CheckConstraint(
+            "src_id <> dst_id",
+            name="ck_relationship_edge_no_self_edge",
+        ),
+        # Symmetric kinds must be stored canonically (src < dst) so a
+        # pair owns at most one row of that type. Asymmetric kinds
+        # (mentor, manager_of) keep direction. Listing the symmetric
+        # kinds inline rather than referencing the Python frozenset
+        # keeps the migration self-contained — adding a new symmetric
+        # kind is a coordinated migration + enum + frozenset change.
+        CheckConstraint(
+            "edge_type NOT IN ('teammate', 'ex_teammate', 'rival', 'friend') " "OR src_id < dst_id",
+            name="ck_relationship_edge_symmetric_canonical",
+        ),
+        CheckConstraint(
+            "strength >= 0 AND strength <= 1",
+            name="ck_relationship_edge_strength_range",
+        ),
+        CheckConstraint(
+            "sentiment >= -1 AND sentiment <= 1",
+            name="ck_relationship_edge_sentiment_range",
+        ),
+    )
+
+
+class RelationshipEvent(Base):
+    """One signal that touched a :class:`RelationshipEdge` (BUF-26, System 07).
+
+    Append-only. Every signal that should affect strength or sentiment
+    lands as a row here first; the writer that produced it also folds
+    ``delta_strength`` / ``delta_sentiment`` into the parent edge and
+    bumps ``last_updated_at`` so the decay job's clock resets.
+
+    Keeping the event log separate from the in-place edge update is the
+    BUF-78 event-log pattern: an audit trail that lets a future
+    reducer rebuild edge state from genesis if the in-place column
+    drifts. The cardinality is several events per edge per season, so
+    the table is bounded by roster turnover, not by tick rate.
+
+    ``event_kind`` is a free-form string deliberately — the value
+    space is much larger than the small enum on the parent edge
+    (``"shared_clutch"``, ``"public_feud"``, ``"social_media_jab"``,
+    ``"won_together"``, ``"benched"``, …) and gating it on a
+    Postgres ENUM would force an ALTER TYPE migration every time a
+    new signal type ships.
+    """
+
+    __tablename__ = "relationship_event"
+
+    event_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        primary_key=True,
+        default=uuid.uuid4,
+    )
+    edge_id: Mapped[uuid.UUID] = mapped_column(
+        UUID(as_uuid=True),
+        ForeignKey("relationship_edge.edge_id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    event_kind: Mapped[str] = mapped_column(String(64), nullable=False)
+    # Both deltas are signed and can land outside ``[-1, 1]`` if a
+    # particularly weighty event swings the edge past saturation; the
+    # parent edge's CHECK constraints clamp the cumulative result.
+    delta_strength: Mapped[float] = mapped_column(
+        Float,
+        nullable=False,
+        server_default="0",
+    )
+    delta_sentiment: Mapped[float] = mapped_column(
+        Float,
+        nullable=False,
+        server_default="0",
+    )
+    # When the event happened in the simulation/world. Indexed because
+    # the event-stream queries (``last 30 days for this edge``,
+    # ``replay this edge from genesis``) all filter on it.
+    occurred_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        nullable=False,
+        index=True,
+    )
+    payload: Mapped[dict[str, Any]] = mapped_column(
+        JSONB,
+        nullable=False,
+        server_default=text("'{}'::jsonb"),
+        default=dict,
+    )
+    created_at: Mapped[datetime] = mapped_column(
+        DateTime(timezone=True),
+        server_default=func.now(),
+        nullable=False,
+    )
+
+    edge: Mapped[RelationshipEdge] = relationship(back_populates="events")
+
+
 __all__ = [
     "AliasReviewQueue",
     "EMBEDDING_DIM",
@@ -950,6 +1170,8 @@ __all__ = [
     "PersonalityEmbedding",
     "PlayerMatchStat",
     "RawRecord",
+    "RelationshipEdge",
+    "RelationshipEvent",
     "StagingInvariantError",
     "StagingRecord",
     "TemporalBleedError",

--- a/packages/shared/tests/conftest.py
+++ b/packages/shared/tests/conftest.py
@@ -97,6 +97,7 @@ def db_engine() -> Generator[Engine, None, None]:
             Base.metadata.drop_all(bind=conn)
             conn.execute(text("DROP TABLE IF EXISTS alembic_version"))
             for typename in (
+                "relationship_edge_type",
                 "review_status",
                 "staging_status",
                 "platform",

--- a/services/data_pipeline/src/data_pipeline/seeds/relationships.py
+++ b/services/data_pipeline/src/data_pipeline/seeds/relationships.py
@@ -1,0 +1,330 @@
+"""``bootstrap_teammate_edges()`` — one-shot teammate-graph seed (BUF-26).
+
+Walks the canonical match history (BUF-8 v2 ``MapResult`` rows joined
+to per-map participation in ``PlayerMatchStat``) and emits one
+:class:`RelationshipEdge` per pair of canonical players that ever
+shared a team_side on the same map.
+
+Per the BUF-26 acceptance: *every pair of former teammates in the DB
+has a teammate or ex-teammate edge*. The cut between the two kinds is
+recency:
+
+* If the pair's most-recent shared map is within
+  :data:`RECENT_TEAMMATE_DAYS` of the bootstrap reference timestamp,
+  the edge is :attr:`RelationshipEdgeType.TEAMMATE`.
+* Otherwise the pair carries the historical :attr:`RelationshipEdgeType.EX_TEAMMATE`.
+
+The bootstrap reference timestamp is the maximum ``match_date`` in the
+DB — the closest analogue to "now" against the seed corpus. This
+matches what the steady-state ecosystem layer would do at world-tick
+0: replay the historical relationships into the world before the sim
+starts ticking.
+
+Strength initialisation is a saturating linear function of the number
+of shared maps:
+
+.. math::
+
+    \\text{strength} = \\min\\!\\left( 1.0, \\frac{\\text{shared\\_maps}}{N} \\right)
+
+with ``N = 20`` so a full split-season's worth of maps maxes the bond.
+Sentiment defaults to ``+1.0``: the bootstrap has no upstream signal
+that would warrant a negative valence — feuds, when they happen, land
+as ``relationship_event`` rows after the bootstrap.
+
+Idempotency: re-running the seed against an already-populated table is
+an UPSERT-with-replace. Existing edges have their strength /
+last_updated_at re-derived from the underlying shared-maps tally so
+re-running after a fresh ``MapResult`` ingest catches the new pairs
+without leaving the old edges stale.
+"""
+
+from __future__ import annotations
+
+import logging
+import uuid
+from collections import defaultdict
+from dataclasses import dataclass, field
+from datetime import datetime, timedelta
+from typing import Any
+
+from esports_sim.db.enums import RelationshipEdgeType
+from esports_sim.db.models import MapResult, Match, PlayerMatchStat, RelationshipEdge
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+_logger = logging.getLogger("data_pipeline.seeds.relationships")
+
+
+# Number of days that the most-recent shared map must lie within for a
+# pair to count as "current" teammates rather than ex-teammates. Tuned
+# to ~13 weeks — roughly one VCT split — so a roster that played
+# together this season is current; a duo last seen a year ago is ex.
+RECENT_TEAMMATE_DAYS: int = 90
+
+
+# Number of shared maps that saturates the initial strength to 1.0.
+# Below this, strength scales linearly. The threshold is opinionated
+# but anchored: a single VCT regular season is roughly 18-22 best-of-
+# three matches per team, so a full split's worth of co-play tops out
+# the bond — anything beyond that is signal redundancy.
+STRENGTH_SATURATION_SHARED_MAPS: int = 20
+
+
+@dataclass(frozen=True, slots=True)
+class _PairAccumulator:
+    """Per-pair aggregate the bootstrap builds before persisting.
+
+    ``shared_maps`` counts distinct ``map_result_id`` values where both
+    players appeared with the same ``team_side``. ``last_match_at`` is
+    the most recent of those.
+    """
+
+    shared_maps: int
+    last_match_at: datetime
+
+
+@dataclass
+class TeammateBootstrapManifest:
+    """Counts emitted by :func:`bootstrap_teammate_edges`.
+
+    Persisted alongside the seed run so an operator can confirm "the
+    bootstrap saw N pairs and produced N edges" without re-running a
+    diagnostic query against the DB.
+    """
+
+    pairs_seen: int = 0
+    teammate_edges_inserted: int = 0
+    ex_teammate_edges_inserted: int = 0
+    edges_updated: int = 0
+    reference_timestamp: datetime | None = None
+    extra: dict[str, Any] = field(default_factory=dict)
+
+    @property
+    def total_edges(self) -> int:
+        return self.teammate_edges_inserted + self.ex_teammate_edges_inserted
+
+
+def _canonical_pair(a: uuid.UUID, b: uuid.UUID) -> tuple[uuid.UUID, uuid.UUID]:
+    """Return ``(min, max)`` so a symmetric pair is keyed unambiguously.
+
+    The DB also enforces this for symmetric edge kinds via the
+    ``ck_relationship_edge_symmetric_canonical`` CHECK; canonicalising
+    in Python keeps the bootstrap's accumulator dict on the same page
+    so we don't end up with two accumulator entries for the same
+    unordered pair.
+    """
+    return (a, b) if a < b else (b, a)
+
+
+def _collect_pairs(
+    session: Session,
+) -> tuple[dict[tuple[uuid.UUID, uuid.UUID], _PairAccumulator], datetime | None]:
+    """Walk PlayerMatchStat + MapResult and build the per-pair accumulator.
+
+    The query joins ``player_match_stat`` to ``map_result`` to recover
+    the per-map timestamp from the parent ``match`` row. Rows with a
+    null ``team_side`` are skipped — without a side assignment we
+    can't tell a teammate from an opponent.
+    """
+    rows = session.execute(
+        select(
+            PlayerMatchStat.entity_id,
+            PlayerMatchStat.team_side,
+            PlayerMatchStat.map_result_id,
+            MapResult.match_id,
+        )
+        .join(MapResult, MapResult.map_result_id == PlayerMatchStat.map_result_id)
+        .where(PlayerMatchStat.team_side.is_not(None))
+    ).all()
+
+    # Group player ids by (map_result_id, team_side); each group is a
+    # team's roster for one map. Pairs within a group are teammates on
+    # that map.
+    by_side: dict[tuple[uuid.UUID, str], list[uuid.UUID]] = defaultdict(list)
+    map_match_ids: dict[uuid.UUID, uuid.UUID] = {}
+    for entity_id, team_side, map_result_id, match_id in rows:
+        by_side[(map_result_id, team_side)].append(entity_id)
+        map_match_ids[map_result_id] = match_id
+
+    if not map_match_ids:
+        return {}, None
+
+    # Resolve match timestamps for the maps we care about. A second
+    # round-trip rather than joining ``match`` directly: the join would
+    # multiply rows we already discarded (null team_side) and the
+    # explicit lookup is easier to read.
+    match_date_rows = session.execute(
+        select(Match.match_id, Match.match_date).where(
+            Match.match_id.in_(set(map_match_ids.values()))
+        )
+    ).all()
+    match_dates: dict[uuid.UUID, datetime] = {
+        row.match_id: row.match_date for row in match_date_rows
+    }
+
+    pairs: dict[tuple[uuid.UUID, uuid.UUID], _PairAccumulator] = {}
+    reference_ts: datetime | None = None
+    for (map_result_id, _side), roster in by_side.items():
+        match_id = map_match_ids[map_result_id]
+        played_at = match_dates.get(match_id)
+        if played_at is None:
+            continue
+        if reference_ts is None or played_at > reference_ts:
+            reference_ts = played_at
+        # All pairs within the same (map_result_id, team_side) group.
+        # Deduplicate just in case the upstream emitted the same
+        # entity twice in a roster (a partial-scrape edge case).
+        unique_roster = sorted(set(roster))
+        for i in range(len(unique_roster)):
+            for j in range(i + 1, len(unique_roster)):
+                key = _canonical_pair(unique_roster[i], unique_roster[j])
+                acc = pairs.get(key)
+                if acc is None:
+                    pairs[key] = _PairAccumulator(
+                        shared_maps=1,
+                        last_match_at=played_at,
+                    )
+                else:
+                    pairs[key] = _PairAccumulator(
+                        shared_maps=acc.shared_maps + 1,
+                        last_match_at=max(acc.last_match_at, played_at),
+                    )
+
+    return pairs, reference_ts
+
+
+def _existing_edges(
+    session: Session,
+    pair_keys: list[tuple[uuid.UUID, uuid.UUID]],
+) -> dict[tuple[uuid.UUID, uuid.UUID, RelationshipEdgeType], RelationshipEdge]:
+    """Pre-load any teammate / ex-teammate edges that already exist.
+
+    Keyed on ``(src, dst, kind)`` so the upsert path can branch on
+    "row exists" vs "fresh insert" without paying a per-pair
+    SELECT. Only pulls the two kinds the bootstrap manages — leaving
+    the steady-state event-driven kinds (rival, mentor, …)
+    untouched even if a pair shows up here.
+    """
+    if not pair_keys:
+        return {}
+    src_ids = [a for a, _ in pair_keys]
+    dst_ids = [b for _, b in pair_keys]
+    rows = (
+        session.execute(
+            select(RelationshipEdge).where(
+                RelationshipEdge.src_id.in_(src_ids),
+                RelationshipEdge.dst_id.in_(dst_ids),
+                RelationshipEdge.edge_type.in_(
+                    (RelationshipEdgeType.TEAMMATE, RelationshipEdgeType.EX_TEAMMATE),
+                ),
+            )
+        )
+        .scalars()
+        .all()
+    )
+    return {(e.src_id, e.dst_id, e.edge_type): e for e in rows}
+
+
+def bootstrap_teammate_edges(
+    session: Session,
+    *,
+    reference_timestamp: datetime | None = None,
+    recent_teammate_days: int = RECENT_TEAMMATE_DAYS,
+    saturation_shared_maps: int = STRENGTH_SATURATION_SHARED_MAPS,
+) -> TeammateBootstrapManifest:
+    """Build a teammate / ex-teammate edge for every former-roster pair.
+
+    Returns a :class:`TeammateBootstrapManifest` with the row counts
+    so the operator-facing CLI can confirm the seed shape.
+
+    ``reference_timestamp`` defaults to the latest match in the DB —
+    the closest analogue to "now" against an offline seed corpus.
+    Pass an explicit value to backdate the bootstrap (e.g. for a
+    deterministic test fixture).
+
+    The function does **not** commit; the caller owns the transaction
+    so the seed composes with sibling work in the same session.
+    """
+    pairs, latest_match = _collect_pairs(session)
+    manifest = TeammateBootstrapManifest(pairs_seen=len(pairs))
+    if not pairs:
+        manifest.reference_timestamp = reference_timestamp
+        return manifest
+
+    ref_ts = reference_timestamp or latest_match
+    assert ref_ts is not None  # _collect_pairs returned pairs => latest_match is set
+    manifest.reference_timestamp = ref_ts
+    recent_threshold = ref_ts - timedelta(days=recent_teammate_days)
+
+    # Symmetric kind: both endpoints are stored canonically (src < dst).
+    # We pre-load existing rows for the pair-keys so re-runs UPSERT
+    # rather than collide on the unique constraint.
+    existing = _existing_edges(session, list(pairs.keys()))
+
+    for (src_id, dst_id), acc in pairs.items():
+        is_recent = acc.last_match_at >= recent_threshold
+        edge_type = RelationshipEdgeType.TEAMMATE if is_recent else RelationshipEdgeType.EX_TEAMMATE
+        strength = min(1.0, acc.shared_maps / float(saturation_shared_maps))
+        extras = {
+            "shared_maps": acc.shared_maps,
+            "last_shared_match_at": acc.last_match_at.isoformat(),
+            "bootstrap_reference_at": ref_ts.isoformat(),
+        }
+
+        # On a kind-flip (e.g. a fresh ingest moved a pair from
+        # ex-teammate to teammate) drop the old row and mint the
+        # new one rather than mutating in place — kind is part of
+        # the unique constraint, so swapping it with the row in
+        # place would still need a delete + insert.
+        for stale_kind in (RelationshipEdgeType.TEAMMATE, RelationshipEdgeType.EX_TEAMMATE):
+            if stale_kind == edge_type:
+                continue
+            stale = existing.pop((src_id, dst_id, stale_kind), None)
+            if stale is not None:
+                session.delete(stale)
+
+        existing_edge = existing.get((src_id, dst_id, edge_type))
+        if existing_edge is None:
+            session.add(
+                RelationshipEdge(
+                    edge_id=uuid.uuid4(),
+                    src_id=src_id,
+                    dst_id=dst_id,
+                    edge_type=edge_type,
+                    strength=strength,
+                    sentiment=1.0,
+                    last_updated_at=acc.last_match_at,
+                    extra=extras,
+                )
+            )
+            if edge_type is RelationshipEdgeType.TEAMMATE:
+                manifest.teammate_edges_inserted += 1
+            else:
+                manifest.ex_teammate_edges_inserted += 1
+        else:
+            existing_edge.strength = strength
+            existing_edge.sentiment = 1.0
+            existing_edge.last_updated_at = acc.last_match_at
+            existing_edge.extra = extras
+            manifest.edges_updated += 1
+
+    session.flush()
+    _logger.info(
+        "teammate bootstrap complete",
+        extra={
+            "pairs_seen": manifest.pairs_seen,
+            "teammate_inserted": manifest.teammate_edges_inserted,
+            "ex_teammate_inserted": manifest.ex_teammate_edges_inserted,
+            "edges_updated": manifest.edges_updated,
+        },
+    )
+    return manifest
+
+
+__all__ = [
+    "RECENT_TEAMMATE_DAYS",
+    "STRENGTH_SATURATION_SHARED_MAPS",
+    "TeammateBootstrapManifest",
+    "bootstrap_teammate_edges",
+]

--- a/services/data_pipeline/src/data_pipeline/seeds/relationships.py
+++ b/services/data_pipeline/src/data_pipeline/seeds/relationships.py
@@ -54,9 +54,8 @@ from esports_sim.db.models import (
     Match,
     PlayerMatchStat,
     RelationshipEdge,
-    RelationshipEvent,
 )
-from sqlalchemy import select, update
+from sqlalchemy import select
 from sqlalchemy.orm import Session
 
 _logger = logging.getLogger("data_pipeline.seeds.relationships")
@@ -304,14 +303,21 @@ def bootstrap_teammate_edges(
                 # Defensive case: both kinds exist for the same
                 # pair (shouldn't happen via the bootstrap, but
                 # could arise from a hand-written event-driven
-                # writer). Migrate the stale row's events onto
-                # the target row before deleting, so the audit
-                # trail survives the consolidation.
-                session.execute(
-                    update(RelationshipEvent)
-                    .where(RelationshipEvent.edge_id == stale.edge_id)
-                    .values(edge_id=target.edge_id)
-                )
+                # writer). Re-parent the stale row's events onto
+                # the target at the ORM level so the cascade-delete
+                # on ``stale`` doesn't propagate into the audit
+                # trail. A bulk SQL UPDATE is *not* enough here:
+                # ``RelationshipEdge.events`` is loaded eagerly
+                # (``selectin``) with ``cascade="all, delete-orphan"``,
+                # so SA's in-memory collection still anchors the
+                # events to ``stale`` and the next flush would
+                # delete them despite the SQL-level reparenting
+                # (Codex P1 on PR #28). Re-assigning ``event.edge``
+                # walks the bidirectional relationship and atomically
+                # moves each child onto the target, so neither orphan
+                # cascade nor delete cascade fires.
+                for event in list(stale.events):
+                    event.edge = target
                 session.delete(stale)
 
         existing_edge = existing.get((src_id, dst_id, edge_type))

--- a/services/data_pipeline/src/data_pipeline/seeds/relationships.py
+++ b/services/data_pipeline/src/data_pipeline/seeds/relationships.py
@@ -339,16 +339,25 @@ def bootstrap_teammate_edges(
             else:
                 manifest.ex_teammate_edges_inserted += 1
         else:
-            # Refresh strength + audit metadata from the latest
-            # match history. Sentiment is intentionally **not**
-            # touched: an event-driven writer (Codex P1 on PR
-            # #28) may have evolved the valence past the
-            # bootstrap default, and resetting it to 1.0 here
-            # would silently corrupt that signal. The bootstrap
-            # owns "did they share rosters and how recently";
-            # ``relationship_event`` owns valence over time.
-            existing_edge.strength = strength
-            existing_edge.last_updated_at = acc.last_match_at
+            # Rerun against an already-seeded edge. The bootstrap is a
+            # baseline-seeding pass — once a post-bootstrap writer
+            # (the event-driven path: ``relationship_event`` rows
+            # folded into the edge, or the monthly decay job) has
+            # advanced ``last_updated_at`` past ``acc.last_match_at``,
+            # they own the live magnitude. Re-deriving ``strength``
+            # from shared-map count would wipe their adjustments AND
+            # rewind the decay anchor, so the next decay pass would
+            # over-apply the elapsed weeks (Codex P1 on PR #28).
+            # Sentiment is never touched on rerun, same rationale.
+            #
+            # The provenance ``extra`` is always refreshed so an
+            # operator can see what the latest match history looks
+            # like for this pair, regardless of whether the event-
+            # driven writer has taken over.
+            event_writer_has_taken_over = existing_edge.last_updated_at > acc.last_match_at
+            if not event_writer_has_taken_over:
+                existing_edge.strength = strength
+                existing_edge.last_updated_at = acc.last_match_at
             existing_edge.extra = extras
             manifest.edges_updated += 1
 

--- a/services/data_pipeline/src/data_pipeline/seeds/relationships.py
+++ b/services/data_pipeline/src/data_pipeline/seeds/relationships.py
@@ -49,8 +49,14 @@ from datetime import datetime, timedelta
 from typing import Any
 
 from esports_sim.db.enums import RelationshipEdgeType
-from esports_sim.db.models import MapResult, Match, PlayerMatchStat, RelationshipEdge
-from sqlalchemy import select
+from esports_sim.db.models import (
+    MapResult,
+    Match,
+    PlayerMatchStat,
+    RelationshipEdge,
+    RelationshipEvent,
+)
+from sqlalchemy import select, update
 from sqlalchemy.orm import Session
 
 _logger = logging.getLogger("data_pipeline.seeds.relationships")
@@ -273,15 +279,39 @@ def bootstrap_teammate_edges(
         }
 
         # On a kind-flip (e.g. a fresh ingest moved a pair from
-        # ex-teammate to teammate) drop the old row and mint the
-        # new one rather than mutating in place — kind is part of
-        # the unique constraint, so swapping it with the row in
-        # place would still need a delete + insert.
+        # ex-teammate to teammate) mutate the existing row's
+        # ``edge_type`` in place rather than delete-and-reinsert.
+        # ``relationship_event.edge_id`` is ``ON DELETE CASCADE``,
+        # so dropping the row would wipe the append-only audit
+        # trail attached to it (Codex P1 on PR #28). The unique
+        # constraint is ``(src, dst, edge_type)`` and we're
+        # swapping the third column on a single row, which stays
+        # unique by construction.
         for stale_kind in (RelationshipEdgeType.TEAMMATE, RelationshipEdgeType.EX_TEAMMATE):
             if stale_kind == edge_type:
                 continue
             stale = existing.pop((src_id, dst_id, stale_kind), None)
-            if stale is not None:
+            if stale is None:
+                continue
+            target = existing.get((src_id, dst_id, edge_type))
+            if target is None:
+                # Single-row flip: mutate kind in place and
+                # re-key the lookup so the update branch below
+                # finds it.
+                stale.edge_type = edge_type
+                existing[(src_id, dst_id, edge_type)] = stale
+            else:
+                # Defensive case: both kinds exist for the same
+                # pair (shouldn't happen via the bootstrap, but
+                # could arise from a hand-written event-driven
+                # writer). Migrate the stale row's events onto
+                # the target row before deleting, so the audit
+                # trail survives the consolidation.
+                session.execute(
+                    update(RelationshipEvent)
+                    .where(RelationshipEvent.edge_id == stale.edge_id)
+                    .values(edge_id=target.edge_id)
+                )
                 session.delete(stale)
 
         existing_edge = existing.get((src_id, dst_id, edge_type))
@@ -303,8 +333,15 @@ def bootstrap_teammate_edges(
             else:
                 manifest.ex_teammate_edges_inserted += 1
         else:
+            # Refresh strength + audit metadata from the latest
+            # match history. Sentiment is intentionally **not**
+            # touched: an event-driven writer (Codex P1 on PR
+            # #28) may have evolved the valence past the
+            # bootstrap default, and resetting it to 1.0 here
+            # would silently corrupt that signal. The bootstrap
+            # owns "did they share rosters and how recently";
+            # ``relationship_event`` owns valence over time.
             existing_edge.strength = strength
-            existing_edge.sentiment = 1.0
             existing_edge.last_updated_at = acc.last_match_at
             existing_edge.extra = extras
             manifest.edges_updated += 1

--- a/services/data_pipeline/tests/conftest.py
+++ b/services/data_pipeline/tests/conftest.py
@@ -82,6 +82,7 @@ def db_engine() -> Generator[Engine, None, None]:
             Base.metadata.drop_all(bind=conn)
             conn.execute(text("DROP TABLE IF EXISTS alembic_version"))
             for typename in (
+                "relationship_edge_type",
                 "review_status",
                 "staging_status",
                 "platform",

--- a/services/data_pipeline/tests/test_relationship_bootstrap.py
+++ b/services/data_pipeline/tests/test_relationship_bootstrap.py
@@ -1,0 +1,307 @@
+"""Integration tests for the BUF-26 teammate-edge bootstrap.
+
+Skipped automatically when ``TEST_DATABASE_URL`` is not set — see
+``conftest.py``. The bootstrap reads ``MapResult`` /
+``PlayerMatchStat`` / ``Match`` rows seeded inline by these tests
+(no fixture corpus dependency) and asserts the BUF-26 acceptance:
+*every pair of former teammates in the DB has a teammate or
+ex-teammate edge*.
+"""
+
+from __future__ import annotations
+
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from data_pipeline.seeds.relationships import (
+    RECENT_TEAMMATE_DAYS,
+    bootstrap_teammate_edges,
+)
+from esports_sim.db.enums import EntityType, RelationshipEdgeType
+from esports_sim.db.models import (
+    Entity,
+    MapResult,
+    Match,
+    PlayerMatchStat,
+    RelationshipEdge,
+)
+from sqlalchemy import select
+
+pytestmark = pytest.mark.integration
+
+
+def _make_player(db_session) -> Entity:
+    e = Entity(canonical_id=uuid.uuid4(), entity_type=EntityType.PLAYER)
+    db_session.add(e)
+    return e
+
+
+def _seed_map(
+    db_session,
+    *,
+    match_date: datetime,
+    team1_players: list[Entity],
+    team2_players: list[Entity],
+    vlr_match_id: str | None = None,
+) -> uuid.UUID:
+    """Seed one match + one map with the supplied rosters per side."""
+    match = Match(
+        match_id=uuid.uuid4(),
+        vlr_match_id=vlr_match_id or f"m-{uuid.uuid4().hex[:10]}",
+        match_date=match_date,
+    )
+    db_session.add(match)
+    db_session.flush()
+
+    mr = MapResult(
+        map_result_id=uuid.uuid4(),
+        match_id=match.match_id,
+        vlr_game_id=f"g-{uuid.uuid4().hex[:10]}",
+        vlr_map_id=1,
+        team1_rounds=13,
+        team2_rounds=10,
+        team1_atk_rounds=7,
+        team1_def_rounds=6,
+        team2_atk_rounds=4,
+        team2_def_rounds=6,
+        team1_stats={},
+        team2_stats={},
+    )
+    db_session.add(mr)
+    db_session.flush()
+
+    for side, roster in (("team1", team1_players), ("team2", team2_players)):
+        for player in roster:
+            db_session.add(
+                PlayerMatchStat(
+                    player_match_stat_id=uuid.uuid4(),
+                    map_result_id=mr.map_result_id,
+                    entity_id=player.canonical_id,
+                    source="vlr",
+                    source_player_id=str(player.canonical_id),
+                    team_side=side,
+                )
+            )
+    db_session.flush()
+    return mr.map_result_id
+
+
+def _canonical_pair(a: Entity, b: Entity) -> tuple[uuid.UUID, uuid.UUID]:
+    if a.canonical_id < b.canonical_id:
+        return (a.canonical_id, b.canonical_id)
+    return (b.canonical_id, a.canonical_id)
+
+
+def test_bootstrap_emits_one_edge_per_former_teammate_pair(db_session) -> None:
+    """Acceptance pin: every pair of former teammates has an edge."""
+    p1 = _make_player(db_session)
+    p2 = _make_player(db_session)
+    p3 = _make_player(db_session)
+    p4 = _make_player(db_session)
+    p5 = _make_player(db_session)
+    opp_a = _make_player(db_session)
+    opp_b = _make_player(db_session)
+    opp_c = _make_player(db_session)
+    opp_d = _make_player(db_session)
+    opp_e = _make_player(db_session)
+    db_session.flush()
+
+    now = datetime(2026, 5, 1, tzinfo=UTC)
+
+    _seed_map(
+        db_session,
+        match_date=now - timedelta(days=10),
+        team1_players=[p1, p2, p3, p4, p5],
+        team2_players=[opp_a, opp_b, opp_c, opp_d, opp_e],
+    )
+
+    manifest = bootstrap_teammate_edges(db_session, reference_timestamp=now)
+
+    # 5 teammate roster -> C(5, 2) = 10 internal pairs per side -> 20 total.
+    assert manifest.pairs_seen == 20
+    assert manifest.total_edges == 20
+
+    edges = db_session.execute(select(RelationshipEdge)).scalars().all()
+    assert len(edges) == 20
+
+    # Every directed pair we expect appears exactly once, canonicalised
+    # so the unordered pair is keyed unambiguously.
+    expected_pairs = set()
+    for roster in ([p1, p2, p3, p4, p5], [opp_a, opp_b, opp_c, opp_d, opp_e]):
+        for i in range(len(roster)):
+            for j in range(i + 1, len(roster)):
+                expected_pairs.add(_canonical_pair(roster[i], roster[j]))
+
+    actual_pairs = {(e.src_id, e.dst_id) for e in edges}
+    assert actual_pairs == expected_pairs
+
+
+def test_bootstrap_distinguishes_recent_teammate_from_ex_teammate(db_session) -> None:
+    """Recent shared maps -> TEAMMATE; older shared maps -> EX_TEAMMATE."""
+    current_a = _make_player(db_session)
+    current_b = _make_player(db_session)
+    historic_a = _make_player(db_session)
+    historic_b = _make_player(db_session)
+    db_session.flush()
+
+    now = datetime(2026, 5, 1, tzinfo=UTC)
+
+    # current pair: well within the recency threshold.
+    _seed_map(
+        db_session,
+        match_date=now - timedelta(days=5),
+        team1_players=[current_a, current_b],
+        team2_players=[],
+    )
+    # historic pair: pushed past the cutoff so they fall into EX_TEAMMATE.
+    _seed_map(
+        db_session,
+        match_date=now - timedelta(days=RECENT_TEAMMATE_DAYS + 30),
+        team1_players=[historic_a, historic_b],
+        team2_players=[],
+    )
+
+    manifest = bootstrap_teammate_edges(db_session, reference_timestamp=now)
+
+    assert manifest.teammate_edges_inserted == 1
+    assert manifest.ex_teammate_edges_inserted == 1
+
+    by_kind: dict[RelationshipEdgeType, list[RelationshipEdge]] = {}
+    for edge in db_session.execute(select(RelationshipEdge)).scalars().all():
+        by_kind.setdefault(edge.edge_type, []).append(edge)
+
+    assert RelationshipEdgeType.TEAMMATE in by_kind
+    assert RelationshipEdgeType.EX_TEAMMATE in by_kind
+
+    teammate_pair = {
+        by_kind[RelationshipEdgeType.TEAMMATE][0].src_id,
+        by_kind[RelationshipEdgeType.TEAMMATE][0].dst_id,
+    }
+    assert teammate_pair == {current_a.canonical_id, current_b.canonical_id}
+
+
+def test_bootstrap_canonicalises_symmetric_pair_endpoints(db_session) -> None:
+    """For symmetric kinds the migration's CHECK enforces ``src < dst``;
+    the bootstrap canonicalises before insert so that constraint never
+    trips."""
+    a = _make_player(db_session)
+    b = _make_player(db_session)
+    db_session.flush()
+
+    _seed_map(
+        db_session,
+        match_date=datetime(2026, 4, 1, tzinfo=UTC),
+        team1_players=[a, b],
+        team2_players=[],
+    )
+
+    bootstrap_teammate_edges(db_session, reference_timestamp=datetime(2026, 5, 1, tzinfo=UTC))
+
+    edge = db_session.execute(select(RelationshipEdge)).scalar_one()
+    assert edge.src_id < edge.dst_id
+
+
+def test_bootstrap_strength_saturates_with_more_shared_maps(db_session) -> None:
+    """A pair that played a single map together has a smaller strength
+    than one with a season's worth of co-play. The saturating linear
+    formula caps at 1.0."""
+    one_off_a = _make_player(db_session)
+    one_off_b = _make_player(db_session)
+    veteran_a = _make_player(db_session)
+    veteran_b = _make_player(db_session)
+    db_session.flush()
+
+    now = datetime(2026, 5, 1, tzinfo=UTC)
+
+    # one shared map for the one-off pair.
+    _seed_map(
+        db_session,
+        match_date=now - timedelta(days=10),
+        team1_players=[one_off_a, one_off_b],
+        team2_players=[],
+    )
+    # 30 shared maps for the veteran pair (well past saturation).
+    for i in range(30):
+        _seed_map(
+            db_session,
+            match_date=now - timedelta(days=10 + i),
+            team1_players=[veteran_a, veteran_b],
+            team2_players=[],
+        )
+
+    bootstrap_teammate_edges(db_session, reference_timestamp=now)
+
+    edges_by_pair = {
+        frozenset({e.src_id, e.dst_id}): e
+        for e in db_session.execute(select(RelationshipEdge)).scalars().all()
+    }
+    one_off_edge = edges_by_pair[frozenset({one_off_a.canonical_id, one_off_b.canonical_id})]
+    veteran_edge = edges_by_pair[frozenset({veteran_a.canonical_id, veteran_b.canonical_id})]
+
+    assert one_off_edge.strength < veteran_edge.strength
+    assert veteran_edge.strength == pytest.approx(1.0)
+
+
+def test_bootstrap_is_idempotent(db_session) -> None:
+    """Re-running the seed on an already-populated DB updates in place
+    rather than colliding on the unique constraint."""
+    a = _make_player(db_session)
+    b = _make_player(db_session)
+    db_session.flush()
+
+    _seed_map(
+        db_session,
+        match_date=datetime(2026, 4, 1, tzinfo=UTC),
+        team1_players=[a, b],
+        team2_players=[],
+    )
+
+    first = bootstrap_teammate_edges(
+        db_session, reference_timestamp=datetime(2026, 5, 1, tzinfo=UTC)
+    )
+    second = bootstrap_teammate_edges(
+        db_session, reference_timestamp=datetime(2026, 5, 1, tzinfo=UTC)
+    )
+
+    assert first.total_edges == 1
+    assert second.total_edges == 0  # nothing new inserted
+    assert second.edges_updated == 1
+
+    edges = db_session.execute(select(RelationshipEdge)).scalars().all()
+    assert len(edges) == 1
+
+
+def test_bootstrap_handles_kind_flip_on_rerun(db_session) -> None:
+    """If a fresh ingest moves a pair's most-recent shared map into the
+    recent window, a re-run swaps the edge from ex-teammate to
+    teammate without colliding on the unique constraint."""
+    a = _make_player(db_session)
+    b = _make_player(db_session)
+    db_session.flush()
+
+    older = datetime(2026, 1, 1, tzinfo=UTC)
+    refresh_ref = datetime(2026, 5, 1, tzinfo=UTC)
+
+    # First seed: only an old map, so the pair lands as ex-teammate.
+    _seed_map(
+        db_session,
+        match_date=older,
+        team1_players=[a, b],
+        team2_players=[],
+    )
+    bootstrap_teammate_edges(db_session, reference_timestamp=refresh_ref)
+    initial = db_session.execute(select(RelationshipEdge)).scalar_one()
+    assert initial.edge_type is RelationshipEdgeType.EX_TEAMMATE
+
+    # Fresh map within the recency window arrives.
+    _seed_map(
+        db_session,
+        match_date=refresh_ref - timedelta(days=5),
+        team1_players=[a, b],
+        team2_players=[],
+    )
+    bootstrap_teammate_edges(db_session, reference_timestamp=refresh_ref)
+
+    after = db_session.execute(select(RelationshipEdge)).scalar_one()
+    assert after.edge_type is RelationshipEdgeType.TEAMMATE

--- a/services/data_pipeline/tests/test_relationship_bootstrap.py
+++ b/services/data_pipeline/tests/test_relationship_bootstrap.py
@@ -479,3 +479,79 @@ def test_bootstrap_consolidation_path_preserves_event_audit_trail(db_session) ->
     events = db_session.execute(select(RelationshipEvent)).scalars().all()
     assert {e.event_kind for e in events} == {"legacy_feud", "recent_clutch"}
     assert all(e.edge_id == teammate_edge.edge_id for e in events)
+
+
+def test_bootstrap_rerun_preserves_event_evolved_strength_and_anchor(db_session) -> None:
+    """Codex P1 (PR #28, 3rd round): once a post-bootstrap writer has
+    advanced ``last_updated_at`` past the match-history baseline (an
+    event was folded in, or the monthly decay job ran), the rerun
+    must NOT re-derive ``strength`` from shared-map count or rewind
+    the anchor — both moves would wipe the writer's adjustments and
+    cause the next decay pass to over-apply elapsed weeks."""
+    a = _make_player(db_session)
+    b = _make_player(db_session)
+    db_session.flush()
+
+    last_match_at = datetime(2026, 4, 1, tzinfo=UTC)
+    _seed_map(
+        db_session,
+        match_date=last_match_at,
+        team1_players=[a, b],
+        team2_players=[],
+    )
+    bootstrap_teammate_edges(db_session, reference_timestamp=datetime(2026, 5, 1, tzinfo=UTC))
+    edge = db_session.execute(select(RelationshipEdge)).scalar_one()
+
+    # Simulate a post-bootstrap event-driven writer: a delta_strength
+    # was folded in and the anchor was advanced past the match-history
+    # baseline (the contract on ``last_updated_at`` per the model
+    # docstring).
+    bumped_strength = 0.85
+    bumped_anchor = last_match_at + timedelta(days=7)
+    edge.strength = bumped_strength
+    edge.last_updated_at = bumped_anchor
+    db_session.flush()
+
+    bootstrap_teammate_edges(db_session, reference_timestamp=datetime(2026, 5, 1, tzinfo=UTC))
+    refreshed = db_session.execute(select(RelationshipEdge)).scalar_one()
+    assert refreshed.strength == pytest.approx(bumped_strength)
+    assert refreshed.last_updated_at == bumped_anchor
+
+
+def test_bootstrap_rerun_refreshes_strength_when_no_event_writer_has_taken_over(
+    db_session,
+) -> None:
+    """Counterpart to the preservation test: if the existing edge is
+    still anchored at the bootstrap baseline (``last_updated_at <=
+    acc.last_match_at``), a fresh ingest with more shared maps should
+    legitimately refresh ``strength``."""
+    a = _make_player(db_session)
+    b = _make_player(db_session)
+    db_session.flush()
+
+    early_match = datetime(2026, 4, 1, tzinfo=UTC)
+    _seed_map(
+        db_session,
+        match_date=early_match,
+        team1_players=[a, b],
+        team2_players=[],
+    )
+    bootstrap_teammate_edges(db_session, reference_timestamp=datetime(2026, 5, 1, tzinfo=UTC))
+    initial = db_session.execute(select(RelationshipEdge)).scalar_one()
+    initial_strength = initial.strength
+
+    # Fresh ingest brings more shared maps for the same pair; the
+    # event-driven path has not touched the edge.
+    for i in range(5):
+        _seed_map(
+            db_session,
+            match_date=early_match + timedelta(days=i + 1),
+            team1_players=[a, b],
+            team2_players=[],
+        )
+
+    bootstrap_teammate_edges(db_session, reference_timestamp=datetime(2026, 5, 1, tzinfo=UTC))
+    refreshed = db_session.execute(select(RelationshipEdge)).scalar_one()
+    assert refreshed.strength > initial_strength
+    # Anchor advances to the latest shared map.
+    assert refreshed.last_updated_at == early_match + timedelta(days=5)

--- a/services/data_pipeline/tests/test_relationship_bootstrap.py
+++ b/services/data_pipeline/tests/test_relationship_bootstrap.py
@@ -391,3 +391,91 @@ def test_bootstrap_kind_flip_preserves_event_audit_trail(db_session) -> None:
     assert len(events) == 1
     assert events[0].event_kind == "public_feud"
     assert events[0].edge_id == after.edge_id
+
+
+def test_bootstrap_consolidation_path_preserves_event_audit_trail(db_session) -> None:
+    """Codex P1 (2nd round, PR #28): defensive case where both teammate
+    kinds happen to coexist for the same pair. Re-parenting must move
+    the stale row's events onto the target *at the ORM level*; a bulk
+    SQL UPDATE alone leaves the in-memory ``stale.events`` collection
+    populated and the cascade-delete on ``stale`` would still wipe the
+    audit trail."""
+    a = _make_player(db_session)
+    b = _make_player(db_session)
+    db_session.flush()
+    src_id, dst_id = (
+        (a.canonical_id, b.canonical_id)
+        if a.canonical_id < b.canonical_id
+        else (b.canonical_id, a.canonical_id)
+    )
+
+    # Hand-construct the inconsistent state: both a TEAMMATE and an
+    # EX_TEAMMATE row for the same pair, each with its own event log.
+    teammate_edge = RelationshipEdge(
+        edge_id=uuid.uuid4(),
+        src_id=src_id,
+        dst_id=dst_id,
+        edge_type=RelationshipEdgeType.TEAMMATE,
+        strength=0.5,
+        sentiment=0.2,
+        last_updated_at=datetime(2026, 4, 1, tzinfo=UTC),
+        extra={},
+    )
+    ex_teammate_edge = RelationshipEdge(
+        edge_id=uuid.uuid4(),
+        src_id=src_id,
+        dst_id=dst_id,
+        edge_type=RelationshipEdgeType.EX_TEAMMATE,
+        strength=0.3,
+        sentiment=-0.4,
+        last_updated_at=datetime(2026, 1, 1, tzinfo=UTC),
+        extra={},
+    )
+    db_session.add_all([teammate_edge, ex_teammate_edge])
+    db_session.flush()
+
+    db_session.add_all(
+        [
+            RelationshipEvent(
+                event_id=uuid.uuid4(),
+                edge_id=ex_teammate_edge.edge_id,
+                event_kind="legacy_feud",
+                delta_strength=0.0,
+                delta_sentiment=-0.4,
+                occurred_at=datetime(2026, 2, 1, tzinfo=UTC),
+                payload={},
+            ),
+            RelationshipEvent(
+                event_id=uuid.uuid4(),
+                edge_id=teammate_edge.edge_id,
+                event_kind="recent_clutch",
+                delta_strength=0.1,
+                delta_sentiment=0.0,
+                occurred_at=datetime(2026, 4, 15, tzinfo=UTC),
+                payload={},
+            ),
+        ]
+    )
+    db_session.flush()
+
+    # Drive the bootstrap with a recent shared map so it converges on
+    # the TEAMMATE kind and has to consolidate the stale EX_TEAMMATE row.
+    refresh_ref = datetime(2026, 5, 1, tzinfo=UTC)
+    _seed_map(
+        db_session,
+        match_date=refresh_ref - timedelta(days=5),
+        team1_players=[a, b],
+        team2_players=[],
+    )
+    bootstrap_teammate_edges(db_session, reference_timestamp=refresh_ref)
+    db_session.flush()
+
+    # Only the target row survives, and both events are attached to it.
+    edges = db_session.execute(select(RelationshipEdge)).scalars().all()
+    assert len(edges) == 1
+    assert edges[0].edge_type is RelationshipEdgeType.TEAMMATE
+    assert edges[0].edge_id == teammate_edge.edge_id
+
+    events = db_session.execute(select(RelationshipEvent)).scalars().all()
+    assert {e.event_kind for e in events} == {"legacy_feud", "recent_clutch"}
+    assert all(e.edge_id == teammate_edge.edge_id for e in events)

--- a/services/data_pipeline/tests/test_relationship_bootstrap.py
+++ b/services/data_pipeline/tests/test_relationship_bootstrap.py
@@ -25,6 +25,7 @@ from esports_sim.db.models import (
     Match,
     PlayerMatchStat,
     RelationshipEdge,
+    RelationshipEvent,
 )
 from sqlalchemy import select
 
@@ -305,3 +306,88 @@ def test_bootstrap_handles_kind_flip_on_rerun(db_session) -> None:
 
     after = db_session.execute(select(RelationshipEdge)).scalar_one()
     assert after.edge_type is RelationshipEdgeType.TEAMMATE
+
+
+def test_bootstrap_rerun_preserves_post_bootstrap_sentiment(db_session) -> None:
+    """Codex P1 (PR #28): an event-driven writer may have evolved the
+    valence past the +1.0 bootstrap default. A re-run must refresh
+    strength + audit metadata without clobbering that learned
+    sentiment."""
+    a = _make_player(db_session)
+    b = _make_player(db_session)
+    db_session.flush()
+
+    _seed_map(
+        db_session,
+        match_date=datetime(2026, 4, 1, tzinfo=UTC),
+        team1_players=[a, b],
+        team2_players=[],
+    )
+    bootstrap_teammate_edges(db_session, reference_timestamp=datetime(2026, 5, 1, tzinfo=UTC))
+
+    edge = db_session.execute(select(RelationshipEdge)).scalar_one()
+    # Simulate a downstream event-driven writer evolving the valence
+    # below the bootstrap default (a feud broke out post-bootstrap).
+    edge.sentiment = -0.4
+    db_session.flush()
+
+    bootstrap_teammate_edges(db_session, reference_timestamp=datetime(2026, 5, 1, tzinfo=UTC))
+    refreshed = db_session.execute(select(RelationshipEdge)).scalar_one()
+    assert refreshed.sentiment == pytest.approx(-0.4)
+
+
+def test_bootstrap_kind_flip_preserves_event_audit_trail(db_session) -> None:
+    """Codex P1 (PR #28): ``relationship_event`` cascades on the parent
+    edge's delete. A naive delete-and-reinsert on a kind flip would
+    wipe the append-only audit log; the in-place mutation keeps the
+    history."""
+    a = _make_player(db_session)
+    b = _make_player(db_session)
+    db_session.flush()
+
+    older = datetime(2026, 1, 1, tzinfo=UTC)
+    refresh_ref = datetime(2026, 5, 1, tzinfo=UTC)
+
+    _seed_map(
+        db_session,
+        match_date=older,
+        team1_players=[a, b],
+        team2_players=[],
+    )
+    bootstrap_teammate_edges(db_session, reference_timestamp=refresh_ref)
+    initial = db_session.execute(select(RelationshipEdge)).scalar_one()
+    assert initial.edge_type is RelationshipEdgeType.EX_TEAMMATE
+
+    # An event-driven writer logs a post-bootstrap signal against this
+    # edge — exactly the audit-trail row Codex's review flagged.
+    db_session.add(
+        RelationshipEvent(
+            event_id=uuid.uuid4(),
+            edge_id=initial.edge_id,
+            event_kind="public_feud",
+            delta_strength=0.0,
+            delta_sentiment=-0.5,
+            occurred_at=older + timedelta(days=30),
+            payload={"source": "test"},
+        )
+    )
+    db_session.flush()
+
+    # Fresh recent map flips the kind; the event log must survive.
+    _seed_map(
+        db_session,
+        match_date=refresh_ref - timedelta(days=5),
+        team1_players=[a, b],
+        team2_players=[],
+    )
+    bootstrap_teammate_edges(db_session, reference_timestamp=refresh_ref)
+
+    after = db_session.execute(select(RelationshipEdge)).scalar_one()
+    assert after.edge_type is RelationshipEdgeType.TEAMMATE
+    # The event_id-stable check: the row that was attached to the
+    # ex-teammate edge is now attached to the same (mutated) edge —
+    # we keep the same edge_id so the audit trail is contiguous.
+    events = db_session.execute(select(RelationshipEvent)).scalars().all()
+    assert len(events) == 1
+    assert events[0].event_kind == "public_feud"
+    assert events[0].edge_id == after.edge_id

--- a/services/ecosystem/src/ecosystem/relationships/__init__.py
+++ b/services/ecosystem/src/ecosystem/relationships/__init__.py
@@ -1,0 +1,48 @@
+"""Pairwise relationships with sentiment + exponential decay (BUF-26, System 07).
+
+The substrate for every "who likes whom" question the ecosystem sim
+needs to answer: ex-teammate goodwill that lingers for years, a rivalry
+that bleeds out without fresh feuds, a mentor-mentee bond whose
+strength erodes when the two stop scrimming together. The schema
+(:class:`esports_sim.db.models.RelationshipEdge` +
+:class:`esports_sim.db.models.RelationshipEvent`) carries the data;
+this package owns the decay math and the steady-state job that applies
+it.
+
+Exports:
+
+* :data:`DECAY_RATES` — per-edge-type exponential decay rate, in units
+  of ``1 / week``. The dict is the load-bearing lookup the spec calls
+  for; bumping a value is a downstream-feature event because the
+  decayed strengths feed the GNN's edge weights.
+* :func:`decay_strength` — pure scalar function. Given a starting
+  strength, an edge type, and a number of weeks elapsed, returns the
+  decayed strength. This is the function the regression test pins.
+* :func:`decay_edge` — applies :func:`decay_strength` to a
+  :class:`RelationshipEdge` in place and bumps ``last_updated_at``.
+  Sentiment is left untouched (valence does not decay).
+* :func:`run_monthly_decay` — the operator-facing job that reads every
+  edge, applies decay, and persists. Intended to run on a monthly
+  cadence (cron / scheduler hook); idempotent to re-run because the
+  ``last_updated_at`` anchor moves forward each pass.
+"""
+
+from __future__ import annotations
+
+from ecosystem.relationships.decay import (
+    DECAY_RATES,
+    DecayError,
+    decay_edge,
+    decay_strength,
+    run_monthly_decay,
+    weeks_between,
+)
+
+__all__ = [
+    "DECAY_RATES",
+    "DecayError",
+    "decay_edge",
+    "decay_strength",
+    "run_monthly_decay",
+    "weeks_between",
+]

--- a/services/ecosystem/src/ecosystem/relationships/decay.py
+++ b/services/ecosystem/src/ecosystem/relationships/decay.py
@@ -1,0 +1,215 @@
+"""Exponential decay of :class:`RelationshipEdge` strength over time.
+
+System 07's load-bearing claim: a relationship without fresh signal
+fades. The math is the simplest model that respects the obvious
+constraints (monotone decreasing, multiplicative composition over
+sub-intervals, parameterised per edge kind):
+
+.. math::
+
+    s(t + \\Delta t) = s(t) \\cdot e^{-r \\cdot \\Delta t}
+
+where ``r`` is :data:`DECAY_RATES` ``[edge_type]`` (units: ``1 /
+week``) and ``Δt`` is the elapsed time in weeks.
+
+Two decay reads of the same edge over disjoint intervals compose to
+the same result as a single read across the union — that's what makes
+the monthly job idempotent under jitter. The
+:func:`run_monthly_decay` job advances ``last_updated_at`` to ``now``
+so the next pass measures from the refreshed anchor.
+
+Sentiment does **not** decay. Valence is a permanent feature of the
+relationship; an ex-teammate keeps positive sentiment after their
+strength has bled out, and a feud rival keeps negative sentiment
+through the same window. Only the magnitude (``strength``) is
+time-eroding.
+"""
+
+from __future__ import annotations
+
+import logging
+import math
+from collections.abc import Mapping
+from datetime import datetime
+
+from esports_sim.db.enums import RelationshipEdgeType
+from esports_sim.db.models import RelationshipEdge
+from sqlalchemy import select
+from sqlalchemy.orm import Session
+
+_logger = logging.getLogger("ecosystem.relationships.decay")
+
+
+class DecayError(ValueError):
+    """Raised when :func:`decay_strength` is asked to operate on an unknown edge type.
+
+    Better to fail loudly here than to fall back to a default rate and
+    silently let edge weights drift in production. Adding a new edge
+    kind requires a coordinated update to
+    :class:`RelationshipEdgeType`, the migration's ENUM list, and
+    :data:`DECAY_RATES`; missing the third surfaces here.
+    """
+
+
+# Per-edge-type decay rates in units of ``1 / week``. The half-life
+# implied by each rate is ``ln(2) / r``:
+#
+# * teammate (0.020) ≈ 35-week half-life — a current-roster bond stays
+#   strong through a season, slowly fades across the off-season if the
+#   pair stops sharing scrims.
+# * ex_teammate (0.010) ≈ 69-week half-life — bonds that survive a
+#   roster move take more than a year to lose half their pull.
+# * rival (0.015) ≈ 46-week half-life — rivalries cool faster than
+#   ex-teammate bonds when no new feud signal lands.
+# * friend (0.012) ≈ 58-week half-life — close to ex-teammate; the
+#   social tie outlives the professional one.
+# * mentor (0.005) ≈ 139-week half-life — coach / mentor bonds are
+#   the slowest to fade; the relationship persists even in long
+#   silences.
+# * manager_of (0.008) ≈ 87-week half-life — operational bonds
+#   between a manager and a team member fall in between.
+#
+# Tuning these is a downstream-feature event: the GNN's edge weights
+# (:mod:`ecosystem.graph.builder`) read the decayed strengths, so a
+# rate change that lands without re-decay produces a torn snapshot
+# where some edges measured against the old rate and others against
+# the new. Bump the schema version on
+# :data:`ecosystem.graph.schema.SCHEMA_VERSION` when changing these.
+DECAY_RATES: Mapping[RelationshipEdgeType, float] = {
+    RelationshipEdgeType.TEAMMATE: 0.020,
+    RelationshipEdgeType.EX_TEAMMATE: 0.010,
+    RelationshipEdgeType.RIVAL: 0.015,
+    RelationshipEdgeType.FRIEND: 0.012,
+    RelationshipEdgeType.MENTOR: 0.005,
+    RelationshipEdgeType.MANAGER_OF: 0.008,
+}
+
+
+# Number of seconds in one week. Hardcoded so the implementation
+# doesn't pull in ``timedelta`` for what is effectively a constant; the
+# accuracy of ``Δt`` in weeks is the only thing the math depends on.
+_SECONDS_PER_WEEK: float = 7.0 * 24.0 * 3600.0
+
+
+def weeks_between(earlier: datetime, later: datetime) -> float:
+    """Return ``later - earlier`` in fractional weeks, never negative.
+
+    A clock skew or out-of-order writer that produces ``later <
+    earlier`` would otherwise grow strength on the next decay pass —
+    explicitly clamped to zero so that case is a no-op rather than a
+    silent corruption.
+    """
+    delta = (later - earlier).total_seconds()
+    if delta <= 0:
+        return 0.0
+    return delta / _SECONDS_PER_WEEK
+
+
+def decay_strength(
+    strength: float,
+    *,
+    edge_type: RelationshipEdgeType,
+    weeks: float,
+) -> float:
+    """Apply ``strength * exp(-rate * weeks)`` for ``edge_type``'s rate.
+
+    Pure function — no side effects, no DB access. The regression
+    test for BUF-26's acceptance pins this directly: an edge with
+    ``strength = 1.0`` and ``weeks = 20`` and the TEAMMATE rate
+    decays to ``exp(-0.4) ≈ 0.6703200460356393``.
+
+    Negative ``weeks`` is treated as a no-op (returns the input
+    unchanged) — the same clamp :func:`weeks_between` applies. The
+    result is also clamped into ``[0, 1]`` so floating-point fuzz
+    around the boundary cannot trip the column's CHECK constraint.
+    """
+    if not 0.0 <= strength <= 1.0:
+        raise DecayError(
+            f"strength={strength!r} is outside the [0, 1] range; "
+            "the column's CHECK constraint guards this in the DB."
+        )
+    if weeks <= 0:
+        return strength
+    try:
+        rate = DECAY_RATES[edge_type]
+    except KeyError as e:
+        raise DecayError(
+            f"no DECAY_RATES entry for edge_type={edge_type!r}; "
+            f"known: {sorted(t.value for t in DECAY_RATES)}"
+        ) from e
+    decayed = strength * math.exp(-rate * weeks)
+    # Clamp to the column's CHECK range. ``exp(-rate * weeks)`` is
+    # bounded in ``(0, 1]`` for non-negative inputs so this is a
+    # belt-and-braces guard against floating-point fuzz.
+    if decayed < 0.0:
+        return 0.0
+    if decayed > 1.0:
+        return 1.0
+    return decayed
+
+
+def decay_edge(edge: RelationshipEdge, *, now: datetime) -> RelationshipEdge:
+    """Apply decay to ``edge`` in place and advance ``last_updated_at``.
+
+    The returned reference is the same instance — the helper is a
+    mutator, not a constructor. ``sentiment`` is left untouched.
+    Re-calling on the same edge is a no-op once the anchor has been
+    moved forward to ``now``, which is what makes
+    :func:`run_monthly_decay` idempotent under jitter.
+
+    The caller is responsible for the ORM session bookkeeping — this
+    function just mutates the in-memory row. ``run_monthly_decay``
+    composes them.
+    """
+    weeks = weeks_between(edge.last_updated_at, now)
+    if weeks == 0.0:
+        # The anchor is already at-or-ahead of ``now``. Don't move it
+        # backward; just no-op.
+        return edge
+    edge.strength = decay_strength(
+        edge.strength,
+        edge_type=edge.edge_type,
+        weeks=weeks,
+    )
+    edge.last_updated_at = now
+    return edge
+
+
+def run_monthly_decay(
+    session: Session,
+    *,
+    now: datetime,
+) -> int:
+    """Apply :func:`decay_edge` to every row in ``relationship_edge``.
+
+    Returns the count of edges touched. Intended cadence is monthly,
+    but the function itself is cadence-agnostic — calling it twice in
+    quick succession is harmless because the anchor moves forward each
+    pass and the second call sees zero elapsed weeks.
+
+    The implementation walks the table in Python rather than issuing a
+    bulk UPDATE for two reasons:
+
+    1. ``DECAY_RATES`` is a Python dict; the per-type rate would have
+       to be folded into the SQL via a CASE per kind, which doesn't
+       generalise as the kind set grows.
+    2. The monthly volume is small (one row per pair-kind, bounded by
+       roster turnover) — Python-side iteration is operationally
+       cheaper than maintaining a bespoke UPDATE statement.
+
+    The caller owns the transaction. We do **not** commit here so the
+    job can compose with sibling work in the same session.
+    """
+    rows = session.execute(select(RelationshipEdge)).scalars().all()
+    touched = 0
+    for edge in rows:
+        previous_strength = edge.strength
+        decay_edge(edge, now=now)
+        if edge.strength != previous_strength or edge.last_updated_at == now:
+            touched += 1
+    _logger.info(
+        "monthly_decay applied",
+        extra={"edges_touched": touched, "total_edges": len(rows)},
+    )
+    session.flush()
+    return touched

--- a/services/ecosystem/src/ecosystem/relationships/decay.py
+++ b/services/ecosystem/src/ecosystem/relationships/decay.py
@@ -204,8 +204,15 @@ def run_monthly_decay(
     touched = 0
     for edge in rows:
         previous_strength = edge.strength
+        previous_anchor = edge.last_updated_at
         decay_edge(edge, now=now)
-        if edge.strength != previous_strength or edge.last_updated_at == now:
+        # Count only rows where decay actually moved state. The
+        # earlier ``or last_updated_at == now`` clause was true for
+        # rows already anchored at ``now`` from a prior pass — an
+        # immediate rerun would log work that didn't happen and
+        # break the function's idempotence signal (Codex P2 on PR
+        # #28).
+        if edge.strength != previous_strength or edge.last_updated_at != previous_anchor:
             touched += 1
     _logger.info(
         "monthly_decay applied",

--- a/services/ecosystem/tests/test_relationship_decay.py
+++ b/services/ecosystem/tests/test_relationship_decay.py
@@ -1,0 +1,191 @@
+"""Unit tests for the BUF-26 relationship decay math.
+
+Pure-Python tests — no Postgres, no SQLAlchemy session. The integration
+tests for the bootstrap path live alongside the data-pipeline tests
+and require ``TEST_DATABASE_URL``.
+"""
+
+from __future__ import annotations
+
+import math
+import uuid
+from datetime import UTC, datetime, timedelta
+
+import pytest
+from ecosystem.relationships import (
+    DECAY_RATES,
+    DecayError,
+    decay_edge,
+    decay_strength,
+    weeks_between,
+)
+from esports_sim.db.enums import RelationshipEdgeType
+from esports_sim.db.models import RelationshipEdge
+
+
+def _make_edge(
+    *,
+    edge_type: RelationshipEdgeType = RelationshipEdgeType.TEAMMATE,
+    strength: float = 1.0,
+    sentiment: float = 1.0,
+    last_updated_at: datetime | None = None,
+) -> RelationshipEdge:
+    """In-memory edge for the pure-Python decay tests."""
+    return RelationshipEdge(
+        edge_id=uuid.uuid4(),
+        src_id=uuid.UUID(int=1),
+        dst_id=uuid.UUID(int=2),
+        edge_type=edge_type,
+        strength=strength,
+        sentiment=sentiment,
+        last_updated_at=last_updated_at or datetime(2026, 1, 1, tzinfo=UTC),
+        extra={},
+    )
+
+
+# ---- DECAY_RATES inventory pin ---------------------------------------------
+
+
+def test_decay_rates_cover_every_relationship_edge_type() -> None:
+    """The dict must have a rate for every enum value — a missing entry
+    raises :class:`DecayError` at runtime, which would block the monthly
+    job and is a much-worse failure mode than a startup mismatch."""
+    assert set(DECAY_RATES) == set(RelationshipEdgeType)
+
+
+@pytest.mark.parametrize("edge_type", list(RelationshipEdgeType))
+def test_every_decay_rate_is_strictly_positive(edge_type: RelationshipEdgeType) -> None:
+    """A non-positive rate would either freeze strength (rate=0) or grow
+    it back over time (rate<0). Both break the System 07 contract."""
+    assert DECAY_RATES[edge_type] > 0.0
+
+
+# ---- decay_strength regression --------------------------------------------
+
+
+def test_decay_strength_zero_weeks_is_identity() -> None:
+    assert decay_strength(0.7, edge_type=RelationshipEdgeType.TEAMMATE, weeks=0.0) == 0.7
+
+
+def test_decay_strength_negative_weeks_is_identity() -> None:
+    """A clock skew that produces ``weeks < 0`` must not grow strength."""
+    assert decay_strength(0.7, edge_type=RelationshipEdgeType.TEAMMATE, weeks=-5.0) == 0.7
+
+
+def test_decay_strength_zero_strength_stays_zero() -> None:
+    assert decay_strength(0.0, edge_type=RelationshipEdgeType.TEAMMATE, weeks=20.0) == 0.0
+
+
+def test_decay_strength_unknown_edge_type_raises() -> None:
+    """Passing a fabricated enum value (e.g. via getattr trickery in a
+    test) should fail loudly so a future kind addition without a rate
+    update doesn't silently degrade decay behaviour."""
+
+    class _Fake:
+        value = "fabricated_kind"
+
+    with pytest.raises(DecayError):
+        decay_strength(0.5, edge_type=_Fake(), weeks=1.0)  # type: ignore[arg-type]
+
+
+def test_decay_strength_rejects_strength_outside_unit_interval() -> None:
+    with pytest.raises(DecayError):
+        decay_strength(1.5, edge_type=RelationshipEdgeType.TEAMMATE, weeks=1.0)
+    with pytest.raises(DecayError):
+        decay_strength(-0.1, edge_type=RelationshipEdgeType.TEAMMATE, weeks=1.0)
+
+
+def test_decay_strength_teammate_20_weeks_acceptance_regression() -> None:
+    """BUF-26 acceptance: edge with strength=1.0 and no signal for 20
+    weeks decays to the expected exponential value."""
+    rate = DECAY_RATES[RelationshipEdgeType.TEAMMATE]
+    expected = math.exp(-rate * 20)
+    actual = decay_strength(
+        1.0,
+        edge_type=RelationshipEdgeType.TEAMMATE,
+        weeks=20.0,
+    )
+    # Pin both the closed-form expected value and the numerical
+    # constant so a future tweak to ``DECAY_RATES`` produces a
+    # localised test failure rather than a slow regression.
+    assert actual == pytest.approx(expected, abs=1e-12)
+    assert actual == pytest.approx(0.6703200460356393, abs=1e-12)
+
+
+def test_decay_strength_composes_over_disjoint_intervals() -> None:
+    """Two decay applications over (a, b) and (b, c) compose to one
+    decay over (a, c). This is what makes the monthly job idempotent
+    under jitter — a 4.7-week gap and a 30.3-week gap give the same
+    result as one 35-week gap."""
+    edge_type = RelationshipEdgeType.RIVAL
+    one_shot = decay_strength(1.0, edge_type=edge_type, weeks=12.0)
+    composed = decay_strength(
+        decay_strength(1.0, edge_type=edge_type, weeks=4.7),
+        edge_type=edge_type,
+        weeks=7.3,
+    )
+    assert composed == pytest.approx(one_shot, abs=1e-12)
+
+
+def test_decay_strength_clamps_to_unit_interval() -> None:
+    """The result is always inside ``[0, 1]`` so the column's CHECK
+    constraint can never trip from floating-point fuzz."""
+    out = decay_strength(1.0, edge_type=RelationshipEdgeType.MENTOR, weeks=520.0)
+    assert 0.0 <= out <= 1.0
+
+
+# ---- decay_edge mutator ---------------------------------------------------
+
+
+def test_decay_edge_advances_anchor_and_decays_strength() -> None:
+    anchor = datetime(2026, 1, 1, tzinfo=UTC)
+    now = anchor + timedelta(weeks=20)
+    edge = _make_edge(strength=1.0, last_updated_at=anchor)
+
+    decay_edge(edge, now=now)
+
+    rate = DECAY_RATES[RelationshipEdgeType.TEAMMATE]
+    assert edge.strength == pytest.approx(math.exp(-rate * 20), abs=1e-12)
+    assert edge.last_updated_at == now
+
+
+def test_decay_edge_leaves_sentiment_alone() -> None:
+    """Sentiment is permanent valence; strength decays and sentiment
+    survives across the same window."""
+    edge = _make_edge(strength=1.0, sentiment=-0.7)
+    decay_edge(edge, now=edge.last_updated_at + timedelta(weeks=40))
+    assert edge.sentiment == -0.7
+
+
+def test_decay_edge_is_idempotent_when_now_matches_anchor() -> None:
+    edge = _make_edge(strength=0.42)
+    decay_edge(edge, now=edge.last_updated_at)
+    assert edge.strength == 0.42
+
+
+def test_decay_edge_does_not_move_anchor_backward() -> None:
+    """A clock skew where ``now`` is earlier than ``last_updated_at``
+    is a no-op; we never grow strength back from a negative gap."""
+    anchor = datetime(2026, 4, 1, tzinfo=UTC)
+    earlier = anchor - timedelta(weeks=2)
+    edge = _make_edge(strength=0.5, last_updated_at=anchor)
+
+    decay_edge(edge, now=earlier)
+
+    assert edge.strength == 0.5
+    assert edge.last_updated_at == anchor
+
+
+# ---- weeks_between sanity --------------------------------------------------
+
+
+def test_weeks_between_clamps_negative_intervals_to_zero() -> None:
+    a = datetime(2026, 1, 1, tzinfo=UTC)
+    b = datetime(2025, 12, 1, tzinfo=UTC)
+    assert weeks_between(a, b) == 0.0
+
+
+def test_weeks_between_returns_fractional_weeks() -> None:
+    a = datetime(2026, 1, 1, tzinfo=UTC)
+    b = a + timedelta(days=10, hours=12)
+    assert weeks_between(a, b) == pytest.approx(10.5 / 7.0, abs=1e-12)

--- a/services/ecosystem/tests/test_relationship_decay.py
+++ b/services/ecosystem/tests/test_relationship_decay.py
@@ -17,6 +17,7 @@ from ecosystem.relationships import (
     DecayError,
     decay_edge,
     decay_strength,
+    run_monthly_decay,
     weeks_between,
 )
 from esports_sim.db.enums import RelationshipEdgeType
@@ -189,3 +190,68 @@ def test_weeks_between_returns_fractional_weeks() -> None:
     a = datetime(2026, 1, 1, tzinfo=UTC)
     b = a + timedelta(days=10, hours=12)
     assert weeks_between(a, b) == pytest.approx(10.5 / 7.0, abs=1e-12)
+
+
+# ---- run_monthly_decay touched-counter contract ---------------------------
+
+
+class _StubSession:
+    """Minimal SA-shaped session stub for the touched-counter unit test.
+
+    Only implements the surface ``run_monthly_decay`` actually exercises:
+    ``execute(...).scalars().all()`` and ``flush()``. Avoids the Postgres
+    fixture dependency for what is a pure-Python invariant.
+    """
+
+    def __init__(self, edges: list[RelationshipEdge]) -> None:
+        self._edges = edges
+
+    def execute(self, _statement: object) -> _StubSession:
+        return self
+
+    def scalars(self) -> _StubSession:
+        return self
+
+    def all(self) -> list[RelationshipEdge]:
+        return self._edges
+
+    def flush(self) -> None:
+        return None
+
+
+def test_run_monthly_decay_does_not_count_idempotent_rerun() -> None:
+    """Codex P2 (PR #28): on an immediate re-run with the same ``now``,
+    ``decay_edge`` is a no-op and the touched-counter must report 0.
+    The earlier ``or last_updated_at == now`` clause was true even for
+    rows the job did not actually move."""
+    anchor = datetime(2026, 1, 1, tzinfo=UTC)
+    later = anchor + timedelta(weeks=4)
+    edges = [_make_edge(strength=1.0, last_updated_at=anchor)]
+    session = _StubSession(edges)
+
+    first = run_monthly_decay(session, now=later)  # type: ignore[arg-type]
+    assert first == 1
+    assert edges[0].last_updated_at == later
+    assert edges[0].strength < 1.0
+
+    second = run_monthly_decay(session, now=later)  # type: ignore[arg-type]
+    assert second == 0
+
+
+def test_run_monthly_decay_counts_only_actually_decayed_edges() -> None:
+    """Mixed batch: a fresh edge plus an already-anchored edge. Only the
+    fresh one moves, so the count is 1 even though the job sees both."""
+    now = datetime(2026, 5, 1, tzinfo=UTC)
+    fresh_edge = _make_edge(
+        strength=1.0,
+        last_updated_at=now - timedelta(weeks=8),
+    )
+    already_anchored = _make_edge(
+        strength=0.42,
+        last_updated_at=now,
+    )
+    session = _StubSession([fresh_edge, already_anchored])
+
+    touched = run_monthly_decay(session, now=now)  # type: ignore[arg-type]
+    assert touched == 1
+    assert already_anchored.strength == 0.42  # unchanged


### PR DESCRIPTION
## Summary

Lands the System 07 substrate: pairwise canonical-entity edges with both a magnitude (`strength`, decays exponentially with no signal) and a permanent valence (`sentiment`, never decays).

- **Schema** (`packages/shared/`):
  - `relationship_edge` + `relationship_event` SQLAlchemy models, `relationship_edge_type` Postgres ENUM, alembic migration 0010.
  - Symmetric kinds (teammate, ex-teammate, rival, friend) are pinned to `src_id < dst_id` via a CHECK constraint so each pair owns at most one row of that type. Asymmetric kinds (mentor, manager_of) keep direction.
  - DB-level CHECKs clamp `strength ∈ [0, 1]` and `sentiment ∈ [-1, 1]`.

- **Decay** (`services/ecosystem/src/ecosystem/relationships/`):
  - `DECAY_RATES` dict — per-edge-type exponential decay rate in units of `1 / week`.
  - `decay_strength(strength, edge_type, weeks)` — pure scalar function: `strength * exp(-rate * weeks)`. Composes over disjoint intervals so the monthly job is idempotent under jitter.
  - `decay_edge(edge, now)` — mutator that applies decay and advances `last_updated_at`. Sentiment is untouched.
  - `run_monthly_decay(session, now)` — operator-facing job that walks the table and applies decay; caller owns the transaction.

- **Bootstrap** (`services/data_pipeline/src/data_pipeline/seeds/relationships.py`):
  - `bootstrap_teammate_edges(session, ...)` walks `PlayerMatchStat ⨝ MapResult ⨝ Match`, groups by `(map_result_id, team_side)` to recover per-map rosters, and emits one edge per former-teammate pair.
  - Kind cut on a 90-day recency window vs. the latest match in the DB; older shared maps land as `EX_TEAMMATE`, recent as `TEAMMATE`.
  - Strength saturates linearly with shared-map count (cap at 20 maps → strength 1.0). Sentiment defaults to +1.0; feuds land later via `relationship_event` rows.
  - Idempotent under re-run; handles kind flips (ex-teammate → teammate) without colliding on the unique constraint.

## BUF-26 Acceptance

- [x] **Decay regression** — pure unit test pins `strength=1.0`, no signal for 20 weeks → `exp(-0.02 * 20) ≈ 0.6703200460356393` (`test_decay_strength_teammate_20_weeks_acceptance_regression`).
- [x] **Every former-teammate pair has an edge** — integration test `test_bootstrap_emits_one_edge_per_former_teammate_pair` asserts `C(5, 2) = 10` edges per side for two 5-player rosters that played one map together.
- [x] **Recency cut** — `test_bootstrap_distinguishes_recent_teammate_from_ex_teammate` validates the kind split.
- [x] **Symmetric canonicalisation** — `test_bootstrap_canonicalises_symmetric_pair_endpoints` asserts `src_id < dst_id` for symmetric edges, matching the migration's CHECK.

## Test plan

- [x] `uv run pytest` — 503 passed, 141 skipped (Postgres integration tests skipped without `TEST_DATABASE_URL`).
- [x] `uv run ruff check .` clean.
- [x] `uv run black --check .` clean.
- [x] `uv run mypy` clean (68 source files).
- [x] `alembic upgrade --sql` renders well-formed DDL for migration 0010 (CREATE TYPE + 2 tables + indexes).
- [ ] Postgres integration tests (`test_relationship_bootstrap.py`) — require `docker compose up postgres` + `TEST_DATABASE_URL`; not exercised in this CI environment but the test file follows the same skip-when-unset pattern as the rest of the suite.

https://claude.ai/code/session_015p4ynyzTwN3Rs8WyNRJeK6

---
_Generated by [Claude Code](https://claude.ai/code/session_015p4ynyzTwN3Rs8WyNRJeK6)_